### PR TITLE
[fix][prompt] fix ptaas trace

### DIFF
--- a/backend/modules/prompt/domain/component/trace/trace_span_convertor.go
+++ b/backend/modules/prompt/domain/component/trace/trace_span_convertor.go
@@ -66,11 +66,12 @@ func MessageToSpanMessage(message *entity.Message) *tracespec.ModelMessage {
 		return nil
 	}
 	return &tracespec.ModelMessage{
-		Role:       RoleToSpanRole(message.Role),
-		Content:    ptr.From(message.Content),
-		Parts:      ContentPartsToSpanParts(message.Parts),
-		ToolCalls:  ToolCallsToSpanToolCalls(message.ToolCalls),
-		ToolCallID: ptr.From(message.ToolCallID),
+		Role:             RoleToSpanRole(message.Role),
+		Content:          ptr.From(message.Content),
+		ReasoningContent: ptr.From(message.ReasoningContent),
+		Parts:            ContentPartsToSpanParts(message.Parts),
+		ToolCalls:        ToolCallsToSpanToolCalls(message.ToolCalls),
+		ToolCallID:       ptr.From(message.ToolCallID),
 	}
 }
 
@@ -125,7 +126,7 @@ func ContentTypeToSpanPartType(partType entity.ContentType) tracespec.ModelMessa
 	switch partType {
 	case entity.ContentTypeText:
 		return tracespec.ModelMessagePartTypeText
-	case entity.ContentTypeImageURL:
+	case entity.ContentTypeImageURL, entity.ContentTypeBase64Data:
 		return tracespec.ModelMessagePartTypeImage
 	case entity.ContentTypeMultiPartVariable:
 		return "multi_part_variable"


### PR DESCRIPTION
Change-Id: I1447f2e267c60cdd7a5cdcfedd127cd8eaf8d859

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \[\<type\>\]\[\<scope\>\]: \<description\>. For example: \[fix\]\[backend\] flaky fix
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: fix the issue of ptaas trace prompt_executor span's output content probability loss.
zh(optional):


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
