### PR TITLE
[fix][backend] 修复 Redis 抖动导致实验调度失败后实验卡住无法执行的问题

### DIFF
--- a/backend/modules/evaluation/domain/entity/event.go
+++ b/backend/modules/evaluation/domain/entity/event.go
@@ -20,8 +20,9 @@ type ExptScheduleEvent struct {
 	Ext       map[string]string
 	Session   *Session
 
-	ItemRetryTimes     int
-	ExecEvalSetItemIDs []int64
+	ItemRetryTimes       int
+	ExecEvalSetItemIDs   []int64
+	InfraErrorRetryTimes int
 }
 
 type ctxTargetCalledCacheKey struct{}

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl.go
@@ -5,7 +5,9 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bytedance/gg/gptr"
@@ -167,7 +169,7 @@ func (e *ExptSchedulerImpl) makeExptRunExecLockKey(exptID, exptRunID int64) stri
 func (e *ExptSchedulerImpl) HandleEventLock(next SchedulerEndPoint) SchedulerEndPoint {
 	return func(ctx context.Context, event *entity.ExptScheduleEvent) error {
 		key := e.makeExptRunExecLockKey(event.ExptID, event.ExptRunID)
-		locked, ctx, cancel, err := e.Mutex.LockWithRenew(ctx, key, time.Second*5, time.Second*60*5)
+		locked, ctx, cancel, err := e.Mutex.LockBackoffWithRenew(ctx, key, time.Second*5, time.Second*60*5)
 		if err != nil {
 			return err
 		}
@@ -215,6 +217,35 @@ func (e *ExptSchedulerImpl) HandleEventErr(next SchedulerEndPoint) SchedulerEndP
 
 		logs.CtxError(ctx, "[ExptEval] HandleEventErr found error: %v, event: %v", nextErr, json.Jsonify(event))
 
+		// 基础设施类错误（Redis抖动、MQ发送失败、context cancel等）：尝试用新ctx重新调度，不直接终止实验
+		if isSchedulerInfraError(nextErr) {
+			maxInfraRetry := 10
+			if event.InfraErrorRetryTimes >= maxInfraRetry {
+				logs.CtxError(ctx, "[ExptEval] infra error reschedule exhausted, expt_id: %v, expt_run_id: %v, retries: %d, err: %v",
+					event.ExptID, event.ExptRunID, event.InfraErrorRetryTimes, nextErr)
+				// 超过最大重试次数，走原有逻辑终止实验
+			} else {
+				logs.CtxWarn(ctx, "[ExptEval] infra error detected, attempting reschedule (%d/%d), expt_id: %v, expt_run_id: %v, err: %v",
+					event.InfraErrorRetryTimes+1, maxInfraRetry, event.ExptID, event.ExptRunID, nextErr)
+
+				// 复制context保留存储内容，仅断开cancel传播
+				freshCtx := context.WithoutCancel(ctx)
+				event.InfraErrorRetryTimes++
+
+				if pubErr := e.Publisher.PublishExptScheduleEvent(freshCtx, event, gptr.Of(time.Second*5)); pubErr != nil {
+					// 重新调度也失败，返回error让MQ框架重投递
+					logs.CtxError(freshCtx, "[ExptEval] reschedule publish failed, rely on MQ retry, expt_id: %v, expt_run_id: %v, pub_err: %v",
+						event.ExptID, event.ExptRunID, pubErr)
+					return nextErr
+				}
+
+				logs.CtxInfo(freshCtx, "[ExptEval] reschedule success after infra error, expt_id: %v, expt_run_id: %v",
+					event.ExptID, event.ExptRunID)
+				return nil
+			}
+		}
+
+		// 业务逻辑错误：终止实验
 		completeCID := fmt.Sprintf("exptexec:onerr:%d", event.ExptRunID)
 
 		if err := e.Manager.CompleteRun(ctx, event.ExptID, event.ExptRunID, event.SpaceID, event.Session, entity.WithCID(completeCID), entity.WithCompleteInterval(time.Second*2)); err != nil {
@@ -228,6 +259,27 @@ func (e *ExptSchedulerImpl) HandleEventErr(next SchedulerEndPoint) SchedulerEndP
 
 		return nil
 	}
+}
+
+// isSchedulerInfraError 判断是否为基础设施类可重试错误
+func isSchedulerInfraError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// context cancel / deadline exceeded 通常由Redis锁续期失败触发
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	errMsg := err.Error()
+	// MQ发送失败
+	if strings.Contains(errMsg, "send batch message fail") {
+		return true
+	}
+	// RPC层错误
+	if strings.Contains(errMsg, "context canceled") || strings.Contains(errMsg, "context deadline exceeded") {
+		return true
+	}
+	return false
 }
 
 func (e *ExptSchedulerImpl) schedule(ctx context.Context, event *entity.ExptScheduleEvent) error {
@@ -316,6 +368,7 @@ func (e *ExptSchedulerImpl) schedule(ctx context.Context, event *entity.ExptSche
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+	event.InfraErrorRetryTimes = 0
 	return mode.NextTick(ctx, event, nextTick)
 }
 

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl_test.go
@@ -120,7 +120,7 @@ func TestExptSchedulerImpl_Schedule(t *testing.T) {
 				f.configer.EXPECT().GetSchedulerAbortCtrl(gomock.Any()).Return(&entity.SchedulerAbortCtrl{}).AnyTimes()
 				f.manager.EXPECT().GetDetail(gomock.Any(), int64(1), int64(3), args.event.Session).Return(mockExpt, nil).Times(1)
 				f.manager.EXPECT().GetRunLog(gomock.Any(), int64(1), int64(2), int64(3), args.event.Session).Return(&entity.ExptRunLog{}, nil).Times(1)
-				f.mutex.EXPECT().LockWithRenew(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, args.ctx, func() {}, nil).Times(1)
+				f.mutex.EXPECT().LockBackoffWithRenew(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, args.ctx, func() {}, nil).Times(1)
 				f.mutex.EXPECT().Unlock(gomock.Any()).Return(true, nil).AnyTimes()
 				f.configer.EXPECT().GetExptExecConf(gomock.Any(), int64(3)).Return(&entity.ExptExecConf{
 					ZombieIntervalSecond: math.MaxInt,
@@ -170,7 +170,7 @@ func TestExptSchedulerImpl_Schedule(t *testing.T) {
 				f.configer.EXPECT().GetSchedulerAbortCtrl(gomock.Any()).Return(&entity.SchedulerAbortCtrl{}).AnyTimes()
 				f.manager.EXPECT().GetDetail(gomock.Any(), int64(1), int64(3), args.event.Session).Return(mockExpt, nil).Times(1)
 				f.manager.EXPECT().GetRunLog(gomock.Any(), int64(1), int64(2), int64(3), args.event.Session).Return(&entity.ExptRunLog{}, nil).Times(1)
-				f.mutex.EXPECT().LockWithRenew(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, args.ctx, func() {}, nil).Times(1)
+				f.mutex.EXPECT().LockBackoffWithRenew(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, args.ctx, func() {}, nil).Times(1)
 				f.mutex.EXPECT().Unlock(gomock.Any()).Return(true, nil).AnyTimes()
 				f.configer.EXPECT().GetExptExecConf(gomock.Any(), int64(3)).Return(&entity.ExptExecConf{
 					ZombieIntervalSecond: math.MaxInt,
@@ -586,7 +586,7 @@ func TestExptSchedulerImpl_HandleEventLock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			unlockCalled := false
-			mutex.EXPECT().LockWithRenew(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.args.locked, context.Background(), func() { unlockCalled = true }, tt.args.lockErr)
+			mutex.EXPECT().LockBackoffWithRenew(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(tt.args.locked, context.Background(), func() { unlockCalled = true }, tt.args.lockErr)
 			if tt.args.locked && tt.args.lockErr == nil {
 				mutex.EXPECT().Unlock(gomock.Any()).Return(true, nil)
 			}
@@ -1511,4 +1511,185 @@ func TestExptSchedulerImpl_terminateZombieEvaluatorRecords(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsSchedulerInfraError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "context.Canceled",
+			err:  context.Canceled,
+			want: true,
+		},
+		{
+			name: "context.DeadlineExceeded",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "wrapped context.Canceled",
+			err:  errors.Join(errors.New("outer"), context.Canceled),
+			want: true,
+		},
+		{
+			name: "send batch message fail",
+			err:  errors.New("send batch message fail, producer_key: expt_scheduler_event_rmq"),
+			want: true,
+		},
+		{
+			name: "rpc context canceled string",
+			err:  errors.New("rpc error: code = Canceled desc = context canceled"),
+			want: true,
+		},
+		{
+			name: "rpc context deadline exceeded string",
+			err:  errors.New("rpc error: code = DeadlineExceeded desc = context deadline exceeded"),
+			want: true,
+		},
+		{
+			name: "business error",
+			err:  errors.New("expt exec found timeout event"),
+			want: false,
+		},
+		{
+			name: "other error",
+			err:  errors.New("some unknown error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSchedulerInfraError(tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExptSchedulerImpl_HandleEventErr(t *testing.T) {
+	tests := []struct {
+		name        string
+		event       *entity.ExptScheduleEvent
+		nextErr     error
+		prepareMock func(f *handleEventErrFields)
+		wantErr     bool
+		assertEvent func(t *testing.T, event *entity.ExptScheduleEvent)
+	}{
+		{
+			name: "next returns nil - success path",
+			event: &entity.ExptScheduleEvent{
+				ExptID: 1, ExptRunID: 2, SpaceID: 3,
+				Session: &entity.Session{UserID: "user1"},
+			},
+			nextErr:     nil,
+			prepareMock: func(f *handleEventErrFields) {},
+			wantErr:     false,
+		},
+		{
+			name: "infra error - reschedule success",
+			event: &entity.ExptScheduleEvent{
+				ExptID: 1, ExptRunID: 2, SpaceID: 3,
+				InfraErrorRetryTimes: 0,
+				Session:              &entity.Session{UserID: "user1"},
+			},
+			nextErr: context.Canceled,
+			prepareMock: func(f *handleEventErrFields) {
+				f.publisher.EXPECT().PublishExptScheduleEvent(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			wantErr: false,
+			assertEvent: func(t *testing.T, event *entity.ExptScheduleEvent) {
+				assert.Equal(t, 1, event.InfraErrorRetryTimes)
+			},
+		},
+		{
+			name: "infra error - reschedule publish fails, return error for MQ retry",
+			event: &entity.ExptScheduleEvent{
+				ExptID: 1, ExptRunID: 2, SpaceID: 3,
+				InfraErrorRetryTimes: 2,
+				Session:              &entity.Session{UserID: "user1"},
+			},
+			nextErr: errors.New("send batch message fail, producer_key: expt_scheduler_event_rmq"),
+			prepareMock: func(f *handleEventErrFields) {
+				f.publisher.EXPECT().PublishExptScheduleEvent(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("mq down")).Times(1)
+			},
+			wantErr: true,
+			assertEvent: func(t *testing.T, event *entity.ExptScheduleEvent) {
+				assert.Equal(t, 3, event.InfraErrorRetryTimes)
+			},
+		},
+		{
+			name: "infra error - retry exhausted, terminate experiment",
+			event: &entity.ExptScheduleEvent{
+				ExptID: 1, ExptRunID: 2, SpaceID: 3,
+				InfraErrorRetryTimes: 10,
+				Session:              &entity.Session{UserID: "user1"},
+			},
+			nextErr: context.Canceled,
+			prepareMock: func(f *handleEventErrFields) {
+				f.manager.EXPECT().CompleteRun(gomock.Any(), int64(1), int64(2), int64(3), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				f.manager.EXPECT().CompleteExpt(gomock.Any(), int64(1), gomock.Any(), int64(3), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			wantErr: false,
+		},
+		{
+			name: "business error - terminate experiment",
+			event: &entity.ExptScheduleEvent{
+				ExptID: 1, ExptRunID: 2, SpaceID: 3,
+				Session: &entity.Session{UserID: "user1"},
+			},
+			nextErr: errors.New("expt exec found timeout event"),
+			prepareMock: func(f *handleEventErrFields) {
+				f.manager.EXPECT().CompleteRun(gomock.Any(), int64(1), int64(2), int64(3), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				f.manager.EXPECT().CompleteExpt(gomock.Any(), int64(1), gomock.Any(), int64(3), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			f := &handleEventErrFields{
+				manager:   svcmocks.NewMockIExptManager(ctrl),
+				publisher: eventmocks.NewMockExptEventPublisher(ctrl),
+			}
+			tt.prepareMock(f)
+
+			svc := &ExptSchedulerImpl{
+				Manager:   f.manager,
+				Publisher: f.publisher,
+			}
+
+			next := func(ctx context.Context, event *entity.ExptScheduleEvent) error {
+				return tt.nextErr
+			}
+
+			handler := svc.HandleEventErr(next)
+			err := handler(context.Background(), tt.event)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.assertEvent != nil {
+				tt.assertEvent(t, tt.event)
+			}
+		})
+	}
+}
+
+type handleEventErrFields struct {
+	manager   *svcmocks.MockIExptManager
+	publisher *eventmocks.MockExptEventPublisher
 }

--- a/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub.go
+++ b/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mohae/deepcopy"
 	"github.com/samber/lo"
 
+	infrabackoff "github.com/coze-dev/coze-loop/backend/infra/backoff"
 	"github.com/coze-dev/coze-loop/backend/infra/mq"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/consts"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
@@ -209,25 +210,12 @@ func (e *exptEventPublisher) batchSendWithTagAndKeys(ctx context.Context, pk str
 		ctx = context.WithValue(ctx, CtxKeyEnv, env) //nolint:staticcheck
 	}
 
-	// 带退避重试发送，容忍短暂的MQ/网络抖动
 	var resp mq.SendResponse
-	var sendErr error
-	maxRetries := 3
-	retryInterval := 200 * time.Millisecond
-	for i := 0; i < maxRetries; i++ {
-		resp, sendErr = p.p.SendBatch(ctx, msgs)
-		if sendErr == nil {
-			break
-		}
-		// context已取消则不再重试
-		if ctx.Err() != nil {
-			break
-		}
-		if i < maxRetries-1 {
-			time.Sleep(retryInterval)
-			retryInterval *= 2
-		}
-	}
+	sendErr := infrabackoff.RetryThreeSeconds(ctx, func() error {
+		var err error
+		resp, err = p.p.SendBatch(ctx, msgs)
+		return err
+	})
 	if sendErr != nil {
 		return errorx.Wrapf(sendErr, "send batch message fail, producer_key: %v, msgs: %v", pk, json.Jsonify(msgs))
 	}

--- a/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub.go
+++ b/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub.go
@@ -208,9 +208,28 @@ func (e *exptEventPublisher) batchSendWithTagAndKeys(ctx context.Context, pk str
 	if env := os.Getenv(XttEnv); env != "" {
 		ctx = context.WithValue(ctx, CtxKeyEnv, env) //nolint:staticcheck
 	}
-	resp, err := p.p.SendBatch(ctx, msgs)
-	if err != nil {
-		return errorx.Wrapf(err, "send batch message fail, producer_key: %v, msgs: %v", pk, json.Jsonify(msgs))
+
+	// 带退避重试发送，容忍短暂的MQ/网络抖动
+	var resp mq.SendResponse
+	var sendErr error
+	maxRetries := 3
+	retryInterval := 200 * time.Millisecond
+	for i := 0; i < maxRetries; i++ {
+		resp, sendErr = p.p.SendBatch(ctx, msgs)
+		if sendErr == nil {
+			break
+		}
+		// context已取消则不再重试
+		if ctx.Err() != nil {
+			break
+		}
+		if i < maxRetries-1 {
+			time.Sleep(retryInterval)
+			retryInterval *= 2
+		}
+	}
+	if sendErr != nil {
+		return errorx.Wrapf(sendErr, "send batch message fail, producer_key: %v, msgs: %v", pk, json.Jsonify(msgs))
 	}
 
 	logs.CtxInfo(ctx, "expt event batch send success, producer_key: %v, tag: %v, message_id: %v, offset: %v", pk, tag, resp.MessageID, resp.Offset)

--- a/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub_test.go
+++ b/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub_test.go
@@ -6,6 +6,7 @@ package producer
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,69 +20,36 @@ import (
 
 func TestBatchSendWithRetry(t *testing.T) {
 	tests := []struct {
-		name         string
-		sendResults  []struct {
-			resp mq.SendResponse
-			err  error
-		}
-		ctxCancel bool
-		wantErr   bool
+		name          string
+		failCount     int // SendBatch连续失败次数，之后返回成功; -1表示一直失败
+		ctxCancel     bool
+		wantErr       bool
+		wantMinCalls  int
 	}{
 		{
-			name: "success on first attempt",
-			sendResults: []struct {
-				resp mq.SendResponse
-				err  error
-			}{
-				{resp: mq.SendResponse{MessageID: "msg1", Offset: 1}, err: nil},
-			},
-			wantErr: false,
+			name:         "success on first attempt",
+			failCount:    0,
+			wantErr:      false,
+			wantMinCalls: 1,
 		},
 		{
-			name: "success on second attempt after transient failure",
-			sendResults: []struct {
-				resp mq.SendResponse
-				err  error
-			}{
-				{resp: mq.SendResponse{}, err: errors.New("connection reset")},
-				{resp: mq.SendResponse{MessageID: "msg1", Offset: 1}, err: nil},
-			},
-			wantErr: false,
+			name:         "success after transient failures",
+			failCount:    2,
+			wantErr:      false,
+			wantMinCalls: 3,
 		},
 		{
-			name: "success on third attempt",
-			sendResults: []struct {
-				resp mq.SendResponse
-				err  error
-			}{
-				{resp: mq.SendResponse{}, err: errors.New("timeout")},
-				{resp: mq.SendResponse{}, err: errors.New("timeout")},
-				{resp: mq.SendResponse{MessageID: "msg1", Offset: 1}, err: nil},
-			},
-			wantErr: false,
+			name:         "all attempts fail within timeout",
+			failCount:    -1,
+			wantErr:      true,
+			wantMinCalls: 2,
 		},
 		{
-			name: "all 3 attempts fail",
-			sendResults: []struct {
-				resp mq.SendResponse
-				err  error
-			}{
-				{resp: mq.SendResponse{}, err: errors.New("timeout")},
-				{resp: mq.SendResponse{}, err: errors.New("timeout")},
-				{resp: mq.SendResponse{}, err: errors.New("timeout")},
-			},
-			wantErr: true,
-		},
-		{
-			name: "context canceled - no retry",
-			sendResults: []struct {
-				resp mq.SendResponse
-				err  error
-			}{
-				{resp: mq.SendResponse{}, err: errors.New("context canceled")},
-			},
-			ctxCancel: true,
-			wantErr:   true,
+			name:         "context canceled - stops retry",
+			failCount:    -1,
+			ctxCancel:    true,
+			wantErr:      true,
+			wantMinCalls: 1,
 		},
 	}
 
@@ -91,17 +59,16 @@ func TestBatchSendWithRetry(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockProducer := mqmocks.NewMockIProducer(ctrl)
-			callIdx := 0
+			var callCount atomic.Int32
 			mockProducer.EXPECT().SendBatch(gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, msgs []*mq.Message) (mq.SendResponse, error) {
-					if callIdx >= len(tt.sendResults) {
-						t.Fatal("unexpected extra SendBatch call")
+					idx := int(callCount.Add(1))
+					if tt.failCount == -1 || idx <= tt.failCount {
+						return mq.SendResponse{}, errors.New("connection reset")
 					}
-					result := tt.sendResults[callIdx]
-					callIdx++
-					return result.resp, result.err
+					return mq.SendResponse{MessageID: "msg1", Offset: 1}, nil
 				},
-			).Times(len(tt.sendResults))
+			).AnyTimes()
 
 			pub := &exptEventPublisher{
 				producers: map[string]*producer{
@@ -128,7 +95,7 @@ func TestBatchSendWithRetry(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, len(tt.sendResults), callIdx)
+			assert.GreaterOrEqual(t, int(callCount.Load()), tt.wantMinCalls)
 		})
 	}
 }

--- a/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub_test.go
+++ b/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub_test.go
@@ -20,11 +20,11 @@ import (
 
 func TestBatchSendWithRetry(t *testing.T) {
 	tests := []struct {
-		name          string
-		failCount     int // SendBatch连续失败次数，之后返回成功; -1表示一直失败
-		ctxCancel     bool
-		wantErr       bool
-		wantMinCalls  int
+		name         string
+		failCount    int
+		ctxCancel    bool
+		wantErr      bool
+		wantMinCalls int
 	}{
 		{
 			name:         "success on first attempt",

--- a/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub_test.go
+++ b/backend/modules/evaluation/infra/mq/rocket/producer/expt_event_pub_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package producer
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/coze-dev/coze-loop/backend/infra/mq"
+	mqmocks "github.com/coze-dev/coze-loop/backend/infra/mq/mocks"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/mq/rocket"
+)
+
+func TestBatchSendWithRetry(t *testing.T) {
+	tests := []struct {
+		name         string
+		sendResults  []struct {
+			resp mq.SendResponse
+			err  error
+		}
+		ctxCancel bool
+		wantErr   bool
+	}{
+		{
+			name: "success on first attempt",
+			sendResults: []struct {
+				resp mq.SendResponse
+				err  error
+			}{
+				{resp: mq.SendResponse{MessageID: "msg1", Offset: 1}, err: nil},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success on second attempt after transient failure",
+			sendResults: []struct {
+				resp mq.SendResponse
+				err  error
+			}{
+				{resp: mq.SendResponse{}, err: errors.New("connection reset")},
+				{resp: mq.SendResponse{MessageID: "msg1", Offset: 1}, err: nil},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success on third attempt",
+			sendResults: []struct {
+				resp mq.SendResponse
+				err  error
+			}{
+				{resp: mq.SendResponse{}, err: errors.New("timeout")},
+				{resp: mq.SendResponse{}, err: errors.New("timeout")},
+				{resp: mq.SendResponse{MessageID: "msg1", Offset: 1}, err: nil},
+			},
+			wantErr: false,
+		},
+		{
+			name: "all 3 attempts fail",
+			sendResults: []struct {
+				resp mq.SendResponse
+				err  error
+			}{
+				{resp: mq.SendResponse{}, err: errors.New("timeout")},
+				{resp: mq.SendResponse{}, err: errors.New("timeout")},
+				{resp: mq.SendResponse{}, err: errors.New("timeout")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "context canceled - no retry",
+			sendResults: []struct {
+				resp mq.SendResponse
+				err  error
+			}{
+				{resp: mq.SendResponse{}, err: errors.New("context canceled")},
+			},
+			ctxCancel: true,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockProducer := mqmocks.NewMockIProducer(ctrl)
+			callIdx := 0
+			mockProducer.EXPECT().SendBatch(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, msgs []*mq.Message) (mq.SendResponse, error) {
+					if callIdx >= len(tt.sendResults) {
+						t.Fatal("unexpected extra SendBatch call")
+					}
+					result := tt.sendResults[callIdx]
+					callIdx++
+					return result.resp, result.err
+				},
+			).Times(len(tt.sendResults))
+
+			pub := &exptEventPublisher{
+				producers: map[string]*producer{
+					rocket.ExptScheduleEventRMQKey: {
+						cfg: rocket.RMQConf{Topic: "test_topic"},
+						p:   mockProducer,
+					},
+				},
+			}
+
+			ctx := context.Background()
+			if tt.ctxCancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			event := &entity.ExptScheduleEvent{ExptID: 1, ExptRunID: 2, SpaceID: 3}
+			err := pub.PublishExptScheduleEvent(ctx, event, nil)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "send batch message fail")
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, len(tt.sendResults), callIdx)
+		})
+	}
+}


### PR DESCRIPTION
(Optional) Translate the PR title into Chinese
[fix][backend] 修复 Redis 抖动导致实验调度失败后实验卡住无法执行的问题
 (Optional) More detailed description for this PR
en:

Problem: When Redis jitter occurs during experiment scheduling, the HandleEventErr middleware terminates the experiment as Failed for any error (including transient infra errors like context canceled from lock renewal failure or MQ send timeout). Since HandleEventErr returns nil, the MQ framework considers the message consumed successfully and won't redeliver, causing the experiment to be permanently stuck.

Root Cause:

1. HandleEventLock uses LockWithRenew (single SetNX, no retry) — any Redis hiccup immediately returns an error.
2. batchSendWithTagAndKeys has no retry — a single MQ send failure propagates up.
3. HandleEventErr treats all errors equally — infra errors and business errors both terminate the experiment.
Fix (3 layers of protection):

1. HandleEventLock : Switch from LockWithRenew to LockBackoffWithRenew (backoff retry up to TTL+1s), tolerating brief Redis instability.
2. batchSendWithTagAndKeys : Add 3 retries with exponential backoff (200ms→400ms→800ms), skipping retry if context is already canceled.
3. HandleEventErr : Distinguish infra errors from business errors via isSchedulerInfraError() . For infra errors:
   - Use context.WithoutCancel(ctx) to create a fresh context (preserving stored values but detaching cancel propagation).
   - Republish the schedule event with InfraErrorRetryTimes incremented (max 10 cross-MQ-consumption retries).
   - If republish also fails, return the error to let the MQ framework redeliver.
   - If retries exhausted (≥10), fall through to terminate the experiment.
New field:

- ExptScheduleEvent.InfraErrorRetryTimes — tracks cross-consumption infra error retry count, reset to 0 on successful NextTick .
zh(optional):

问题： Redis 抖动时，锁续期失败导致 context cancel，或 MQ 发送失败， HandleEventErr 直接将实验标记为 Failed 且返回 nil（MQ 不会重投递），实验永久卡住。

修复：

1. HandleEventLock 改用 LockBackoffWithRenew ，容忍短暂 Redis 抖动。
2. batchSend 增加 3 次退避重试。
3. HandleEventErr 区分基础设施错误和业务错误：对 infra error 使用 context.WithoutCancel(ctx) 重新投递调度消息，通过 InfraErrorRetryTimes 字段跨消费轮次累计最多重试 10 次。 (Optional) Which issue(s) this PR fixes
Fixes experiment permanently stuck in Running status when Redis jitter causes context canceled error during scheduler event processing.