### PR TITLE
[feat][prompt] prompt support model config extra field

### DIFF
--- a/backend/kitex_gen/coze/loop/prompt/domain/prompt/k-prompt.go
+++ b/backend/kitex_gen/coze/loop/prompt/domain/prompt/k-prompt.go
@@ -3384,6 +3384,20 @@ func (p *ModelConfig) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 9:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField9(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -3514,6 +3528,20 @@ func (p *ModelConfig) FastReadField8(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *ModelConfig) FastReadField9(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.Extra = _field
+	return offset, nil
+}
+
 func (p *ModelConfig) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -3529,6 +3557,7 @@ func (p *ModelConfig) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 		offset += p.fastWriteField6(buf[offset:], w)
 		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
+		offset += p.fastWriteField9(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
 	return offset
@@ -3545,6 +3574,7 @@ func (p *ModelConfig) BLength() int {
 		l += p.field6Length()
 		l += p.field7Length()
 		l += p.field8Length()
+		l += p.field9Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -3622,6 +3652,15 @@ func (p *ModelConfig) fastWriteField8(buf []byte, w thrift.NocopyWriter) int {
 	return offset
 }
 
+func (p *ModelConfig) fastWriteField9(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetExtra() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 9)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.Extra)
+	}
+	return offset
+}
+
 func (p *ModelConfig) field1Length() int {
 	l := 0
 	if p.IsSetModelID() {
@@ -3694,6 +3733,15 @@ func (p *ModelConfig) field8Length() int {
 	return l
 }
 
+func (p *ModelConfig) field9Length() int {
+	l := 0
+	if p.IsSetExtra() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.Extra)
+	}
+	return l
+}
+
 func (p *ModelConfig) DeepCopy(s interface{}) error {
 	src, ok := s.(*ModelConfig)
 	if !ok {
@@ -3738,6 +3786,14 @@ func (p *ModelConfig) DeepCopy(s interface{}) error {
 	if src.JSONMode != nil {
 		tmp := *src.JSONMode
 		p.JSONMode = &tmp
+	}
+
+	if src.Extra != nil {
+		var tmp string
+		if *src.Extra != "" {
+			tmp = kutils.StringDeepCopy(*src.Extra)
+		}
+		p.Extra = &tmp
 	}
 
 	return nil

--- a/backend/kitex_gen/coze/loop/prompt/domain/prompt/prompt.go
+++ b/backend/kitex_gen/coze/loop/prompt/domain/prompt/prompt.go
@@ -4579,6 +4579,7 @@ type ModelConfig struct {
 	PresencePenalty  *float64 `thrift:"presence_penalty,6,optional" frugal:"6,optional,double" form:"presence_penalty" json:"presence_penalty,omitempty" query:"presence_penalty"`
 	FrequencyPenalty *float64 `thrift:"frequency_penalty,7,optional" frugal:"7,optional,double" form:"frequency_penalty" json:"frequency_penalty,omitempty" query:"frequency_penalty"`
 	JSONMode         *bool    `thrift:"json_mode,8,optional" frugal:"8,optional,bool" form:"json_mode" json:"json_mode,omitempty" query:"json_mode"`
+	Extra            *string  `thrift:"extra,9,optional" frugal:"9,optional,string" form:"extra" json:"extra,omitempty" query:"extra"`
 }
 
 func NewModelConfig() *ModelConfig {
@@ -4683,6 +4684,18 @@ func (p *ModelConfig) GetJSONMode() (v bool) {
 	}
 	return *p.JSONMode
 }
+
+var ModelConfig_Extra_DEFAULT string
+
+func (p *ModelConfig) GetExtra() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetExtra() {
+		return ModelConfig_Extra_DEFAULT
+	}
+	return *p.Extra
+}
 func (p *ModelConfig) SetModelID(val *int64) {
 	p.ModelID = val
 }
@@ -4707,6 +4720,9 @@ func (p *ModelConfig) SetFrequencyPenalty(val *float64) {
 func (p *ModelConfig) SetJSONMode(val *bool) {
 	p.JSONMode = val
 }
+func (p *ModelConfig) SetExtra(val *string) {
+	p.Extra = val
+}
 
 var fieldIDToName_ModelConfig = map[int16]string{
 	1: "model_id",
@@ -4717,6 +4733,7 @@ var fieldIDToName_ModelConfig = map[int16]string{
 	6: "presence_penalty",
 	7: "frequency_penalty",
 	8: "json_mode",
+	9: "extra",
 }
 
 func (p *ModelConfig) IsSetModelID() bool {
@@ -4749,6 +4766,10 @@ func (p *ModelConfig) IsSetFrequencyPenalty() bool {
 
 func (p *ModelConfig) IsSetJSONMode() bool {
 	return p.JSONMode != nil
+}
+
+func (p *ModelConfig) IsSetExtra() bool {
+	return p.Extra != nil
 }
 
 func (p *ModelConfig) Read(iprot thrift.TProtocol) (err error) {
@@ -4828,6 +4849,14 @@ func (p *ModelConfig) Read(iprot thrift.TProtocol) (err error) {
 		case 8:
 			if fieldTypeId == thrift.BOOL {
 				if err = p.ReadField8(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 9:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField9(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -4950,6 +4979,17 @@ func (p *ModelConfig) ReadField8(iprot thrift.TProtocol) error {
 	p.JSONMode = _field
 	return nil
 }
+func (p *ModelConfig) ReadField9(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Extra = _field
+	return nil
+}
 
 func (p *ModelConfig) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -4987,6 +5027,10 @@ func (p *ModelConfig) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField8(oprot); err != nil {
 			fieldId = 8
+			goto WriteFieldError
+		}
+		if err = p.writeField9(oprot); err != nil {
+			fieldId = 9
 			goto WriteFieldError
 		}
 	}
@@ -5151,6 +5195,24 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 8 end error: ", p), err)
 }
+func (p *ModelConfig) writeField9(oprot thrift.TProtocol) (err error) {
+	if p.IsSetExtra() {
+		if err = oprot.WriteFieldBegin("extra", thrift.STRING, 9); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Extra); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 9 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 9 end error: ", p), err)
+}
 
 func (p *ModelConfig) String() string {
 	if p == nil {
@@ -5188,6 +5250,9 @@ func (p *ModelConfig) DeepEqual(ano *ModelConfig) bool {
 		return false
 	}
 	if !p.Field8DeepEqual(ano.JSONMode) {
+		return false
+	}
+	if !p.Field9DeepEqual(ano.Extra) {
 		return false
 	}
 	return true
@@ -5285,6 +5350,18 @@ func (p *ModelConfig) Field8DeepEqual(src *bool) bool {
 		return false
 	}
 	if *p.JSONMode != *src {
+		return false
+	}
+	return true
+}
+func (p *ModelConfig) Field9DeepEqual(src *string) bool {
+
+	if p.Extra == src {
+		return true
+	} else if p.Extra == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Extra, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/modules/prompt/application/convertor/prompt.go
+++ b/backend/modules/prompt/application/convertor/prompt.go
@@ -411,6 +411,7 @@ func ModelConfigDTO2DO(dto *prompt.ModelConfig) *entity.ModelConfig {
 		PresencePenalty:  dto.PresencePenalty,
 		FrequencyPenalty: dto.FrequencyPenalty,
 		JSONMode:         dto.JSONMode,
+		Extra:            dto.Extra,
 	}
 }
 
@@ -805,6 +806,7 @@ func ModelConfigDO2DTO(do *entity.ModelConfig) *prompt.ModelConfig {
 		PresencePenalty:  do.PresencePenalty,
 		FrequencyPenalty: do.FrequencyPenalty,
 		JSONMode:         do.JSONMode,
+		Extra:            do.Extra,
 	}
 }
 

--- a/backend/modules/prompt/application/convertor/prompt_test.go
+++ b/backend/modules/prompt/application/convertor/prompt_test.go
@@ -646,3 +646,18 @@ func TestMessageDO2DTO(t *testing.T) {
 		})
 	}
 }
+
+func TestModelConfigExtraConversion(t *testing.T) {
+	extra := ptr.Of(`{"foo":"bar"}`)
+	dto := &prompt.ModelConfig{
+		Extra: extra,
+	}
+
+	do := ModelConfigDTO2DO(dto)
+	assert.NotNil(t, do)
+	assert.Equal(t, extra, do.Extra)
+
+	dtoBack := ModelConfigDO2DTO(do)
+	assert.NotNil(t, dtoBack)
+	assert.Equal(t, extra, dtoBack.Extra)
+}

--- a/backend/modules/prompt/application/execute_test.go
+++ b/backend/modules/prompt/application/execute_test.go
@@ -519,6 +519,7 @@ func TestOverridePromptParams(t *testing.T) {
 				ModelConfig: &entity.ModelConfig{
 					ModelID:     456,
 					Temperature: ptr.Of(0.7),
+					Extra:       ptr.Of(`{"source":"base"}`),
 				},
 			},
 		},
@@ -586,6 +587,7 @@ func TestOverridePromptParams(t *testing.T) {
 						ModelID:     ptr.Of(int64(789)),
 						Temperature: ptr.Of(0.9),
 						MaxTokens:   ptr.Of(int32(2000)),
+						Extra:       ptr.Of(`{"source":"override"}`),
 					},
 				},
 			},
@@ -598,6 +600,7 @@ func TestOverridePromptParams(t *testing.T) {
 							ModelID:     789,
 							Temperature: ptr.Of(0.9),
 							MaxTokens:   ptr.Of(int32(2000)),
+							Extra:       ptr.Of(`{"source":"override"}`),
 						},
 					},
 				}
@@ -651,10 +654,17 @@ func TestOverridePromptParams(t *testing.T) {
 					if tt.args.promptDO.PromptCommit.PromptDetail != nil {
 						promptCopy.PromptCommit.PromptDetail = &entity.PromptDetail{}
 						if tt.args.promptDO.PromptCommit.PromptDetail.ModelConfig != nil {
+							orig := tt.args.promptDO.PromptCommit.PromptDetail.ModelConfig
 							promptCopy.PromptCommit.PromptDetail.ModelConfig = &entity.ModelConfig{
-								ModelID:     tt.args.promptDO.PromptCommit.PromptDetail.ModelConfig.ModelID,
-								Temperature: tt.args.promptDO.PromptCommit.PromptDetail.ModelConfig.Temperature,
-								MaxTokens:   tt.args.promptDO.PromptCommit.PromptDetail.ModelConfig.MaxTokens,
+								ModelID:          orig.ModelID,
+								MaxTokens:        orig.MaxTokens,
+								Temperature:      orig.Temperature,
+								TopK:             orig.TopK,
+								TopP:             orig.TopP,
+								PresencePenalty:  orig.PresencePenalty,
+								FrequencyPenalty: orig.FrequencyPenalty,
+								JSONMode:         orig.JSONMode,
+								Extra:            orig.Extra,
 							}
 						}
 					}

--- a/backend/modules/prompt/domain/entity/prompt_detail.go
+++ b/backend/modules/prompt/domain/entity/prompt_detail.go
@@ -177,6 +177,7 @@ type ModelConfig struct {
 	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
 	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
 	JSONMode         *bool    `json:"json_mode,omitempty"`
+	Extra            *string  `json:"extra,omitempty"`
 }
 
 func (pt *PromptTemplate) formatMessages(messages []*Message, variableVals []*VariableVal) ([]*Message, error) {

--- a/idl/thrift/coze/loop/prompt/domain/prompt.thrift
+++ b/idl/thrift/coze/loop/prompt/domain/prompt.thrift
@@ -100,6 +100,7 @@ struct ModelConfig {
     6: optional double presence_penalty
     7: optional double frequency_penalty
     8: optional bool json_mode
+    9: optional string extra
 }
 
 struct Message {


### PR DESCRIPTION
#### What type of PR is this?
  feat

  #### Check the PR title.
  - [x] This PR title match the format: [<type>][<scope>]: <description>. For example: [fix][backend] flaky fix
  - [x] The description of this PR title is user-oriented and clear enough for others to understand.
  - [x] Add documentation if the current PR requires user awareness at the usage level.
  - [x] This PR is written in English. PRs not in English will not be reviewed.


  #### (Optional) Translate the PR title into Chinese.
  [功能][prompt] prompt支持模型配置额外字段


  #### (Optional) More detailed description for this PR(en: English/zh: Chinese).

  en:
  This PR adds support for an `extra` field in the model configuration, allowing clients to pass additional custom
  parameters to the LLM models. This field is preserved throughout the entire prompt execution flow, from API requests to
   domain entities.

  **Changes:**
  - Added `extra` field (optional string) to `ModelConfig` in the Thrift IDL definition
  - Updated all data converters (DTO↔DO) to handle the new field
  - Enhanced existing tests to verify the extra field is properly preserved during:
    - Data conversion between layers
    - Prompt parameter overrides
    - LLM call parameter preparation
  - All generated code (kitex_gen) updated accordingly

  **Use case:**
  This field enables passing model-specific configurations (e.g., JSON strings with custom parameters) that may not be 
  covered by the standard ModelConfig fields.

  zh(optional):
  此 PR 为模型配置添加了 `extra` 字段支持，允许客户端向 LLM 模型传递额外的自定义参数。该字段在整个 prompt 
  执行流程中都会被保留，从 API 请求到领域实体。

  **变更内容:**
  - 在 Thrift IDL 定义中为 `ModelConfig` 添加了 `extra` 字段(可选字符串)
  - 更新了所有数据转换器(DTO↔DO)以处理新字段
  - 增强了现有测试，验证 extra 字段在以下场景中被正确保留:
    - 层与层之间的数据转换
    - Prompt 参数覆盖
    - LLM 调用参数准备
  - 相应更新了所有生成代码(kitex_gen)

  **使用场景:**
  此字段可用于传递标准 ModelConfig 字段未涵盖的模型特定配置(例如,包含自定义参数的 JSON 字符串)。
