### PR TITLE
[fix][backend] restore FailRetry logic to skip completed evaluators

### DIFF
--- a/backend/modules/evaluation/domain/service/expt_result_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl.go
@@ -120,7 +120,7 @@ func (e ExptResultServiceImpl) GetExptItemTurnResults(ctx context.Context, exptI
 		if turnEvaluatorVerIDToResultID[ref.ExptTurnResultID] == nil {
 			turnEvaluatorVerIDToResultID[ref.ExptTurnResultID] = make(map[int64]int64)
 		}
-		turnEvaluatorVerIDToResultID[ref.ExptTurnResultID][ref.EvaluatorVersionID] = ref.EvaluatorVersionID
+		turnEvaluatorVerIDToResultID[ref.ExptTurnResultID][ref.EvaluatorVersionID] = ref.EvaluatorResultID
 	}
 
 	res := make([]*entity.ExptTurnResult, 0, len(turnResults))

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl.go
@@ -260,7 +260,7 @@ func (e *ExptItemEvalCtxExecutor) buildExptTurnEvalCtx(ctx context.Context, turn
 		}
 		recordMap := make(map[int64]*entity.EvaluatorRecord)
 		for _, record := range evaluatorRecords {
-			recordMap[record.ID] = record
+			recordMap[record.EvaluatorVersionID] = record
 		}
 		etec.ExptTurnRunResult.EvaluatorResults = recordMap
 	}


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->

##### 1. Defect 1: Historical Result ID Mapping Error

###### 1.1 Problem Description
In the `GetExptItemTurnResults` method, when constructing the mapping table for historical results, the `EvaluatorVersionID` (Evaluator Version ID) was incorrectly assigned as the Value. The expected Value should have been the `EvaluatorResultID` (Primary Key ID of the evaluation record).

###### 1.2 Fix Details
*   **File**: `backend/modules/evaluation/domain/service/expt_result_impl.go`
*   **Method**: `GetExptItemTurnResults`

**Code Comparison**:

```go
// Before (Bug)
// Error: Value assigned as VersionID (e.g., 1001)
turnEvaluatorVerIDToResultID[ref.ExptTurnResultID][ref.EvaluatorVersionID] = ref.EvaluatorVersionID

// After (Fix)
// Correct: Value assigned as ResultID (e.g., 74839201)
turnEvaluatorVerIDToResultID[ref.ExptTurnResultID][ref.EvaluatorVersionID] = ref.EvaluatorResultID
```

###### 1.3 Verification and Impact

*   **Table**: `expt_turn_result_run_log`
*   **Column**: `evaluator_result_ids`
*   **Before Fix**: `{"EvalVerIDToResID":{"1001":1001}}` — Invalid reference pointing to a non-existent record ID.
*   **After Fix**: `{"EvalVerIDToResID":{"1001":74839201}}` — Valid reference correctly pointing to the primary key in the `evaluator_record` table.

> **Note**: Although the database would eventually "self-heal" by overwriting old data with new data generated from re-running the LLM evaluation if this issue were left unfixed, **the primary purpose of the PreEval stage is to reuse old data**. If the ID is incorrect here, the Worker cannot retrieve the corresponding historical record using the incorrect ID when initializing the context via `e.evaluatorRecordService.BatchGetEvaluatorRecord`. Consequently, the checkpoint recovery mechanism would fail at the very first step.

---

##### 2. Defect 2: Worker Cache Key Mismatch

###### 2.1 Problem Description
Even if the ID mapping is correct, the Worker used `RecordID` as the Map Key when constructing the context cache. However, the subsequent read logic used `EvaluatorVersionID` as the Key for lookups. This **Key Mismatch** resulted in a permanent cache miss.

###### 2.2 Fix Details
*   **File**: `backend/modules/evaluation/domain/service/expt_run_item_impl.go`
*   **Method**: `buildExptTurnEvalCtx`

**Code Comparison**:

```go
// Before (Bug)
// Error: Using RecordID as Key
recordMap[record.ID] = record 

// After (Fix)
// Correct: Using EvaluatorVersionID as Key, aligning with the read logic
recordMap[record.EvaluatorVersionID] = record
```

###### 2.3 Verification (Memory Level)

After the fix, the Worker execution flow is as follows:

1.  **Context Construction (`buildExptTurnEvalCtx`)**:
    Correctly constructs the `etec.ExptTurnRunResult.EvaluatorResults` Map with `EvaluatorVersionID` as the Key.

2.  **Execution (`CallEvaluators`)**:
    When iterating through evaluators, the cache is successfully hit, allowing completed tasks to be skipped.

    ```go
    // backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go

    func (e *DefaultExptTurnEvaluationImpl) CallEvaluators(ctx context.Context, etec *entity.ExptTurnEvalCtx, targetResult *entity.EvalTargetRecord) (map[int64]*entity.EvaluatorRecord, error) {  
        // ...
        for _, evaluatorVersion := range expt.Evaluators {  
            // Verification Point: Lookup using VersionID now successfully retrieves the cache
            existResult := etec.ExptTurnRunResult.GetEvaluatorRecord(evaluatorVersion.GetEvaluatorVersionID())  
      
            if existResult != nil && existResult.Status == entity.EvaluatorRunStatusSuccess {  
                // Successfully skipped!
                evaluatorResults[existResult.ID] = existResult
                continue  
            }  
            // ...
        }
        // ...
    }
    ```


#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #400


