### PR TITLE
[refactor][backend] support configurable force_path_style for S3 client

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -214,7 +214,7 @@ func newComponent(ctx context.Context) (*component, error) {
 		cfg.AccessKeyID = getOssUser()
 		cfg.SecretAccessKey = getOssPassword()
 		cfg.Bucket = getOssBucket()
-		cfg.ForcePathStyle = getOssForcePathStyle()
+		cfg.ForcePathStyle = getOssForcePathStyle(componentConfig)
 	})
 	objectStorage, err := fileserver.NewS3Client(s3Config)
 	if err != nil {
@@ -348,7 +348,13 @@ func getOssBucket() string {
 	return os.Getenv("COZE_LOOP_OSS_BUCKET")
 }
 
-func getOssForcePathStyle() *bool {
+func getOssForcePathStyle(componentConfig *ComponentConfig) *bool {
+	// 优先从配置文件读取
+	if componentConfig != nil && componentConfig.S3Config.ForcePathStyle != nil {
+		return componentConfig.S3Config.ForcePathStyle
+	}
+
+	// 配置文件未设置时，回退到域名判断（向后兼容）
 	if getOssDomain() == "coze-loop-minio" {
 		return gptr.Of(true)
 	}


### PR DESCRIPTION
Previously, the ForcePathStyle setting was hardcoded based on domain name detection, making it difficult to adapt to different object storage services.

This commit refactors the getOssForcePathStyle function to read from the configuration file (infrastructure.yaml) with a fallback to domain-based detection for backward compatibility.

Changes:
- Modify getOssForcePathStyle to accept componentConfig parameter
- Prioritize reading force_path_style from s3_config in infrastructure.yaml
- Fallback to domain-based detection when config is not set

Benefits:
- Flexibility to configure force_path_style for any S3-compatible storage
- Easier integration with different object storage backends (MinIO, RustFS, etc.)
- Maintains backward compatibility with existing deployments

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
