### PR TITLE
[feat][backend] add workspace-level max span limit config

### DIFF
--- a/backend/modules/observability/application/trace.go
+++ b/backend/modules/observability/application/trace.go
@@ -361,6 +361,7 @@ func (t *TraceApplication) SearchTraceTree(ctx context.Context, req *trace.Searc
 	if err != nil {
 		return nil, errorx.WrapByCode(err, obErrorx.CommercialCommonInvalidParamCodeCode, errorx.WithExtraMsg("Get trace req is invalid"))
 	}
+	sReq.Limit = t.traceConfig.GetSearchTraceTreeMaxSpanLimit(ctx, req.GetWorkspaceID())
 	sResp, err := t.traceService.GetTrace(ctx, sReq)
 	if err != nil {
 		return nil, err

--- a/backend/modules/observability/application/trace_test.go
+++ b/backend/modules/observability/application/trace_test.go
@@ -981,6 +981,7 @@ func TestTraceApplication_SearchTraceTree(t *testing.T) {
 				mockAuth := rpcmock.NewMockIAuthProvider(ctrl)
 				mockCfg := confmock.NewMockITraceConfig(ctrl)
 				mockCfg.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(30))
+				mockCfg.EXPECT().GetSearchTraceTreeMaxSpanLimit(gomock.Any(), gomock.Any()).Return(int32(10000))
 				mockAuth.EXPECT().CheckWorkspacePermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockSvc.EXPECT().GetTrace(gomock.Any(), gomock.Any()).Return(&service.GetTraceResp{
 					TraceId: "trace-1",
@@ -1017,6 +1018,7 @@ func TestTraceApplication_SearchTraceTree(t *testing.T) {
 				mockAuth := rpcmock.NewMockIAuthProvider(ctrl)
 				mockCfg := confmock.NewMockITraceConfig(ctrl)
 				mockCfg.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(30))
+				mockCfg.EXPECT().GetSearchTraceTreeMaxSpanLimit(gomock.Any(), gomock.Any()).Return(int32(10000))
 				mockAuth.EXPECT().CheckWorkspacePermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 				mockSvc.EXPECT().GetTrace(gomock.Any(), gomock.Any()).Return(nil, assert.AnError)
 				return fields{
@@ -1036,6 +1038,47 @@ func TestTraceApplication_SearchTraceTree(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "success case with custom span limit",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockSvc := svcmock.NewMockITraceService(ctrl)
+				mockAuth := rpcmock.NewMockIAuthProvider(ctrl)
+				mockCfg := confmock.NewMockITraceConfig(ctrl)
+				mockCfg.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(30))
+				mockCfg.EXPECT().GetSearchTraceTreeMaxSpanLimit(gomock.Any(), int64(12)).Return(int32(5000))
+				mockAuth.EXPECT().CheckWorkspacePermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockSvc.EXPECT().GetTrace(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, req *service.GetTraceReq) (*service.GetTraceResp, error) {
+						assert.Equal(t, int32(5000), req.Limit)
+						return &service.GetTraceResp{
+							TraceId: "trace-1",
+							Spans:   loop_span.SpanList{},
+						}, nil
+					})
+				return fields{
+					traceSvc: mockSvc,
+					auth:     mockAuth,
+					traceCfg: mockCfg,
+				}
+			},
+			args: args{
+				ctx: context.Background(),
+				req: &trace.SearchTraceTreeRequest{
+					WorkspaceID: 12,
+					TraceID:     "trace-1",
+					StartTime:   start,
+					EndTime:     end,
+				},
+			},
+			want: &trace.SearchTraceTreeResponse{
+				Spans: []*span.OutputSpan{},
+				TracesAdvanceInfo: &trace.TraceAdvanceInfo{
+					TraceID: "trace-1",
+					Tokens:  &trace.TokenCost{},
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "permission error",

--- a/backend/modules/observability/domain/component/config/config.go
+++ b/backend/modules/observability/domain/component/config/config.go
@@ -235,6 +235,7 @@ type ITraceConfig interface {
 	GetMetricQueryConfig(ctx context.Context) *MetricQueryConfig
 	GetBackfillConfig(ctx context.Context) *BackfillConfig
 	GetReflowInsertConfig(ctx context.Context) *ReflowInsertConfig
+	GetSearchTraceTreeMaxSpanLimit(ctx context.Context, workspaceID int64) int32
 
 	conf.IConfigLoader
 }

--- a/backend/modules/observability/domain/component/config/mocks/config.go
+++ b/backend/modules/observability/domain/component/config/mocks/config.go
@@ -201,6 +201,20 @@ func (mr *MockITraceConfigMockRecorder) GetReflowInsertConfig(ctx any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReflowInsertConfig", reflect.TypeOf((*MockITraceConfig)(nil).GetReflowInsertConfig), ctx)
 }
 
+// GetSearchTraceTreeMaxSpanLimit mocks base method.
+func (m *MockITraceConfig) GetSearchTraceTreeMaxSpanLimit(ctx context.Context, workspaceID int64) int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSearchTraceTreeMaxSpanLimit", ctx, workspaceID)
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetSearchTraceTreeMaxSpanLimit indicates an expected call of GetSearchTraceTreeMaxSpanLimit.
+func (mr *MockITraceConfigMockRecorder) GetSearchTraceTreeMaxSpanLimit(ctx, workspaceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchTraceTreeMaxSpanLimit", reflect.TypeOf((*MockITraceConfig)(nil).GetSearchTraceTreeMaxSpanLimit), ctx, workspaceID)
+}
+
 // GetPlatformSpansTrans mocks base method.
 func (m *MockITraceConfig) GetPlatformSpansTrans(ctx context.Context) (*config.SpanTransHandlerConfig, error) {
 	m.ctrl.T.Helper()

--- a/backend/modules/observability/domain/trace/service/trace_service.go
+++ b/backend/modules/observability/domain/trace/service/trace_service.go
@@ -1216,8 +1216,10 @@ func (r *TraceServiceImpl) GetTrace(ctx context.Context, req *GetTraceReq) (*Get
 	if !req.WithDetail {
 		limit = 10000
 	}
-	if req.Limit > 0 && req.Limit < limit {
-		limit = req.Limit
+	if req.Limit > 0 {
+		if !req.WithDetail || req.Limit < limit {
+			limit = req.Limit
+		}
 	}
 	traceResult, err := r.traceRepo.GetTrace(ctx, &repo.GetTraceParam{
 		WorkSpaceID:     strconv.FormatInt(req.WorkspaceID, 10),

--- a/backend/modules/observability/domain/trace/service/trace_service_test.go
+++ b/backend/modules/observability/domain/trace/service/trace_service_test.go
@@ -2909,6 +2909,82 @@ func TestTraceServiceImpl_GetTrace(t *testing.T) {
 			},
 		},
 		{
+			name: "get trace without detail and custom limit overrides default",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				repoMock := repomocks.NewMockITraceRepo(ctrl)
+				repoMock.EXPECT().GetTrace(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, param *repo.GetTraceParam) (*repo.GetTraceResult, error) {
+						assert.Equal(t, int32(15000), param.Limit)
+						return &repo.GetTraceResult{Spans: loop_span.SpanList{}}, nil
+					})
+				confMock := confmocks.NewMockITraceConfig(ctrl)
+				tenantProviderMock := tenantmocks.NewMockITenantProvider(ctrl)
+				tenantProviderMock.EXPECT().GetTenantsByPlatformType(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"spans"}, nil).AnyTimes()
+				filterFactoryMock := filtermocks.NewMockPlatformFilterFactory(ctrl)
+				buildHelper := NewTraceFilterProcessorBuilder(filterFactoryMock, map[entity.ProcessorScene][]span_processor.Factory{entity.SceneGetTrace: {}, entity.SceneListSpans: {}, entity.SceneAdvanceInfo: {}, entity.SceneIngestTrace: {}, entity.SceneSearchTraceOApi: {}, entity.SceneListSpansOApi: {}})
+				metricsMock := metricmocks.NewMockITraceMetrics(ctrl)
+				metricsMock.EXPECT().EmitGetTrace(gomock.Any(), gomock.Any(), gomock.Any()).Return()
+				return fields{
+					traceRepo:      repoMock,
+					traceConfig:    confMock,
+					buildHelper:    buildHelper,
+					metrics:        metricsMock,
+					tenantProvider: tenantProviderMock,
+				}
+			},
+			args: args{
+				ctx: context.Background(),
+				req: &GetTraceReq{
+					PlatformType: loop_span.PlatformCozeLoop,
+					TraceID:      "123",
+					WithDetail:   false,
+					Limit:        15000, // exceeds default 10000, should be used directly
+				},
+			},
+			want: &GetTraceResp{
+				TraceId: "123",
+				Spans:   loop_span.SpanList{},
+			},
+		},
+		{
+			name: "get trace without detail and limit smaller than default",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				repoMock := repomocks.NewMockITraceRepo(ctrl)
+				repoMock.EXPECT().GetTrace(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, param *repo.GetTraceParam) (*repo.GetTraceResult, error) {
+						assert.Equal(t, int32(5000), param.Limit)
+						return &repo.GetTraceResult{Spans: loop_span.SpanList{}}, nil
+					})
+				confMock := confmocks.NewMockITraceConfig(ctrl)
+				tenantProviderMock := tenantmocks.NewMockITenantProvider(ctrl)
+				tenantProviderMock.EXPECT().GetTenantsByPlatformType(gomock.Any(), gomock.Any(), gomock.Any()).Return([]string{"spans"}, nil).AnyTimes()
+				filterFactoryMock := filtermocks.NewMockPlatformFilterFactory(ctrl)
+				buildHelper := NewTraceFilterProcessorBuilder(filterFactoryMock, map[entity.ProcessorScene][]span_processor.Factory{entity.SceneGetTrace: {}, entity.SceneListSpans: {}, entity.SceneAdvanceInfo: {}, entity.SceneIngestTrace: {}, entity.SceneSearchTraceOApi: {}, entity.SceneListSpansOApi: {}})
+				metricsMock := metricmocks.NewMockITraceMetrics(ctrl)
+				metricsMock.EXPECT().EmitGetTrace(gomock.Any(), gomock.Any(), gomock.Any()).Return()
+				return fields{
+					traceRepo:      repoMock,
+					traceConfig:    confMock,
+					buildHelper:    buildHelper,
+					metrics:        metricsMock,
+					tenantProvider: tenantProviderMock,
+				}
+			},
+			args: args{
+				ctx: context.Background(),
+				req: &GetTraceReq{
+					PlatformType: loop_span.PlatformCozeLoop,
+					TraceID:      "123",
+					WithDetail:   false,
+					Limit:        5000, // less than default 10000, should be used
+				},
+			},
+			want: &GetTraceResp{
+				TraceId: "123",
+				Spans:   loop_span.SpanList{},
+			},
+		},
+		{
 			name: "get trace with pagination token returns next page",
 			fieldsGetter: func(ctrl *gomock.Controller) fields {
 				repoMock := repomocks.NewMockITraceRepo(ctrl)

--- a/backend/modules/observability/infra/config/trace.go
+++ b/backend/modules/observability/infra/config/trace.go
@@ -32,12 +32,14 @@ const (
 	metricQueryConfigKey               = "metric_query_config"
 	backfillCfgKey                     = "backfill_config"
 	reflowInsertCfgKey                 = "reflow_insert_config"
+	searchTraceTreeMaxSpanLimitCfgKey  = "search_trace_tree_max_span_limit"
 
-	defaultBackfillDispatchBatchSize  = 10
-	defaultBackfillDispatchIntervalMs = 1000
-	defaultBackfillCkQueryLimit       = 100
-	defaultEvalSetInvokeBatchSize     = 1
-	defaultDatasetInvokeBatchSize     = 1
+	defaultBackfillDispatchBatchSize   = 10
+	defaultBackfillDispatchIntervalMs  = 1000
+	defaultBackfillCkQueryLimit        = 100
+	defaultEvalSetInvokeBatchSize      = 1
+	defaultDatasetInvokeBatchSize      = 1
+	defaultSearchTraceTreeMaxSpanLimit = 10000
 )
 
 type TraceConfigCenter struct {
@@ -256,6 +258,19 @@ func (t *TraceConfigCenter) GetReflowInsertConfig(ctx context.Context) *config.R
 		cfg.DatasetInvokeBatchSize.Default = defaultDatasetInvokeBatchSize
 	}
 	return cfg
+}
+
+func (t *TraceConfigCenter) GetSearchTraceTreeMaxSpanLimit(ctx context.Context, workspaceID int64) int32 {
+	cfg := &config.SpaceAwareParam[int32]{}
+	if err := t.UnmarshalKey(ctx, searchTraceTreeMaxSpanLimitCfgKey, cfg); err != nil {
+		logs.CtxWarn(ctx, "fail to get search trace tree max span limit config, %v", err)
+		return defaultSearchTraceTreeMaxSpanLimit
+	}
+	limit := cfg.Get(workspaceID)
+	if limit <= 0 {
+		return defaultSearchTraceTreeMaxSpanLimit
+	}
+	return limit
 }
 
 func NewTraceConfigCenter(confP conf.IConfigLoader) config.ITraceConfig {

--- a/backend/modules/observability/infra/config/trace_test.go
+++ b/backend/modules/observability/infra/config/trace_test.go
@@ -1025,3 +1025,106 @@ func TestNewTraceConfigCenter(t *testing.T) {
 func stringPtr(s string) *string {
 	return &s
 }
+
+func TestTraceConfigCenter_GetSearchTraceTreeMaxSpanLimit(t *testing.T) {
+	type fields struct {
+		configLoader *confmocks.MockIConfigLoader
+	}
+	type args struct {
+		ctx         context.Context
+		workspaceID int64
+	}
+	tests := []struct {
+		name         string
+		fieldsGetter func(ctrl *gomock.Controller) fields
+		args         args
+		want         int32
+	}{
+		{
+			name: "get default limit when workspace not in overrides",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockLoader := confmocks.NewMockIConfigLoader(ctrl)
+				mockLoader.EXPECT().UnmarshalKey(gomock.Any(), searchTraceTreeMaxSpanLimitCfgKey, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, key string, v interface{}, opts ...interface{}) error {
+						cfg := v.(*config.SpaceAwareParam[int32])
+						cfg.Default = 10000
+						cfg.Overrides = map[int64]int32{100: 5000}
+						return nil
+					})
+				return fields{configLoader: mockLoader}
+			},
+			args: args{ctx: context.Background(), workspaceID: 200},
+			want: 10000,
+		},
+		{
+			name: "get override limit when workspace in overrides",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockLoader := confmocks.NewMockIConfigLoader(ctrl)
+				mockLoader.EXPECT().UnmarshalKey(gomock.Any(), searchTraceTreeMaxSpanLimitCfgKey, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, key string, v interface{}, opts ...interface{}) error {
+						cfg := v.(*config.SpaceAwareParam[int32])
+						cfg.Default = 10000
+						cfg.Overrides = map[int64]int32{100: 5000}
+						return nil
+					})
+				return fields{configLoader: mockLoader}
+			},
+			args: args{ctx: context.Background(), workspaceID: 100},
+			want: 5000,
+		},
+		{
+			name: "get override limit larger than default",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockLoader := confmocks.NewMockIConfigLoader(ctrl)
+				mockLoader.EXPECT().UnmarshalKey(gomock.Any(), searchTraceTreeMaxSpanLimitCfgKey, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, key string, v interface{}, opts ...interface{}) error {
+						cfg := v.(*config.SpaceAwareParam[int32])
+						cfg.Default = 10000
+						cfg.Overrides = map[int64]int32{100: 20000}
+						return nil
+					})
+				return fields{configLoader: mockLoader}
+			},
+			args: args{ctx: context.Background(), workspaceID: 100},
+			want: 20000,
+		},
+		{
+			name: "fallback to default when unmarshal fails",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockLoader := confmocks.NewMockIConfigLoader(ctrl)
+				mockLoader.EXPECT().UnmarshalKey(gomock.Any(), searchTraceTreeMaxSpanLimitCfgKey, gomock.Any()).
+					Return(fmt.Errorf("config error"))
+				return fields{configLoader: mockLoader}
+			},
+			args: args{ctx: context.Background(), workspaceID: 100},
+			want: defaultSearchTraceTreeMaxSpanLimit,
+		},
+		{
+			name: "fallback to default when config value is zero",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockLoader := confmocks.NewMockIConfigLoader(ctrl)
+				mockLoader.EXPECT().UnmarshalKey(gomock.Any(), searchTraceTreeMaxSpanLimitCfgKey, gomock.Any()).
+					DoAndReturn(func(ctx context.Context, key string, v interface{}, opts ...interface{}) error {
+						cfg := v.(*config.SpaceAwareParam[int32])
+						cfg.Default = 0
+						return nil
+					})
+				return fields{configLoader: mockLoader}
+			},
+			args: args{ctx: context.Background(), workspaceID: 100},
+			want: defaultSearchTraceTreeMaxSpanLimit,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			f := tt.fieldsGetter(ctrl)
+			tr := &TraceConfigCenter{
+				IConfigLoader: f.configLoader,
+			}
+			got := tr.GetSearchTraceTreeMaxSpanLimit(tt.args.ctx, tt.args.workspaceID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
…archTraceTree

Add configurable max span limit per workspace for the SearchTraceTree API. Workspaces not in the config will fallback to 10000 spans.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
