### PR TITLE
[fix][evaluation]: add evaluator record service to refresh async records

### DIFF
--- a/backend/modules/evaluation/domain/service/expt_run_item_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl.go
@@ -103,7 +103,7 @@ func (e *ExptItemEvalCtxExecutor) EvalTurns(ctx context.Context, eiec *entity.Ex
 
 		ctx = context.WithValue(ctx, consts.CtxKeyLogID, etec.GetTurnEvalLogID(ctx, turn.ID)) //nolint:staticcheck
 
-		turnRunRes := NewExptTurnEvaluation(e.Metric, e.evalTargetService, e.evaluatorService, e.benefitService, e.evalAsyncRepo, e.evalSetItemSvc).Eval(ctx, etec)
+		turnRunRes := NewExptTurnEvaluation(e.Metric, e.evalTargetService, e.evaluatorService, e.benefitService, e.evalAsyncRepo, e.evalSetItemSvc, e.evaluatorRecordService).Eval(ctx, etec)
 
 		if err := e.storeTurnRunResult(ctx, etec, turnRunRes); err != nil {
 			return false, err

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
@@ -40,24 +40,27 @@ func NewExptTurnEvaluation(
 	benefitService benefit.IBenefitService,
 	evalAsyncRepo repo.IEvalAsyncRepo,
 	evalSetItemSvc EvaluationSetItemService,
+	evaluatorRecordService EvaluatorRecordService,
 ) ExptItemTurnEvaluation {
 	return &DefaultExptTurnEvaluationImpl{
-		metric:            metric,
-		evalTargetService: evalTargetService,
-		evaluatorService:  evaluatorService,
-		benefitService:    benefitService,
-		evalAsyncRepo:     evalAsyncRepo,
-		evalSetItemSvc:    evalSetItemSvc,
+		metric:                 metric,
+		evalTargetService:      evalTargetService,
+		evaluatorService:       evaluatorService,
+		benefitService:         benefitService,
+		evalAsyncRepo:          evalAsyncRepo,
+		evalSetItemSvc:         evalSetItemSvc,
+		evaluatorRecordService: evaluatorRecordService,
 	}
 }
 
 type DefaultExptTurnEvaluationImpl struct {
-	metric            metrics.ExptMetric
-	evalTargetService IEvalTargetService
-	evaluatorService  EvaluatorService
-	benefitService    benefit.IBenefitService
-	evalAsyncRepo     repo.IEvalAsyncRepo
-	evalSetItemSvc    EvaluationSetItemService
+	metric                 metrics.ExptMetric
+	evalTargetService      IEvalTargetService
+	evaluatorService       EvaluatorService
+	benefitService         benefit.IBenefitService
+	evalAsyncRepo          repo.IEvalAsyncRepo
+	evalSetItemSvc         EvaluationSetItemService
+	evaluatorRecordService EvaluatorRecordService
 }
 
 func (e *DefaultExptTurnEvaluationImpl) Eval(ctx context.Context, etec *entity.ExptTurnEvalCtx) (trr *entity.ExptTurnRunResult) {
@@ -299,7 +302,31 @@ func (e *DefaultExptTurnEvaluationImpl) CallEvaluators(ctx context.Context, etec
 		evaluatorResults[evID] = result
 	}
 
+	if evalErr == nil {
+		evaluatorResults, evalErr = e.refreshAsyncEvaluatorRecords(ctx, evaluatorResults)
+	}
+
 	return evaluatorResults, evalErr
+}
+
+func (e *DefaultExptTurnEvaluationImpl) refreshAsyncEvaluatorRecords(ctx context.Context, evaluatorResults map[int64]*entity.EvaluatorRecord) (map[int64]*entity.EvaluatorRecord, error) {
+	if e.evaluatorRecordService == nil {
+		return evaluatorResults, nil
+	}
+	for evID, record := range evaluatorResults {
+		if record == nil || record.Status != entity.EvaluatorRunStatusAsyncInvoking {
+			continue
+		}
+		updatedRecord, err := e.evaluatorRecordService.GetEvaluatorRecord(ctx, record.ID, false)
+		if err != nil {
+			return evaluatorResults, err
+		}
+		if updatedRecord != nil {
+			logs.CtxInfo(ctx, "[ExptTurnEval] refreshed async evaluator record, record_id: %v, old_status: %v, new_status: %v", record.ID, record.Status, updatedRecord.Status)
+			evaluatorResults[evID] = updatedRecord
+		}
+	}
+	return evaluatorResults, nil
 }
 
 func (e *DefaultExptTurnEvaluationImpl) callEvaluators(ctx context.Context, execEvaluatorVersionIDs []int64, etec *entity.ExptTurnEvalCtx,

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
@@ -3555,3 +3555,348 @@ func TestDefaultExptTurnEvaluationImpl_CheckBenefit_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultExptTurnEvaluationImpl_refreshAsyncEvaluatorRecords(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		service        func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl
+		input          map[int64]*entity.EvaluatorRecord
+		wantErr        bool
+		validateResult func(t *testing.T, result map[int64]*entity.EvaluatorRecord)
+	}{
+		{
+			name: "nil evaluatorRecordService - skip refresh",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				return &DefaultExptTurnEvaluationImpl{}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: {ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking},
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Equal(t, entity.EvaluatorRunStatusAsyncInvoking, result[101].Status)
+			},
+		},
+		{
+			name: "no async invoking records - no refresh needed",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: {ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusSuccess},
+				102: {ID: 202, EvaluatorVersionID: 102, Status: entity.EvaluatorRunStatusFail},
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Equal(t, entity.EvaluatorRunStatusSuccess, result[101].Status)
+				assert.Equal(t, entity.EvaluatorRunStatusFail, result[102].Status)
+			},
+		},
+		{
+			name: "nil record in map - skip",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: nil,
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Nil(t, result[101])
+			},
+		},
+		{
+			name: "async record refreshed to success",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				mockRecordSvc.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(201), false).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusSuccess}, nil,
+				)
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: {ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking},
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Equal(t, entity.EvaluatorRunStatusSuccess, result[101].Status)
+				assert.Equal(t, int64(201), result[101].ID)
+			},
+		},
+		{
+			name: "async record still invoking after refresh",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				mockRecordSvc.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(201), false).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking}, nil,
+				)
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: {ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking},
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Equal(t, entity.EvaluatorRunStatusAsyncInvoking, result[101].Status)
+			},
+		},
+		{
+			name: "GetEvaluatorRecord returns error",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				mockRecordSvc.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(201), false).Return(nil, errors.New("db error"))
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: {ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking},
+			},
+			wantErr: true,
+		},
+		{
+			name: "mixed records - only refresh async invoking ones",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				mockRecordSvc.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(302), false).Return(
+					&entity.EvaluatorRecord{ID: 302, EvaluatorVersionID: 102, Status: entity.EvaluatorRunStatusSuccess}, nil,
+				)
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input: map[int64]*entity.EvaluatorRecord{
+				101: {ID: 301, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusSuccess},
+				102: {ID: 302, EvaluatorVersionID: 102, Status: entity.EvaluatorRunStatusAsyncInvoking},
+			},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Equal(t, entity.EvaluatorRunStatusSuccess, result[101].Status)
+				assert.Equal(t, int64(301), result[101].ID)
+				assert.Equal(t, entity.EvaluatorRunStatusSuccess, result[102].Status)
+				assert.Equal(t, int64(302), result[102].ID)
+			},
+		},
+		{
+			name: "empty map - no-op",
+			service: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockRecordSvc := svcmocks.NewMockEvaluatorRecordService(ctrl)
+				return &DefaultExptTurnEvaluationImpl{evaluatorRecordService: mockRecordSvc}
+			},
+			input:   map[int64]*entity.EvaluatorRecord{},
+			wantErr: false,
+			validateResult: func(t *testing.T, result map[int64]*entity.EvaluatorRecord) {
+				assert.Empty(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			svc := tt.service(ctrl)
+			result, err := svc.refreshAsyncEvaluatorRecords(context.Background(), tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.validateResult != nil {
+				tt.validateResult(t, result)
+			}
+		})
+	}
+}
+
+func TestDefaultExptTurnEvaluationImpl_CallEvaluators_WithRefresh(t *testing.T) {
+	t.Parallel()
+
+	mockContent := &entity.Content{Text: gptr.Of("value1")}
+	mockTargetResult := &entity.EvalTargetRecord{
+		EvalTargetOutputData: &entity.EvalTargetOutputData{
+			OutputFields: map[string]*entity.Content{
+				"field1": mockContent,
+			},
+		},
+	}
+
+	baseEtec := func() *entity.ExptTurnEvalCtx {
+		return &entity.ExptTurnEvalCtx{
+			ExptItemEvalCtx: &entity.ExptItemEvalCtx{
+				EvalSetItem: &entity.EvaluationSetItem{ID: 1, ItemID: 2},
+				Event:       &entity.ExptItemEvalEvent{Session: &entity.Session{UserID: "test_user"}, ExptID: 1, SpaceID: 2},
+				Expt: &entity.Experiment{
+					ID: 1, SpaceID: 2,
+					Evaluators: []*entity.Evaluator{
+						{
+							ID:            101,
+							EvaluatorType: entity.EvaluatorTypeAgent,
+							AgentEvaluatorVersion: &entity.AgentEvaluatorVersion{
+								ID: 101,
+							},
+						},
+					},
+					EvalConf: &entity.EvaluationConfiguration{
+						ItemConcurNum: gptr.Of(1),
+						ConnectorConf: entity.Connector{
+							EvaluatorsConf: &entity.EvaluatorsConf{
+								EvaluatorConcurNum: gptr.Of(1),
+								EvaluatorConf: []*entity.EvaluatorConf{
+									{
+										EvaluatorVersionID: 101,
+										IngressConf: &entity.EvaluatorIngressConf{
+											EvalSetAdapter: &entity.FieldAdapter{FieldConfs: []*entity.FieldConf{}},
+											TargetAdapter:  &entity.FieldAdapter{FieldConfs: []*entity.FieldConf{}},
+										},
+										RunConf: &entity.EvaluatorRunConfig{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExptTurnRunResult: &entity.ExptTurnRunResult{},
+			Turn:              &entity.Turn{FieldDataList: []*entity.FieldData{}},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		prepare        func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl
+		etec           func() *entity.ExptTurnEvalCtx
+		wantErr        bool
+		validateResult func(t *testing.T, results map[int64]*entity.EvaluatorRecord)
+	}{
+		{
+			name: "async evaluator refreshed to success after sync evaluator completes",
+			prepare: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockMetric := metricsmocks.NewMockExptMetric(ctrl)
+				mockEvaluatorService := svcmocks.NewMockEvaluatorService(ctrl)
+				mockBenefitService := benefitmocks.NewMockIBenefitService(ctrl)
+				mockEvalTargetService := svcmocks.NewMockIEvalTargetService(ctrl)
+				mockEvalAsyncRepo := repomocks.NewMockIEvalAsyncRepo(ctrl)
+				mockEvaluatorRecordService := svcmocks.NewMockEvaluatorRecordService(ctrl)
+
+				mockBenefitService.EXPECT().CheckAndDeductEvalBenefit(gomock.Any(), gomock.Any()).Return(&benefit.CheckAndDeductEvalBenefitResult{}, nil)
+				mockEvaluatorService.EXPECT().AsyncRunEvaluator(gomock.Any(), gomock.Any()).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking}, nil,
+				)
+				mockMetric.EXPECT().EmitTurnExecEvaluatorResult(gomock.Any(), false)
+				mockEvalAsyncRepo.EXPECT().SetEvalAsyncCtx(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockEvaluatorRecordService.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(201), false).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusSuccess}, nil,
+				)
+
+				return &DefaultExptTurnEvaluationImpl{
+					metric:                 mockMetric,
+					evaluatorService:       mockEvaluatorService,
+					benefitService:         mockBenefitService,
+					evalTargetService:      mockEvalTargetService,
+					evalAsyncRepo:          mockEvalAsyncRepo,
+					evaluatorRecordService: mockEvaluatorRecordService,
+				}
+			},
+			etec:    baseEtec,
+			wantErr: false,
+			validateResult: func(t *testing.T, results map[int64]*entity.EvaluatorRecord) {
+				assert.Len(t, results, 1)
+				for _, record := range results {
+					assert.Equal(t, entity.EvaluatorRunStatusSuccess, record.Status)
+				}
+			},
+		},
+		{
+			name: "async evaluator still invoking after refresh",
+			prepare: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockMetric := metricsmocks.NewMockExptMetric(ctrl)
+				mockEvaluatorService := svcmocks.NewMockEvaluatorService(ctrl)
+				mockBenefitService := benefitmocks.NewMockIBenefitService(ctrl)
+				mockEvalTargetService := svcmocks.NewMockIEvalTargetService(ctrl)
+				mockEvalAsyncRepo := repomocks.NewMockIEvalAsyncRepo(ctrl)
+				mockEvaluatorRecordService := svcmocks.NewMockEvaluatorRecordService(ctrl)
+
+				mockBenefitService.EXPECT().CheckAndDeductEvalBenefit(gomock.Any(), gomock.Any()).Return(&benefit.CheckAndDeductEvalBenefitResult{}, nil)
+				mockEvaluatorService.EXPECT().AsyncRunEvaluator(gomock.Any(), gomock.Any()).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking}, nil,
+				)
+				mockMetric.EXPECT().EmitTurnExecEvaluatorResult(gomock.Any(), false)
+				mockEvalAsyncRepo.EXPECT().SetEvalAsyncCtx(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockEvaluatorRecordService.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(201), false).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking}, nil,
+				)
+
+				return &DefaultExptTurnEvaluationImpl{
+					metric:                 mockMetric,
+					evaluatorService:       mockEvaluatorService,
+					benefitService:         mockBenefitService,
+					evalTargetService:      mockEvalTargetService,
+					evalAsyncRepo:          mockEvalAsyncRepo,
+					evaluatorRecordService: mockEvaluatorRecordService,
+				}
+			},
+			etec:    baseEtec,
+			wantErr: false,
+			validateResult: func(t *testing.T, results map[int64]*entity.EvaluatorRecord) {
+				assert.Len(t, results, 1)
+				for _, record := range results {
+					assert.Equal(t, entity.EvaluatorRunStatusAsyncInvoking, record.Status)
+				}
+			},
+		},
+		{
+			name: "refresh returns error",
+			prepare: func(ctrl *gomock.Controller) *DefaultExptTurnEvaluationImpl {
+				mockMetric := metricsmocks.NewMockExptMetric(ctrl)
+				mockEvaluatorService := svcmocks.NewMockEvaluatorService(ctrl)
+				mockBenefitService := benefitmocks.NewMockIBenefitService(ctrl)
+				mockEvalTargetService := svcmocks.NewMockIEvalTargetService(ctrl)
+				mockEvalAsyncRepo := repomocks.NewMockIEvalAsyncRepo(ctrl)
+				mockEvaluatorRecordService := svcmocks.NewMockEvaluatorRecordService(ctrl)
+
+				mockBenefitService.EXPECT().CheckAndDeductEvalBenefit(gomock.Any(), gomock.Any()).Return(&benefit.CheckAndDeductEvalBenefitResult{}, nil)
+				mockEvaluatorService.EXPECT().AsyncRunEvaluator(gomock.Any(), gomock.Any()).Return(
+					&entity.EvaluatorRecord{ID: 201, EvaluatorVersionID: 101, Status: entity.EvaluatorRunStatusAsyncInvoking}, nil,
+				)
+				mockMetric.EXPECT().EmitTurnExecEvaluatorResult(gomock.Any(), false)
+				mockEvalAsyncRepo.EXPECT().SetEvalAsyncCtx(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockEvaluatorRecordService.EXPECT().GetEvaluatorRecord(gomock.Any(), int64(201), false).Return(nil, errors.New("db error"))
+
+				return &DefaultExptTurnEvaluationImpl{
+					metric:                 mockMetric,
+					evaluatorService:       mockEvaluatorService,
+					benefitService:         mockBenefitService,
+					evalTargetService:      mockEvalTargetService,
+					evalAsyncRepo:          mockEvalAsyncRepo,
+					evaluatorRecordService: mockEvaluatorRecordService,
+				}
+			},
+			etec:    baseEtec,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			svc := tt.prepare(ctrl)
+			etec := tt.etec()
+
+			results, err := svc.CallEvaluators(context.Background(), etec, mockTargetResult)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.validateResult != nil {
+				tt.validateResult(t, results)
+			}
+		})
+	}
+}

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
@@ -35,8 +35,9 @@ func TestNewExptTurnEvaluation(t *testing.T) {
 	mockBenefitService := benefitmocks.NewMockIBenefitService(ctrl)
 	mockEvalAsyncRepo := repomocks.NewMockIEvalAsyncRepo(ctrl)
 	mockEvalSetItemSvc := svcmocks.NewMockEvaluationSetItemService(ctrl)
+	mockEvaluatorRecordService := svcmocks.NewMockEvaluatorRecordService(ctrl)
 
-	eval := NewExptTurnEvaluation(mockMetric, mockEvalTargetService, mockEvaluatorService, mockBenefitService, mockEvalAsyncRepo, mockEvalSetItemSvc)
+	eval := NewExptTurnEvaluation(mockMetric, mockEvalTargetService, mockEvaluatorService, mockBenefitService, mockEvalAsyncRepo, mockEvalSetItemSvc, mockEvaluatorRecordService)
 	assert.NotNil(t, eval)
 
 	impl, ok := eval.(*DefaultExptTurnEvaluationImpl)
@@ -47,6 +48,7 @@ func TestNewExptTurnEvaluation(t *testing.T) {
 	assert.Equal(t, mockBenefitService, impl.benefitService)
 	assert.Equal(t, mockEvalAsyncRepo, impl.evalAsyncRepo)
 	assert.Equal(t, mockEvalSetItemSvc, impl.evalSetItemSvc)
+	assert.Equal(t, mockEvaluatorRecordService, impl.evaluatorRecordService)
 }
 
 func TestDefaultExptTurnEvaluationImpl_Eval(t *testing.T) {


### PR DESCRIPTION
Add EvaluatorRecordService to DefaultExptTurnEvaluationImpl to refresh async evaluator records during evaluation. This ensures the latest status of async evaluators is retrieved before proceeding with the evaluation.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
