### PR TITLE
feat: add IDL definitions for common tool management

### DIFF
--- a/idl/thrift/coze/loop/apis/coze.loop.apis.thrift
+++ b/idl/thrift/coze/loop/apis/coze.loop.apis.thrift
@@ -13,6 +13,7 @@ include "../evaluation/coze.loop.evaluation.expt.thrift"
 include "../evaluation/coze.loop.evaluation.openapi.thrift"
 include "../data/coze.loop.data.dataset.thrift"
 include "../prompt/coze.loop.prompt.manage.thrift"
+include "../prompt/coze.loop.prompt.tool_manage.thrift"
 include "../prompt/coze.loop.prompt.debug.thrift"
 include "../prompt/coze.loop.prompt.execute.thrift"
 include "../prompt/coze.loop.prompt.openapi.thrift"
@@ -34,6 +35,7 @@ service DatasetService extends coze.loop.data.dataset.DatasetService{}
 service TagService extends coze.loop.data.tag.TagService{}
 
 service PromptManageService extends coze.loop.prompt.manage.PromptManageService{}
+service ToolManageService extends coze.loop.prompt.tool_manage.ToolManageService{}
 service PromptDebugService extends coze.loop.prompt.debug.PromptDebugService{}
 service PromptExecuteService extends coze.loop.prompt.execute.PromptExecuteService{}
 service PromptOpenAPIService extends coze.loop.prompt.openapi.PromptOpenAPIService{}

--- a/idl/thrift/coze/loop/prompt/coze.loop.prompt.thrift
+++ b/idl/thrift/coze/loop/prompt/coze.loop.prompt.thrift
@@ -1,11 +1,13 @@
 namespace go coze.loop.prompt
 
 include "coze.loop.prompt.manage.thrift"
+include "coze.loop.prompt.tool_manage.thrift"
 include "coze.loop.prompt.debug.thrift"
 include "coze.loop.prompt.openapi.thrift"
 include "coze.loop.prompt.execute.thrift"
 
 service PromptManageService extends coze.loop.prompt.manage.PromptManageService{}
+service ToolManageService extends coze.loop.prompt.tool_manage.ToolManageService{}
 service PromptDebugService extends coze.loop.prompt.debug.PromptDebugService{}
 service PromptExecuteService extends coze.loop.prompt.execute.PromptExecuteService{}
 service PromptOpenAPIService extends coze.loop.prompt.openapi.PromptOpenAPIService{}

