### PR TITLE
[feat][prompt] add prompt_key for GetPromptOApi

### DIFF
--- a/backend/kitex_gen/coze/loop/prompt/openapi/coze.loop.prompt.openapi.go
+++ b/backend/kitex_gen/coze/loop/prompt/openapi/coze.loop.prompt.openapi.go
@@ -5755,6 +5755,7 @@ func (p *DeletePromptOApiResponse) Field255DeepEqual(src *base.BaseResp) bool {
 type GetPromptOApiRequest struct {
 	PromptID      *int64       `thrift:"prompt_id,1,optional" frugal:"1,optional,i64" json:"prompt_id" path:"prompt_id" `
 	WorkspaceID   *int64       `thrift:"workspace_id,2,optional" frugal:"2,optional,i64" json:"workspace_id" query:"workspace_id" `
+	PromptKey     *string      `thrift:"prompt_key,3,optional" frugal:"3,optional,string" json:"prompt_key,omitempty" query:"prompt_key"`
 	WithCommit    *bool        `thrift:"with_commit,11,optional" frugal:"11,optional,bool" json:"with_commit,omitempty" query:"with_commit"`
 	CommitVersion *string      `thrift:"commit_version,12,optional" frugal:"12,optional,string" json:"commit_version,omitempty" query:"commit_version"`
 	WithDraft     *bool        `thrift:"with_draft,21,optional" frugal:"21,optional,bool" json:"with_draft,omitempty" query:"with_draft"`
@@ -5791,6 +5792,18 @@ func (p *GetPromptOApiRequest) GetWorkspaceID() (v int64) {
 		return GetPromptOApiRequest_WorkspaceID_DEFAULT
 	}
 	return *p.WorkspaceID
+}
+
+var GetPromptOApiRequest_PromptKey_DEFAULT string
+
+func (p *GetPromptOApiRequest) GetPromptKey() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetPromptKey() {
+		return GetPromptOApiRequest_PromptKey_DEFAULT
+	}
+	return *p.PromptKey
 }
 
 var GetPromptOApiRequest_WithCommit_DEFAULT bool
