### PR TITLE
fix[infra] add default-character-set=utf8mb4 to entrypoint.sh

### DIFF
--- a/release/deployment/docker-compose/bootstrap/mysql-init/entrypoint.sh
+++ b/release/deployment/docker-compose/bootstrap/mysql-init/entrypoint.sh
@@ -52,6 +52,7 @@ i=1
 for file in $(ls "$BASE_INIT_PATH" | grep '\.sql$'); do
   echo "+ Init #$i: $file"
   mysql \
+    --default-character-set=utf8mb4 \
     -h "$MYSQL_HOST" \
     -u "$MYSQL_USER" \
     -D "$MYSQL_DATABASE" \
@@ -64,6 +65,7 @@ echo "Loading compatibility functions..."
 if [ -f "$ALTERS_PATH/alter_proc.sql" ]; then
   echo "+ Proc: alter_proc.sql"
   mysql \
+    --default-character-set=utf8mb4 \
     -h "$MYSQL_HOST" \
     -u "$MYSQL_USER" \
     -D "$MYSQL_DATABASE" \
@@ -88,6 +90,7 @@ if [ -d "$ALTERS_PATH" ]; then
 
     # Execute the file content through the compatibility system
     mysql \
+      --default-character-set=utf8mb4 \
       -h "$MYSQL_HOST" \
       -u "$MYSQL_USER" \
       -D "$MYSQL_DATABASE" \


### PR DESCRIPTION
### What type of PR is this?

fix

### Check the PR title

* [x] This PR title match the format: [<type>][<scope>] <description>. For example: [fix][backend] flaky fix
* [x] The description of this PR title is user-oriented and clear enough for others to understand.
* [ ] Add documentation if the current PR requires user awareness at the usage level.
* [x] This PR is written in English. PRs not in English will not be reviewed.

### (Optional) Translate the PR title into Chinese

[fix][backend] 强制 MySQL 客户端在初始化 SQL 时使用 utf8mb4 字符集

### (Optional) More detailed description for this PR(en: English/zh: Chinese)

en: This PR adds the --default-character-set=utf8mb4 flag to the mysql command in entrypoint.sh. Not all Docker MySQL image versions use utf8mb4 as the default character set configuration. Without this explicit flag, Chinese characters in the initialization SQLs are rendered as garbled text. This change ensures consistent encoding behavior and prevents data corruption during the init process.

zh(optional): 此 PR 在 entrypoint.sh 的 mysql 命令中添加了 --default-character-set=utf8mb4 参数。 并非所有版本的 Docker MySQL 镜像都默认使用 utf8mb4 编码配置。如果不显式指定该参数，会导致初始化 SQL 中的中文内容显示为乱码。此修改强制统一字符集，确保中文数据能被正确导入和显示。

### (Optional) Which issue(s) this PR fixes

Fixes #