--- a/idl/thrift/coze/loop/prompt/coze.loop.prompt.tool_manage.thrift
+++ b/idl/thrift/coze/loop/prompt/coze.loop.prompt.tool_manage.thrift
@@ -1,0 +1,155 @@
+namespace go coze.loop.prompt.tool_manage
+
+include "../../../base.thrift"
+include "./domain/tool.thrift"
+include "./domain/user.thrift"
+
+service ToolManageService {
+    CreateToolResponse CreateTool(1: CreateToolRequest request) (api.post = '/api/prompt/v1/tools')
+    GetToolDetailResponse GetToolDetail(1: GetToolDetailRequest request) (api.get = '/api/prompt/v1/tools/:tool_id')
+    ListToolResponse ListTool(1: ListToolRequest request) (api.post = '/api/prompt/v1/tools/list')
+    SaveToolDetailResponse SaveToolDetail(1: SaveToolDetailRequest request) (api.post = '/api/prompt/v1/tools/:tool_id/drafts/save')
+    CommitToolDraftResponse CommitToolDraft(1: CommitToolDraftRequest request) (api.post = '/api/prompt/v1/tools/:tool_id/drafts/commit')
+    ListToolCommitResponse ListToolCommit(1: ListToolCommitRequest request) (api.post = '/api/prompt/v1/tools/:tool_id/commits/list')
+    BatchGetToolsResponse BatchGetTools(1: BatchGetToolsRequest request) (api.post = '/api/prompt/v1/tools/mget')
+}
+
+struct CreateToolRequest {
+    1: optional i64 workspace_id (api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"workspace_id"')
+
+    11: optional string tool_name (vt.not_nil="true", vt.min_size="1")
+    12: optional string tool_description
+
+    21: optional tool.ToolDetail draft_detail
+
+    255: optional base.Base Base
+}
+
+struct CreateToolResponse {
+    1: optional i64 tool_id (api.js_conv="true", go.tag='json:"tool_id"')
+
+    255: optional base.BaseResp BaseResp
+}
+
+struct GetToolDetailRequest {
+    1: optional i64 tool_id (api.path='tool_id', api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"tool_id"')
+    2: optional i64 workspace_id (api.query="workspace_id", api.js_conv='true', go.tag='json:"workspace_id"')
+
+    11: optional bool with_commit (api.query="with_commit")
+    12: optional string commit_version (api.query="commit_version")
+
+    21: optional bool with_draft (api.query="with_draft")
+
+    255: optional base.Base Base
+}
+
+struct GetToolDetailResponse {
+    1: optional tool.Tool tool
+
+    255: optional base.BaseResp BaseResp
+}
+
+struct ListToolRequest {
+    1: optional i64 workspace_id (api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"workspace_id"')
+
+    11: optional string key_word
+    12: optional list<string> created_bys
+    13: optional bool committed_only
+
+    127: optional i32 page_num (vt.not_nil="true", vt.gt="0")
+    128: optional i32 page_size (vt.not_nil="true", vt.gt="0", vt.le="100")
+    129: optional ListToolOrderBy order_by
+    130: optional bool asc
+
+    255: optional base.Base Base
+}
+
+struct ListToolResponse {
+    1: optional list<tool.Tool> tools
+
+    11: optional list<user.UserInfoDetail> users
+
+    127: optional i32 total
+
+    255: optional base.BaseResp BaseResp
+}
+
+typedef string ListToolOrderBy (ts.enum="true")
+const ListToolOrderBy ListToolOrderBy_CommittedAt = "committed_at"
+const ListToolOrderBy ListToolOrderBy_CreatedAt = "created_at"
+
+struct SaveToolDetailRequest {
+    1: optional i64 tool_id (api.path='tool_id', api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"tool_id"')
+    2: optional i64 workspace_id (api.query="workspace_id", api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"workspace_id"')
+
+    11: optional tool.ToolDetail tool_detail (vt.not_nil = "true")
+    12: optional string base_version
+
+    255: optional base.Base Base
+}
+
+struct SaveToolDetailResponse {
+    255: optional base.BaseResp BaseResp
+}
+
+struct CommitToolDraftRequest {
+    1: optional i64 tool_id (api.path='tool_id', api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"tool_id"')
+    2: optional i64 workspace_id (api.query="workspace_id", api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"workspace_id"')
+
+    11: optional string commit_version (vt.not_nil="true", vt.min_size="1")
+    12: optional string commit_description
+    13: optional string base_version
+
+    255: optional base.Base Base
+}
+
+struct CommitToolDraftResponse {
+    255: optional base.BaseResp BaseResp
+}
+
+struct ListToolCommitRequest {
+    1: optional i64 tool_id (api.path='tool_id', api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"tool_id"')
+    2: optional i64 workspace_id (api.query="workspace_id", api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"workspace_id"')
+    3: optional bool with_commit_detail (api.query="with_commit_detail")
+
+    127: optional i32 page_size (vt.not_nil="true", vt.gt="0")
+    128: optional string page_token
+    129: optional bool asc
+
+    255: optional base.Base Base
+}
+
+struct ListToolCommitResponse {
+    1: optional list<tool.CommitInfo> tool_commit_infos
+    2: optional map<string, tool.ToolDetail> tool_commit_detail_mapping
+
+    11: optional list<user.UserInfoDetail> users
+
+    127: optional bool has_more
+    128: optional string next_page_token
+
+    255: optional base.BaseResp BaseResp
+}
+
+struct ToolQuery {
+    1: optional i64 tool_id (api.js_conv='true', go.tag='json:"tool_id"')
+    2: optional string version
+}
+
+struct ToolResult {
+    1: optional ToolQuery query
+    2: optional tool.Tool tool
+}
+
+struct BatchGetToolsRequest {
+    1: optional i64 workspace_id (api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"workspace_id"')
+    2: optional list<ToolQuery> queries (vt.min_size="1")
+
+    255: optional base.Base Base
+}
+
+struct BatchGetToolsResponse {
+    1: optional list<ToolResult> items
+
+    255: optional base.BaseResp BaseResp
+}

--- a/idl/thrift/coze/loop/prompt/domain/tool.thrift
+++ b/idl/thrift/coze/loop/prompt/domain/tool.thrift
@@ -1,0 +1,41 @@
+namespace go coze.loop.prompt.domain.tool
+
+const string PublicDraftVersion = "$PublicDraft"
+
+struct Tool {
+    1: optional i64 id (api.js_conv="true", go.tag='json:"id"')
+    2: optional i64 workspace_id (api.js_conv="true", go.tag='json:"workspace_id"')
+    3: optional ToolBasic tool_basic
+    4: optional ToolCommit tool_commit
+
+    255: optional map<string, string> ext_infos
+}
+
+struct ToolBasic {
+    1: optional string name
+    2: optional string description
+    3: optional string latest_committed_version
+    4: optional string created_by
+    5: optional string updated_by
+    6: optional i64 created_at (api.js_conv="true", go.tag='json:"created_at"')
+    7: optional i64 updated_at (api.js_conv="true", go.tag='json:"updated_at"')
+}
+
+struct ToolCommit {
+    1: optional ToolDetail detail
+    2: optional CommitInfo commit_info
+}
+
+struct CommitInfo {
+    1: optional string version
+    2: optional string base_version
+    3: optional string description
+    4: optional string committed_by
+    5: optional i64 committed_at (api.js_conv="true", go.tag='json:"committed_at"')
+}
+
+struct ToolDetail {
+    1: optional string content
+
+    255: optional map<string, string> ext_infos
+}


### PR DESCRIPTION
## Summary
- 从 feat/common_tool 分支中提取 IDL 相关改动，包含 tool 管理接口定义
- 新增 `coze.loop.prompt.tool_manage.thrift` 和 `domain/tool.thrift`
- 更新 `coze.loop.apis.thrift` 和 `coze.loop.prompt.thrift` 引用

## Test plan
- [ ] 验证 thrift IDL 编译通过
- [ ] 确认新增接口定义与 feat/common_tool 一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)