### PR TITLE
[fix][clickhouse-init] correct SQL syntax and enable multiquery in bootstrap scripts

### DIFF
--- a/release/deployment/docker-compose/bootstrap/clickhouse-init/entrypoint.sh
+++ b/release/deployment/docker-compose/bootstrap/clickhouse-init/entrypoint.sh
@@ -51,6 +51,7 @@ for file in $(ls /coze-loop-clickhouse-init/bootstrap/init-sql | grep '\.sql$');
     -u "${COZE_LOOP_CLICKHOUSE_USER}" \
     --password="${COZE_LOOP_CLICKHOUSE_PASSWORD}" \
     --database="${COZE_LOOP_CLICKHOUSE_DATABASE}" \
+    --multiquery \
     < "/coze-loop-clickhouse-init/bootstrap/init-sql/${file}"
   i=$((i + 1))
 done

--- a/release/deployment/docker-compose/bootstrap/clickhouse-init/init-sql/evaluation.sql
+++ b/release/deployment/docker-compose/bootstrap/clickhouse-init/init-sql/evaluation.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS expt_turn_result_filter
     `created_at` DateTime,
     `updated_at` DateTime,
     `eval_target_metrics` Map(String, Int64),
-    `evaluator_weighted_score` Float64
+    `evaluator_weighted_score` Float64,
     INDEX idx_space_id space_id TYPE bloom_filter() GRANULARITY 1,
     INDEX idx_expt_id expt_id TYPE bloom_filter() GRANULARITY 1,
     INDEX idx_item_id item_id TYPE bloom_filter() GRANULARITY 1,


### PR DESCRIPTION
This PR fixes two issues in the ClickHouse bootstrap initialization. 

First, the evaluation.sql file was missing a comma after the evaluator_weighted_score column definition, which caused a syntax error during table creation when skip indexes were present. 

Second, the clickhouse-client command in entrypoint.sh did not use the --multiquery flag, which is required to execute multiple SQL statements such as CREATE TABLE followed by ALTER TABLE in a single .sql file. Both changes are necessary for successful database initialization in Docker environments. The fix has been verified locally with ClickHouse version 23.8.