@@ -5858,6 +5871,9 @@ func (p *GetPromptOApiRequest) SetPromptID(val *int64) {
 func (p *GetPromptOApiRequest) SetWorkspaceID(val *int64) {
 	p.WorkspaceID = val
 }
+func (p *GetPromptOApiRequest) SetPromptKey(val *string) {
+	p.PromptKey = val
+}
 func (p *GetPromptOApiRequest) SetWithCommit(val *bool) {
 	p.WithCommit = val
 }
@@ -5877,6 +5893,7 @@ func (p *GetPromptOApiRequest) SetBase(val *base.Base) {
 var fieldIDToName_GetPromptOApiRequest = map[int16]string{
 	1:   "prompt_id",
 	2:   "workspace_id",
+	3:   "prompt_key",
 	11:  "with_commit",
 	12:  "commit_version",
 	21:  "with_draft",
@@ -5890,6 +5907,10 @@ func (p *GetPromptOApiRequest) IsSetPromptID() bool {
 
 func (p *GetPromptOApiRequest) IsSetWorkspaceID() bool {
 	return p.WorkspaceID != nil
+}
+
+func (p *GetPromptOApiRequest) IsSetPromptKey() bool {
+	return p.PromptKey != nil
 }
 
 func (p *GetPromptOApiRequest) IsSetWithCommit() bool {
@@ -5941,6 +5962,14 @@ func (p *GetPromptOApiRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 2:
 			if fieldTypeId == thrift.I64 {
 				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField3(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -6037,6 +6066,17 @@ func (p *GetPromptOApiRequest) ReadField2(iprot thrift.TProtocol) error {
 	p.WorkspaceID = _field
 	return nil
 }
+func (p *GetPromptOApiRequest) ReadField3(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.PromptKey = _field
+	return nil
+}
 func (p *GetPromptOApiRequest) ReadField11(iprot thrift.TProtocol) error {
 
 	var _field *bool
@@ -6099,6 +6139,10 @@ func (p *GetPromptOApiRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField2(oprot); err != nil {
 			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
 			goto WriteFieldError
 		}
 		if err = p.writeField11(oprot); err != nil {
@@ -6174,6 +6218,24 @@ WriteFieldBeginError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+func (p *GetPromptOApiRequest) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetPromptKey() {
+		if err = oprot.WriteFieldBegin("prompt_key", thrift.STRING, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.PromptKey); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
 }
 func (p *GetPromptOApiRequest) writeField11(oprot thrift.TProtocol) (err error) {
 	if p.IsSetWithCommit() {
@@ -6286,6 +6348,9 @@ func (p *GetPromptOApiRequest) DeepEqual(ano *GetPromptOApiRequest) bool {
 	if !p.Field2DeepEqual(ano.WorkspaceID) {
 		return false
 	}
+	if !p.Field3DeepEqual(ano.PromptKey) {
+		return false
+	}
 	if !p.Field11DeepEqual(ano.WithCommit) {
 		return false
 	}
@@ -6324,6 +6389,18 @@ func (p *GetPromptOApiRequest) Field2DeepEqual(src *int64) bool {
 		return false
 	}
 	if *p.WorkspaceID != *src {
+		return false
+	}
+	return true
+}
+func (p *GetPromptOApiRequest) Field3DeepEqual(src *string) bool {
+
+	if p.PromptKey == src {
+		return true
+	} else if p.PromptKey == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.PromptKey, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/prompt/openapi/coze.loop.prompt.openapi_validator.go
+++ b/backend/kitex_gen/coze/loop/prompt/openapi/coze.loop.prompt.openapi_validator.go
@@ -211,12 +211,6 @@ func (p *DeletePromptOApiResponse) IsValid() error {
 	return nil
 }
 func (p *GetPromptOApiRequest) IsValid() error {
-	if p.PromptID == nil {
-		return fmt.Errorf("field PromptID not_nil rule failed")
-	}
-	if *p.PromptID <= int64(0) {
-		return fmt.Errorf("field PromptID gt rule failed, current value: %v", *p.PromptID)
-	}
 	if p.Extra != nil {
 		if err := p.Extra.IsValid(); err != nil {
 			return fmt.Errorf("field Extra not valid, %w", err)

--- a/backend/kitex_gen/coze/loop/prompt/openapi/k-coze.loop.prompt.openapi.go
+++ b/backend/kitex_gen/coze/loop/prompt/openapi/k-coze.loop.prompt.openapi.go
@@ -4230,6 +4230,20 @@ func (p *GetPromptOApiRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 3:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 11:
 			if fieldTypeId == thrift.BOOL {
 				l, err = p.FastReadField11(buf[offset:])
@@ -4346,6 +4360,20 @@ func (p *GetPromptOApiRequest) FastReadField2(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *GetPromptOApiRequest) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.PromptKey = _field
+	return offset, nil
+}
+
 func (p *GetPromptOApiRequest) FastReadField11(buf []byte) (int, error) {
 	offset := 0
 
@@ -4423,6 +4451,7 @@ func (p *GetPromptOApiRequest) FastWriteNocopy(buf []byte, w thrift.NocopyWriter
 		offset += p.fastWriteField2(buf[offset:], w)
 		offset += p.fastWriteField11(buf[offset:], w)
 		offset += p.fastWriteField21(buf[offset:], w)
+		offset += p.fastWriteField3(buf[offset:], w)
 		offset += p.fastWriteField12(buf[offset:], w)
 		offset += p.fastWriteField254(buf[offset:], w)
 		offset += p.fastWriteField255(buf[offset:], w)
@@ -4436,6 +4465,7 @@ func (p *GetPromptOApiRequest) BLength() int {
 	if p != nil {
 		l += p.field1Length()
 		l += p.field2Length()
+		l += p.field3Length()
 		l += p.field11Length()
 		l += p.field12Length()
 		l += p.field21Length()
@@ -4460,6 +4490,15 @@ func (p *GetPromptOApiRequest) fastWriteField2(buf []byte, w thrift.NocopyWriter
 	if p.IsSetWorkspaceID() {
 		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 2)
 		offset += thrift.Binary.WriteI64(buf[offset:], *p.WorkspaceID)
+	}
+	return offset
+}
+
+func (p *GetPromptOApiRequest) fastWriteField3(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetPromptKey() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 3)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.PromptKey)
 	}
 	return offset
 }
@@ -4527,6 +4566,15 @@ func (p *GetPromptOApiRequest) field2Length() int {
 	return l
 }
 
+func (p *GetPromptOApiRequest) field3Length() int {
+	l := 0
+	if p.IsSetPromptKey() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.PromptKey)
+	}
+	return l
+}
+
 func (p *GetPromptOApiRequest) field11Length() int {
 	l := 0
 	if p.IsSetWithCommit() {
@@ -4586,6 +4634,14 @@ func (p *GetPromptOApiRequest) DeepCopy(s interface{}) error {
 	if src.WorkspaceID != nil {
 		tmp := *src.WorkspaceID
 		p.WorkspaceID = &tmp
+	}
+
+	if src.PromptKey != nil {
+		var tmp string
+		if *src.PromptKey != "" {
+			tmp = kutils.StringDeepCopy(*src.PromptKey)
+		}
+		p.PromptKey = &tmp
 	}
 
 	if src.WithCommit != nil {

--- a/idl/thrift/coze/loop/prompt/coze.loop.prompt.openapi.thrift
+++ b/idl/thrift/coze/loop/prompt/coze.loop.prompt.openapi.thrift
@@ -126,8 +126,9 @@ struct DeletePromptOApiResponse {
 }
 
 struct GetPromptOApiRequest {
-    1: optional i64 prompt_id (api.path='prompt_id', api.js_conv='true', vt.not_nil='true', vt.gt='0', go.tag='json:"prompt_id"')
+    1: optional i64 prompt_id (api.path='prompt_id', api.js_conv='true', go.tag='json:"prompt_id"')
     2: optional i64 workspace_id (api.query="workspace_id", api.js_conv='true', go.tag='json:"workspace_id"')
+    3: optional string prompt_key (api.query="prompt_key")
 
     11: optional bool with_commit (api.query="with_commit")
     12: optional string commit_version (api.query="commit_version")


### PR DESCRIPTION
GetPromptOApi : Add prompt_key query parameter to GetPromptOApiRequest . When prompt_id is 0 and prompt_key is provided, resolve prompt_id by calling GetPromptMetaByKey RPC before proceeding with the original flow. The gray check ( isPromptV2Gray ) is evaluated first.