### PR TITLE
[feat][prompt] add prompt key baggage

### DIFF
--- a/backend/modules/prompt/domain/service/execute.go
+++ b/backend/modules/prompt/domain/service/execute.go
@@ -354,6 +354,10 @@ func (p *PromptServiceImpl) startSequenceSpan(ctx context.Context, prompt *entit
 			consts.SpanTagPromptVariables: trace.VariableValsToSpanPromptVariables(variableVals),
 			consts.SpanTagMessages:        trace.MessagesToSpanMessages(messages),
 		}))
+		span.SetBaggage(ctx, map[string]string{
+			consts.SpanBaggagePromptKey:     prompt.PromptKey,
+			consts.SpanBaggagePromptVersion: prompt.GetVersion(),
+		})
 	}
 	return ctx, span
 }

--- a/backend/modules/prompt/pkg/consts/trace.go
+++ b/backend/modules/prompt/pkg/consts/trace.go
@@ -26,6 +26,11 @@ const (
 )
 
 const (
+	SpanBaggagePromptKey     = "prompt_key"
+	SpanBaggagePromptVersion = "prompt_version"
+)
+
+const (
 	SpanTagCallTypePromptPlayground = "PromptPlayground"
 	SpanTagCallTypePromptDebug      = "PromptDebug"
 	SpanTagCallTypePTaaS            = "PTaaS"


### PR DESCRIPTION
## PR Type

- [x] feat
- [ ] build
- [ ] ci
- [ ] docs
- [ ] optimize
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] style
- [ ] test
- [ ] chore

---

## PR Title Check

**PR Title**

[feat][prompt] add prompt key baggage

**Checklist**

- [x] This PR title matches the format: `[<type>][<scope>] <description>`  
  _Example: `[fix][backend] flaky fix`_
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Documentation has been added if this PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.

---

## (Optional) PR Title Translation (Chinese)

> 为 Prompt 调用链增加 prompt key 与版本信息的 baggage 透传能力

---

## Detailed Description

### English

- Add `SpanBaggagePromptKey` and `SpanBaggagePromptVersion` baggage keys in  
  `backend/modules/prompt/pkg/consts/trace.go:28`.
- When starting a prompt execution sequence span in  
  `backend/modules/prompt/domain/service/execute.go:354`, set the current prompt’s key and version
  into span baggage, so downstream services can retrieve them from the tracing context for:
  - observability
  - debugging
  - attribution

### Chinese (Optional)

- 在 `backend/modules/prompt/pkg/consts/trace.go:28` 新增  
  `SpanBaggagePromptKey` 和 `SpanBaggagePromptVersion` 两个 trace baggage 字段，用于记录 prompt 的 key 和版本。
- 在 `backend/modules/prompt/domain/service/execute.go:354` 的 `startSequenceSpan` 中，
  将当前 prompt 的 `PromptKey` 和版本写入 span baggage，方便下游服务通过链路追踪还原具体使用的
  prompt 配置，用于问题排查和观测分析。

---

## Related Issues

- N/A  
  （如果有关联 issue，可补充：`Fixes #<issue number>`）