### PR TITLE
[feat][evaluation] allow online experiments to return eval_set in bat…

### DIFF
--- a/backend/modules/evaluation/application/convertor/experiment/expt.go
+++ b/backend/modules/evaluation/application/convertor/experiment/expt.go
@@ -421,7 +421,7 @@ func ToExptDTO(experiment *entity.Experiment) *domain_expt.Experiment {
 	}
 
 	res.EvalTarget = target.EvalTargetDO2DTO(experiment.Target)
-	if experiment.ExptType != entity.ExptType_Online {
+	if experiment.EvalSet != nil {
 		res.EvalSet = evaluation_set.EvaluationSetDO2DTO(experiment.EvalSet)
 	}
 	res.Evaluators = make([]*evaluatordto.Evaluator, 0, len(experiment.Evaluators))

--- a/backend/modules/evaluation/application/convertor/experiment/expt_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/expt_test.go
@@ -2529,3 +2529,59 @@ func TestCreateEvalTargetParamDTO2DO_WithCluster(t *testing.T) {
 		assert.Nil(t, result)
 	})
 }
+
+func TestToExptDTO_EvalSetByNilCheck(t *testing.T) {
+	t.Run("离线实验有EvalSet时返回EvalSet", func(t *testing.T) {
+		experiment := &entity.Experiment{
+			ExptType: entity.ExptType_Offline,
+			EvalSet: &entity.EvaluationSet{
+				ID:   100,
+				Name: "test_eval_set",
+			},
+		}
+
+		result := ToExptDTO(experiment)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.EvalSet)
+		assert.Equal(t, int64(100), gptr.Indirect(result.EvalSet.ID))
+		assert.Equal(t, "test_eval_set", gptr.Indirect(result.EvalSet.Name))
+	})
+
+	t.Run("在线实验有EvalSet时返回EvalSet", func(t *testing.T) {
+		experiment := &entity.Experiment{
+			ExptType: entity.ExptType_Online,
+			EvalSet: &entity.EvaluationSet{
+				ID:   200,
+				Name: "online_eval_set",
+			},
+		}
+
+		result := ToExptDTO(experiment)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.EvalSet)
+		assert.Equal(t, int64(200), gptr.Indirect(result.EvalSet.ID))
+		assert.Equal(t, "online_eval_set", gptr.Indirect(result.EvalSet.Name))
+	})
+
+	t.Run("在线实验EvalSet为nil时不返回EvalSet", func(t *testing.T) {
+		experiment := &entity.Experiment{
+			ExptType: entity.ExptType_Online,
+			EvalSet:  nil,
+		}
+
+		result := ToExptDTO(experiment)
+		assert.NotNil(t, result)
+		assert.Nil(t, result.EvalSet)
+	})
+
+	t.Run("离线实验EvalSet为nil时不返回EvalSet", func(t *testing.T) {
+		experiment := &entity.Experiment{
+			ExptType: entity.ExptType_Offline,
+			EvalSet:  nil,
+		}
+
+		result := ToExptDTO(experiment)
+		assert.NotNil(t, result)
+		assert.Nil(t, result.EvalSet)
+	})
+}

--- a/backend/modules/evaluation/domain/service/expt_manage_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_manage_impl.go
@@ -968,9 +968,7 @@ func (e *ExptMangerImpl) List(ctx context.Context, page, pageSize int32, spaceID
 		return nil, 0, err
 	}
 	for idx := range exptTuples {
-		if expts[idx].ExptType != entity.ExptType_Online {
-			expts[idx].EvalSet = exptTuples[idx].EvalSet
-		}
+		expts[idx].EvalSet = exptTuples[idx].EvalSet
 		expts[idx].Target = exptTuples[idx].Target
 		expts[idx].Evaluators = exptTuples[idx].Evaluators
 	}

