### PR TITLE
[fix][foundation]: authRes slice contain a nil item

### DIFF
--- a/backend/modules/foundation/application/auth.go
+++ b/backend/modules/foundation/application/auth.go
@@ -48,7 +48,7 @@ func (a *AuthApplicationImpl) MCheckPermission(ctx context.Context, request *aut
 		return nil, err
 	}
 
-	authRes := make([]*authModel.SubjectActionObjectAuthRes, len(request.Auths))
+	authRes := make([]*authModel.SubjectActionObjectAuthRes, 0, len(request.Auths))
 	for _, authObject := range request.Auths {
 		isAllowed := true
 		for _, object := range authObject.Objects {


### PR DESCRIPTION
Change-Id: Id4d8d1809f35c77291de793175750156493917a9

#### What type of PR is this?
fix: fix authRes slice contain a empty item

old way
`
	authRes := make([]*authModel.SubjectActionObjectAuthRes, len(request.Auths))
	for _, authObject := range request.Auths {
		isAllowed := true
		for _, object := range authObject.Objects {
			if object.SpaceID != nil && object.GetSpaceID() != strconv.FormatInt(spaceID, 10) {
				isAllowed = false
				break
			}
		}
		authRes = append(authRes, &authModel.SubjectActionObjectAuthRes{
			SubjectActionObjects: authObject,
			IsAllowed:            ptr.Of(isUserSpace && isAllowed),
		})
	}
`

Initialization method for the first row， would set a nil item to authRes

#### Check the PR title.
\[fix\]\[backend\]  fix authRes slice contain a empty item
