### PR TITLE
[fix][backend] prevent SSTI denial-of-service in prompt template rendering

### DIFF
--- a/backend/modules/prompt/pkg/template/go_template.go
+++ b/backend/modules/prompt/pkg/template/go_template.go
@@ -6,23 +6,37 @@ package template
 import (
 	"bytes"
 	"text/template"
+	"time"
 
 	prompterr "github.com/coze-dev/coze-loop/backend/modules/prompt/pkg/errno"
 	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
 )
 
 func InterpolateGoTemplate(templateStr string, variables map[string]any) (string, error) {
-	// 解析模板
 	tpl, err := template.New("prompt").Parse(templateStr)
 	if err != nil {
 		return "", errorx.NewByCode(prompterr.TemplateParseErrorCode, errorx.WithExtraMsg(err.Error()))
 	}
 
-	// 执行模板渲染
 	var out bytes.Buffer
-	err = tpl.Execute(&out, variables)
-	if err != nil {
-		return "", errorx.NewByCode(prompterr.TemplateRenderErrorCode, errorx.WithExtraMsg(err.Error()))
+	lw := &LimitedWriter{W: &out, N: MaxTemplateOutputSize}
+
+	type result struct {
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ch <- result{err: tpl.Execute(lw, variables)}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return "", errorx.NewByCode(prompterr.TemplateRenderErrorCode, errorx.WithExtraMsg(r.err.Error()))
+		}
+	case <-time.After(MaxTemplateTimeout):
+		return "", errorx.NewByCode(prompterr.TemplateRenderErrorCode,
+			errorx.WithExtraMsg("template rendering timeout"))
 	}
 
 	return out.String(), nil

--- a/backend/modules/prompt/pkg/template/go_template_test.go
+++ b/backend/modules/prompt/pkg/template/go_template_test.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -315,4 +316,29 @@ func TestInterpolateGoTemplate_EdgeCases(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Value: <no value>", got)
 	})
+}
+
+func TestInterpolateGoTemplate_OutputSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	longValue := strings.Repeat("X", 512*1024)
+	templateStr := "{{.a}}{{.a}}{{.a}}"
+	_, err := InterpolateGoTemplate(templateStr, map[string]any{"a": longValue})
+	assert.Error(t, err)
+	statusErr, ok := errorx.FromStatusError(err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(prompterr.TemplateRenderErrorCode), statusErr.Code())
+}
+
+func TestInterpolateGoTemplate_LargeRange(t *testing.T) {
+	t.Parallel()
+
+	items := make([]int, 100)
+	for i := range items {
+		items[i] = i
+	}
+	templateStr := "{{range .items}}{{.}},{{end}}"
+	got, err := InterpolateGoTemplate(templateStr, map[string]any{"items": items})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, got)
 }

--- a/backend/modules/prompt/pkg/template/jinja_template.go
+++ b/backend/modules/prompt/pkg/template/jinja_template.go
@@ -6,18 +6,19 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/nikolalohinski/gonja/v2"
 	"github.com/nikolalohinski/gonja/v2/exec"
 	"github.com/nikolalohinski/gonja/v2/nodes"
 	"github.com/nikolalohinski/gonja/v2/parser"