--- a/backend/modules/evaluation/domain/service/expt_manage_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_manage_impl_test.go
@@ -1138,6 +1138,46 @@ func TestExptMangerImpl_List(t *testing.T) {
 			t.Errorf("List() error = %v, wantErr nil", err)
 		}
 	})
+
+	t.Run("在线实验也填充EvalSet", func(t *testing.T) {
+		onlineExpt := &entity.Experiment{
+			ID:                  456,
+			ExptType:            entity.ExptType_Online,
+			EvalSetID:           10,
+			EvalSetVersionID:    20,
+			EvaluatorVersionRef: []*entity.ExptEvaluatorVersionRef{{EvaluatorVersionID: 222}},
+		}
+		onlineEvalSetVersion := &entity.EvaluationSetVersion{ID: 20, EvaluationSetID: 10}
+		onlineEvalSet := &entity.EvaluationSet{ID: 10, Name: "online_eval_set", EvaluationSetVersion: onlineEvalSetVersion}
+
+		mockExptRepo.EXPECT().
+			List(ctx, page, pageSize, filter, orderBys, spaceID).
+			Return([]*entity.Experiment{onlineExpt}, int64(1), nil).Times(1)
+		mockEvaluationSetVersionService.EXPECT().
+			BatchGetEvaluationSetVersions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*entity.BatchGetEvaluationSetVersionsResult{
+				{Version: onlineEvalSetVersion, EvaluationSet: onlineEvalSet},
+			}, nil).AnyTimes()
+		mockEvalTargetService.EXPECT().
+			BatchGetEvalTargetVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*entity.EvalTarget{}, nil).AnyTimes()
+		mockEvaluatorService.EXPECT().
+			BatchGetEvaluatorVersion(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*entity.Evaluator{}, nil).AnyTimes()
+		mockExptResultService.EXPECT().
+			MGetStats(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*entity.ExptStats{}, nil).AnyTimes()
+		mockExptAggrResultService.EXPECT().
+			BatchGetExptAggrResultByExperimentIDs(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return([]*entity.ExptAggregateResult{}, nil).AnyTimes()
+
+		got, count, err := mgr.List(ctx, page, pageSize, spaceID, filter, orderBys, session)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(1), count)
+		assert.Len(t, got, 1)
+		assert.NotNil(t, got[0].EvalSet, "在线实验也应填充EvalSet")
+		assert.Equal(t, int64(10), got[0].EvalSet.ID)
+	})
 }
 
 func TestExptMangerImpl_ListExptRaw(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title

- [x] This PR title match the format: $$<type>$$$$<scope>$$ <description>. For example: $$fix$$$$backend$$ flaky fix
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.

**PR Title:** [feat][evaluation] allow online experiments to return eval_set in batch_get and list APIs

#### (Optional) Translate the PR title into Chinese

[feat][evaluation] 在线评测实验在 batch_get 和 list 接口中也返回 eval_set 信息

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)

en:
Previously, the `batch_get` and `list` experiment APIs filtered out `eval_set` (including column schema) for online experiments based on `ExptType`. This PR replaces the `ExptType`-based filtering with a nil-check on the `EvalSet` field, so that online experiments also return `eval_set` and its associated column schema when the data actually exists.

**Changes:**
- **Convertor layer** (`expt.go`): Changed `if experiment.ExptType != entity.ExptType_Online` to `if experiment.EvalSet != nil`
- **Domain layer** (`expt_manage_impl.go`): Removed the `ExptType_Online` guard in the `List` method that prevented assigning `EvalSet` to online experiments
- **Tests**: Added unit tests covering online/offline experiments with and without `EvalSet`

zh(optional):
此前 `batch_get` 和 `list` 实验接口会根据 `ExptType` 过滤掉在线评测实验的 `eval_set`（含列 schema）。本 PR 将判断条件从实验类型改为对 `EvalSet` 字段的 nil 检查，使得在线评测实验在有关联数据集时也能正确返回 `eval_set` 及列 schema 信息。

#### (Optional) Which issue(s) this PR fixes