### PR TITLE
[feat][prompt] prompt support prompt thinking

### DIFF
--- a/idl/thrift/coze/loop/prompt/domain/prompt.thrift
+++ b/idl/thrift/coze/loop/prompt/domain/prompt.thrift
@@ -98,7 +98,17 @@ struct ModelConfig {
     6: optional double presence_penalty
     7: optional double frequency_penalty
     8: optional bool json_mode
+    9: optional Thinking thinking
 }
+
+struct Thinking {
+    1: optional ThinkingOption thinking_option
+}
+
+typedef string ThinkingOption (ts.enum="true")
+const ThinkingOption thinking_option_disabled = "disabled"
+const ThinkingOption thinking_option_enabled = "enabled"
+const ThinkingOption thinking_option_auto = "auto"
 
 struct Message {
     1: optional Role role


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: [feat][prompt-debugger]: support reasoning effort configuration
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese.
[feat][prompt]: 支持深度思考（ReasoningEffort）配置

#### (Optional) More detailed description for this PR (en: English / zh: Chinese).
en:
This PR introduces the **ReasoningEffort** capability to allow users to control model reasoning depth through the `ThinkingOption` field in `ModelConfig`.  
The change affects both **internal debugging (outer field - Debug)** and **PTaaS (outer field - Execute/ExecuteStreaming)** paths.

Key updates:
- Added new field `ModelConfig.thinking` which contains `ThinkingOption`.
- Defined a new enum `ThinkingOption` with values: `disabled`, `enabled`, and `auto`.
- Updated corresponding Thrift struct definitions and related service interfaces:
  - `DebugStreaming`
  - `Execute`
  - `ExecuteStreaming`

zh(optional):
本次 PR 增加了深度思考（ReasoningEffort）配置能力，允许用户通过 `ModelConfig` 控制大模型的思考力度。

主要改动如下：
- 新增字段：`ModelConfig.thinking`，包含 `ThinkingOption`。
- 定义枚举 `ThinkingOption`，取值包括：`disabled`、`enabled`、`auto`。
- 更新以下接口：
  - 外场 - 调试：`DebugStreaming`
  - 外场 - PTaas：`Execute`、`ExecuteStreaming`

#### (Optional) Which issue(s) this PR fixes:
N/A