+	"github.com/pkg/errors"
 
 	prompterr "github.com/coze-dev/coze-loop/backend/modules/prompt/pkg/errno"
 	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
 )
 
 func init() {
-	// 安全初始化 gonja v2，禁用危险的控制结构
 	nilParser := func(p *parser.Parser, args *parser.Parser) (nodes.ControlStructure, error) {
 		return nil, fmt.Errorf("invalid statement")
 	}
@@ -25,23 +26,78 @@ func init() {
 	_ = gonja.DefaultEnvironment.ControlStructures.Replace("extends", nilParser)
 	_ = gonja.DefaultEnvironment.ControlStructures.Replace("import", nilParser)
 	_ = gonja.DefaultEnvironment.ControlStructures.Replace("from", nilParser)
+
+	gonja.DefaultEnvironment.Context.Set("range", safeRangeFunction)
+}
+
+func safeRangeFunction(_ *exec.Evaluator, params *exec.VarArgs) ([]int, error) {
+	var (
+		start = 0
+		stop  = -1
+		step  = 1
+	)
+	switch n := len(params.Args); n > 0 {
+	case n == 1 && params.Args[0].IsInteger():
+		stop = params.Args[0].Integer()
+	case n == 2 && params.Args[0].IsInteger() && params.Args[1].IsInteger():
+		start = params.Args[0].Integer()
+		stop = params.Args[1].Integer()
+	case n == 3 && params.Args[0].IsInteger() && params.Args[1].IsInteger() && params.Args[2].IsInteger():
+		start = params.Args[0].Integer()
+		stop = params.Args[1].Integer()
+		step = params.Args[2].Integer()
+	default:
+		return nil, exec.ErrInvalidCall(errors.New("expected signature is [start, ]stop[, step] where all arguments are integers"))
+	}
+
+	if step == 0 {
+		return nil, exec.ErrInvalidCall(errors.New("step must not be zero"))
+	}
+
+	count := 0
+	if step > 0 && stop > start {
+		count = (stop - start + step - 1) / step
+	} else if step < 0 && start > stop {
+		count = (start - stop - step - 1) / (-step)
+	}
+
+	if count > MaxRangeSize {
+		return nil, exec.ErrInvalidCall(fmt.Errorf("range size %d exceeds maximum allowed %d", count, MaxRangeSize))
+	}
+
+	result := make([]int, 0, count)
+	for i := start; (step > 0 && i < stop) || (step < 0 && i > stop); i += step {
+		result = append(result, i)
+	}
+	return result, nil
 }
 
 func InterpolateJinja2(templateStr string, variables map[string]any) (string, error) {
-	// 解析模板
 	tpl, err := gonja.FromString(templateStr)
 	if err != nil {
 		return "", errorx.NewByCode(prompterr.TemplateParseErrorCode, errorx.WithExtraMsg(err.Error()))
 	}
 
-	// 创建执行上下文
 	data := exec.NewContext(variables)
 	var out bytes.Buffer
+	lw := &LimitedWriter{W: &out, N: MaxTemplateOutputSize}
 
-	// 执行模板渲染
-	err = tpl.Execute(&out, data)
-	if err != nil {
-		return "", errorx.NewByCode(prompterr.TemplateRenderErrorCode, errorx.WithExtraMsg(err.Error()))
+	type result struct {
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ch <- result{err: tpl.Execute(lw, data)}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			return "", errorx.NewByCode(prompterr.TemplateRenderErrorCode, errorx.WithExtraMsg(r.err.Error()))
+		}
+	case <-time.After(MaxTemplateTimeout):
+		return "", errorx.NewByCode(prompterr.TemplateRenderErrorCode,
+			errorx.WithExtraMsg("template rendering timeout"))
 	}
 
 	return out.String(), nil

--- a/backend/modules/prompt/pkg/template/jinja_template.go
+++ b/backend/modules/prompt/pkg/template/jinja_template.go
@@ -33,7 +33,7 @@ func init() {
 func safeRangeFunction(_ *exec.Evaluator, params *exec.VarArgs) ([]int, error) {
 	var (
 		start = 0
-		stop  = -1
+		stop  int
 		step  = 1
 	)
 	switch n := len(params.Args); n > 0 {

--- a/backend/modules/prompt/pkg/template/jinja_template_test.go
+++ b/backend/modules/prompt/pkg/template/jinja_template_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	prompterr "github.com/coze-dev/coze-loop/backend/modules/prompt/pkg/errno"
+	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
+)
+
+func TestInterpolateJinja2_BasicRendering(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		templateStr string
+		variables   map[string]any
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "simple variable",
+			templateStr: "Hello, {{ name }}!",
+			variables:   map[string]any{"name": "World"},
+			want:        "Hello, World!",
+		},
+		{
+			name:        "if condition",
+			templateStr: "{% if show %}Visible{% else %}Hidden{% endif %}",
+			variables:   map[string]any{"show": true},
+			want:        "Visible",
+		},
+		{
+			name:        "for loop with small range",
+			templateStr: "{% for i in range(5) %}{{ i }},{% endfor %}",
+			variables:   nil,
+			want:        "0,1,2,3,4,",
+		},
+		{
+			name:        "for loop with start and stop",
+			templateStr: "{% for i in range(2, 6) %}{{ i }},{% endfor %}",
+			variables:   nil,
+			want:        "2,3,4,5,",
+		},
+		{
+			name:        "for loop with step",
+			templateStr: "{% for i in range(0, 10, 2) %}{{ i }},{% endfor %}",
+			variables:   nil,
+			want:        "0,2,4,6,8,",
+		},
+		{
+			name:        "empty template",
+			templateStr: "",
+			variables:   nil,
+			want:        "",
+		},
+		{
+			name:        "static text",
+			templateStr: "No variables here",
+			variables:   nil,
+			want:        "No variables here",
+		},
+		{
+			name:        "for loop over list",
+			templateStr: "{% for item in items %}{{ item }},{% endfor %}",
+			variables:   map[string]any{"items": []string{"a", "b", "c"}},
+			want:        "a,b,c,",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := InterpolateJinja2(tt.templateStr, tt.variables)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestInterpolateJinja2_SafeRange_BlocksLargeRange(t *testing.T) {
+	t.Parallel()
+
+	templateStr := "{% for i in range(100000) %}X{% endfor %}"
+	_, err := InterpolateJinja2(templateStr, nil)
+	assert.Error(t, err)
+	statusErr, ok := errorx.FromStatusError(err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(prompterr.TemplateRenderErrorCode), statusErr.Code())
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestInterpolateJinja2_SafeRange_BlocksNestedDoS(t *testing.T) {
+	t.Parallel()
+
+	templateStr := "{% for i in range(10000000) %}{% for j in range(100000) %}DoS{% endfor %}{% endfor %}"
+	_, err := InterpolateJinja2(templateStr, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+}
+
+func TestInterpolateJinja2_SafeRange_AllowsMaxBoundary(t *testing.T) {
+	t.Parallel()
+
+	templateStr := "{% for i in range(10000) %}X{% endfor %}"
+	got, err := InterpolateJinja2(templateStr, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 10000, len(got))
+}
+
+func TestInterpolateJinja2_SafeRange_StepZero(t *testing.T) {
+	t.Parallel()
+
+	templateStr := "{% for i in range(0, 10, 0) %}X{% endfor %}"
+	_, err := InterpolateJinja2(templateStr, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "step must not be zero")
+}
+
+func TestInterpolateJinja2_SafeRange_NegativeStep(t *testing.T) {
+	t.Parallel()
+
+	templateStr := "{% for i in range(10, 0, -1) %}{{ i }},{% endfor %}"
+	got, err := InterpolateJinja2(templateStr, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "10,9,8,7,6,5,4,3,2,1,", got)
+}
+
+func TestInterpolateJinja2_OutputSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	longValue := strings.Repeat("X", 512*1024)
+	templateStr := "{{ a }}{{ a }}{{ a }}"
+	_, err := InterpolateJinja2(templateStr, map[string]any{"a": longValue})
+	assert.Error(t, err)
+	statusErr, ok := errorx.FromStatusError(err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(prompterr.TemplateRenderErrorCode), statusErr.Code())
+}
+
+func TestInterpolateJinja2_DisabledControlStructures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		templateStr string
+	}{
+		{
+			name:        "include is disabled",
+			templateStr: `{% include "other.html" %}`,
+		},
+		{
+			name:        "extends is disabled",
+			templateStr: `{% extends "base.html" %}`,
+		},
+		{
+			name:        "import is disabled",
+			templateStr: `{% import "macros.html" as macros %}`,
+		},
+		{
+			name:        "from is disabled",
+			templateStr: `{% from "macros.html" import hello %}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := InterpolateJinja2(tt.templateStr, nil)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestInterpolateJinja2_ParseError(t *testing.T) {
+	t.Parallel()
+
+	_, err := InterpolateJinja2("{% if %}", nil)
+	assert.Error(t, err)
+	statusErr, ok := errorx.FromStatusError(err)
+	assert.True(t, ok)
+	assert.Equal(t, int32(prompterr.TemplateParseErrorCode), statusErr.Code())
+}

--- a/backend/modules/prompt/pkg/template/safe_writer.go
+++ b/backend/modules/prompt/pkg/template/safe_writer.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+const (
+	MaxTemplateOutputSize int64         = 1 << 20 // 1MB
+	MaxTemplateTimeout    time.Duration = 10 * time.Second
+	MaxRangeSize          int           = 10000
+)
+
+var ErrOutputSizeLimitExceeded = fmt.Errorf("template output size limit exceeded")
+
+type LimitedWriter struct {
+	W io.Writer
+	N int64
+}
+
+func (lw *LimitedWriter) Write(p []byte) (n int, err error) {
+	if lw.N <= 0 {
+		return 0, ErrOutputSizeLimitExceeded
+	}
+	if int64(len(p)) > lw.N {
+		p = p[:lw.N]
+		lw.N = 0
+		_, err = lw.W.Write(p)
+		if err != nil {
+			return 0, err
+		}
+		return len(p), ErrOutputSizeLimitExceeded
+	}
+	n, err = lw.W.Write(p)
+	lw.N -= int64(n)
+	return
+}

--- a/backend/modules/prompt/pkg/template/safe_writer_test.go
+++ b/backend/modules/prompt/pkg/template/safe_writer_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimitedWriter_NormalWrite(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 100}
+
+	n, err := lw.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", buf.String())
+	assert.Equal(t, int64(95), lw.N)
+}
+
+func TestLimitedWriter_ExactLimit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 5}
+
+	n, err := lw.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "hello", buf.String())
+	assert.Equal(t, int64(0), lw.N)
+}
+
+func TestLimitedWriter_ExceedsLimit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 3}
+
+	n, err := lw.Write([]byte("hello"))
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOutputSizeLimitExceeded))
+	assert.Equal(t, 3, n)
+	assert.Equal(t, "hel", buf.String())
+}
+
+func TestLimitedWriter_ZeroRemaining(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 0}
+
+	n, err := lw.Write([]byte("hello"))
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOutputSizeLimitExceeded))
+	assert.Equal(t, 0, n)
+	assert.Equal(t, "", buf.String())
+}
+
+func TestLimitedWriter_MultipleWrites(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	lw := &LimitedWriter{W: &buf, N: 10}
+
+	n, err := lw.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	n, err = lw.Write([]byte("world!"))
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrOutputSizeLimitExceeded))
+	assert.Equal(t, 5, n)
+	assert.Equal(t, "helloworld", buf.String())
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title

- [x] This PR title match the format: [<type>][<scope>] <description>. For example: [fix][backend] flaky fix
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

[fix][backend] 修复 Prompt 模板渲染中的 SSTI 拒绝服务漏洞

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)

en:

This PR fixes a critical Server-Side Template Injection (SSTI) denial-of-service vulnerability in the prompt template rendering engine. A malicious user could craft a Jinja2 prompt template like `{% for i in range(10000000) %}{% for j in range(100000) %}DoS{% endfor %}{% endfor %}` to cause the server to exhaust CPU and memory, leading to a complete service outage (OOM crash).

**Root Cause:**
- The gonja Jinja2 engine's built-in `range()` function uses an unbounded channel-based implementation with no size limit, allowing generation of billions of iterations.
- Neither Jinja2 nor Go Template rendering had timeout controls or output size limits.

**Changes (Defense in Depth - 3 layers):**

1. **Safe `range` function** (Jinja2): Replaced the original channel-based `range()` with a safe slice-based version that pre-calculates iteration count and rejects any range exceeding 10,000 elements. Also added `step=0` validation to prevent infinite loops.

2. **Rendering timeout** (Jinja2 + Go Template): Added 10-second timeout guard using goroutine + `time.After` to prevent any form of infinite loop or blocking from hanging the service.

3. **Output size limit** (Jinja2 + Go Template): Introduced `LimitedWriter` that caps template output at 1MB, immediately aborting rendering when exceeded to prevent memory exhaustion.

**Files changed:**
- `backend/modules/prompt/pkg/template/safe_writer.go` — New: `LimitedWriter`, constants, error definitions
- `backend/modules/prompt/pkg/template/jinja_template.go` — Modified: safe range + timeout + output limit
- `backend/modules/prompt/pkg/template/go_template.go` — Modified: timeout + output limit
- `backend/modules/prompt/pkg/template/safe_writer_test.go` — New: 5 unit tests for LimitedWriter
- `backend/modules/prompt/pkg/template/jinja_template_test.go` — New: 14 unit tests for Jinja2 safety
- `backend/modules/prompt/pkg/template/go_template_test.go` — Modified: 2 new DoS protection tests

All existing tests pass. No breaking changes to the template rendering API.

zh(optional):

本 PR 修复了 Prompt 模板渲染引擎中的一个严重 SSTI 拒绝服务漏洞。恶意用户可通过构造 Jinja2 模板（如嵌套 `for` + `range` 大数循环）导致服务器 CPU 和内存耗尽，造成服务宕机。

修复采用纵深防御策略：
1. 安全 `range` 函数：限制最大迭代次数为 10000，超出直接拒绝
2. 渲染超时控制：10 秒超时兜底，防止无限循环
3. 输出大小限制：`LimitedWriter` 限制输出最大 1MB，防止内存耗尽

#### (Optional) Which issue(s) this PR fixes

N/A