### PR TITLE
[fix][evaluation] reject unsupported eval target type on SubmitExperimentOApi

### DIFF
--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -101,9 +101,9 @@ func OpenAPIRuntimeParamDTO2Domain(param *openapiCommon.RuntimeParam) *domainCom
 	return &domainCommon.RuntimeParam{JSONValue: param.JSONValue}
 }
 
-func OpenAPICreateEvalTargetParamDTO2Domain(param *openapi.SubmitExperimentEvalTargetParam) *domainEvalTarget.CreateEvalTargetParam {
+func OpenAPICreateEvalTargetParamDTO2Domain(param *openapi.SubmitExperimentEvalTargetParam) (*domainEvalTarget.CreateEvalTargetParam, error) {
 	if param == nil {
-		return nil
+		return nil, nil
 	}
 
 	result := &domainEvalTarget.CreateEvalTargetParam{
@@ -116,7 +116,7 @@ func OpenAPICreateEvalTargetParamDTO2Domain(param *openapi.SubmitExperimentEvalT
 	if param.EvalTargetType != nil {
 		evalType, err := mapOpenAPIEvalTargetType(*param.EvalTargetType)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		result.EvalTargetType = &evalType
 	}
@@ -124,14 +124,14 @@ func OpenAPICreateEvalTargetParamDTO2Domain(param *openapi.SubmitExperimentEvalT
 	if param.BotInfoType != nil {
 		botInfoType, err := mapOpenAPICozeBotInfoType(*param.BotInfoType)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		result.BotInfoType = &botInfoType
 	}
 	if param.Region != nil {
 		region, err := mapOpenAPIRegion(*param.Region)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		result.Region = &region
 	}
@@ -153,7 +153,7 @@ func OpenAPICreateEvalTargetParamDTO2Domain(param *openapi.SubmitExperimentEvalT
 		result.AgentConnection = openapiAgentConnectionDTO2Domain(param.AgentConnection)
 	}
 
-	return result
+	return result, nil
 }
 
 func openapiAgentConnectionDTO2Domain(dtoObj *openapiEvalTarget.AgentConnection) *domaindoEvalTarget.AgentConnection {
@@ -217,6 +217,38 @@ func parseStringToInt64(value string) (int64, error) {
 	return strconv.ParseInt(value, 10, 64)
 }
 
+// supportedOpenAPIEvalTargetTypes is the set of eval target types accepted by
+// the OpenAPI experiment-create path, in a stable order for error messages.
+var supportedOpenAPIEvalTargetTypes = []openapiEvalTarget.EvalTargetType{
+	openapiEvalTarget.EvalTargetTypeCozeBot,
+	openapiEvalTarget.EvalTargetTypeCozeLoopPrompt,
+	openapiEvalTarget.EvalTargetTypeTrace,
+	openapiEvalTarget.EvalTargetTypeCozeWorkflow,
+	openapiEvalTarget.EvalTargetTypeVolcengineAgent,
+	openapiEvalTarget.EvalTargetTypeCustomRPCServer,
+}
+
+func supportedOpenAPIEvalTargetTypesString() string {
+	parts := make([]string, 0, len(supportedOpenAPIEvalTargetTypes))
+	for _, t := range supportedOpenAPIEvalTargetTypes {
+		parts = append(parts, string(t))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// SupportedOpenAPIEvalTargetTypesString returns the comma-separated list of
+// eval target types accepted by the OpenAPI experiment-create path.
+func SupportedOpenAPIEvalTargetTypesString() string {
+	return supportedOpenAPIEvalTargetTypesString()
+}
+
+// IsSupportedOpenAPIEvalTargetType reports whether t is an eval target type
+// accepted by the OpenAPI experiment-create path.
+func IsSupportedOpenAPIEvalTargetType(t openapiEvalTarget.EvalTargetType) bool {
+	_, err := mapOpenAPIEvalTargetType(t)
+	return err == nil
+}
+
 func mapOpenAPIEvalTargetType(openapiType openapiEvalTarget.EvalTargetType) (domaindoEvalTarget.EvalTargetType, error) {
 	switch openapiType {
 	case openapiEvalTarget.EvalTargetTypeCozeBot:
@@ -232,7 +264,7 @@ func mapOpenAPIEvalTargetType(openapiType openapiEvalTarget.EvalTargetType) (dom
 	case openapiEvalTarget.EvalTargetTypeCustomRPCServer:
 		return domaindoEvalTarget.EvalTargetType_CustomRPCServer, nil
 	default:
-		return 0, fmt.Errorf("unsupported eval target type: %s", openapiType)
+		return 0, fmt.Errorf("unsupported eval target type: %s. supported: [%s]", openapiType, supportedOpenAPIEvalTargetTypesString())
 	}
 }
 

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -229,11 +229,8 @@ var supportedOpenAPIEvalTargetTypes = []openapiEvalTarget.EvalTargetType{
 }
 
 func supportedOpenAPIEvalTargetTypesString() string {
-	parts := make([]string, 0, len(supportedOpenAPIEvalTargetTypes))
-	for _, t := range supportedOpenAPIEvalTargetTypes {
-		parts = append(parts, t)
-	}
-	return strings.Join(parts, ", ")
+	// EvalTargetType is a string alias, so the slice is directly joinable.
+	return strings.Join(supportedOpenAPIEvalTargetTypes, ", ")
 }
 
 // SupportedOpenAPIEvalTargetTypesString returns the comma-separated list of

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -231,7 +231,7 @@ var supportedOpenAPIEvalTargetTypes = []openapiEvalTarget.EvalTargetType{
 func supportedOpenAPIEvalTargetTypesString() string {
 	parts := make([]string, 0, len(supportedOpenAPIEvalTargetTypes))
 	for _, t := range supportedOpenAPIEvalTargetTypes {
-		parts = append(parts, string(t))
+		parts = append(parts, t)
 	}
 	return strings.Join(parts, ", ")
 }

--- a/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
@@ -133,7 +133,8 @@ func TestOpenAPICreateEvalTargetParamDTO2Domain(t *testing.T) {
 		},
 	}
 
-	converted := OpenAPICreateEvalTargetParamDTO2Domain(param)
+	converted, err := OpenAPICreateEvalTargetParamDTO2Domain(param)
+	assert.NoError(t, err)
 	if assert.NotNil(t, converted) {
 		assert.Equal(t, "123", gptr.Indirect(converted.SourceTargetID))
 		assert.Equal(t, "456", gptr.Indirect(converted.BotPublishVersion))
@@ -151,10 +152,20 @@ func TestOpenAPICreateEvalTargetParamDTO2Domain(t *testing.T) {
 		}
 	}
 
-	invalidType := openapiEvalTarget.EvalTargetType("invalid")
-	assert.Nil(t, OpenAPICreateEvalTargetParamDTO2Domain(&openapi.SubmitExperimentEvalTargetParam{EvalTargetType: &invalidType}))
+	// An unsupported eval target type (e.g. faas_http is an AccessProtocol, not
+	// an EvalTargetType) must now return an error listing the supported types,
+	// not be silently dropped to nil (Meego 7328626066).
+	invalidType := openapiEvalTarget.EvalTargetType("faas_http")
+	gotInvalid, errInvalid := OpenAPICreateEvalTargetParamDTO2Domain(&openapi.SubmitExperimentEvalTargetParam{EvalTargetType: &invalidType})
+	assert.Nil(t, gotInvalid)
+	if assert.Error(t, errInvalid) {
+		assert.Contains(t, errInvalid.Error(), "unsupported eval target type")
+		assert.Contains(t, errInvalid.Error(), "custom_rpc_server")
+	}
 	invalidRegion := openapiEvalTarget.Region("invalid")
-	assert.Nil(t, OpenAPICreateEvalTargetParamDTO2Domain(&openapi.SubmitExperimentEvalTargetParam{Region: &invalidRegion}))
+	gotRegion, errRegion := OpenAPICreateEvalTargetParamDTO2Domain(&openapi.SubmitExperimentEvalTargetParam{Region: &invalidRegion})
+	assert.Nil(t, gotRegion)
+	assert.Error(t, errRegion)
 }
 
 func TestParseOpenAPIEvaluatorVersions(t *testing.T) {
@@ -1593,11 +1604,14 @@ func TestOpenAPICreateEvalTargetParamDTO2DomainV2(t *testing.T) {
 	paramDraft := &openapi.SubmitExperimentEvalTargetParam{
 		BotInfoType: &botDraft,
 	}
-	gotDraft := OpenAPICreateEvalTargetParamDTO2Domain(paramDraft)
+	gotDraft, errDraft := OpenAPICreateEvalTargetParamDTO2Domain(paramDraft)
+	assert.NoError(t, errDraft)
 	assert.Equal(t, domaindoEvalTarget.CozeBotInfoType_DraftBot, *gotDraft.BotInfoType)
 
 	invalidBot := openapiEvalTarget.CozeBotInfoType("invalid")
-	assert.Nil(t, OpenAPICreateEvalTargetParamDTO2Domain(&openapi.SubmitExperimentEvalTargetParam{BotInfoType: &invalidBot}))
+	gotInvalidBot, errInvalidBot := OpenAPICreateEvalTargetParamDTO2Domain(&openapi.SubmitExperimentEvalTargetParam{BotInfoType: &invalidBot})
+	assert.Nil(t, gotInvalidBot)
+	assert.Error(t, errInvalidBot)
 }
 
 func TestDomainRuntimeParamDTO2OpenAPI(t *testing.T) {
@@ -2923,7 +2937,8 @@ func TestOpenAPICreateEvalTargetParamDTO2Domain_WithClusterAndAgentConnection(t 
 		},
 	}
 
-	converted := OpenAPICreateEvalTargetParamDTO2Domain(param)
+	converted, err := OpenAPICreateEvalTargetParamDTO2Domain(param)
+	assert.NoError(t, err)
 	if assert.NotNil(t, converted) {
 		assert.Equal(t, "agent-1", gptr.Indirect(converted.SourceTargetID))
 		assert.Equal(t, gptr.Of("cluster-abc"), converted.Cluster)
@@ -2952,7 +2967,8 @@ func TestOpenAPICreateEvalTargetParamDTO2Domain_WithClusterAndAgentConnection(t 
 	paramNoConn := &openapi.SubmitExperimentEvalTargetParam{
 		SourceTargetID: gptr.Of("agent-2"),
 	}
-	converted2 := OpenAPICreateEvalTargetParamDTO2Domain(paramNoConn)
+	converted2, err2 := OpenAPICreateEvalTargetParamDTO2Domain(paramNoConn)
+	assert.NoError(t, err2)
 	if assert.NotNil(t, converted2) {
 		assert.Nil(t, converted2.Cluster)
 		assert.Nil(t, converted2.AgentConnection)

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -1048,6 +1048,24 @@ func (e *EvalOpenAPIApplication) SubmitExperimentOApi(ctx context.Context, req *
 		return nil, err
 	}
 
+	// Validate eval target type before building the request: an unsupported
+	// target type (e.g. faas_http, which is an AccessProtocol — not an
+	// EvalTargetType) must be rejected here instead of being silently dropped.
+	// The convertor below also returns this error; validating up front yields a
+	// clear param error and lists the supported types for the caller.
+	if req.EvalTargetParam != nil && req.EvalTargetParam.EvalTargetType != nil {
+		if !experiment_convertor.IsSupportedOpenAPIEvalTargetType(*req.EvalTargetParam.EvalTargetType) {
+			return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(
+				fmt.Sprintf("unsupported eval target type: %s. supported: [%s]",
+					*req.EvalTargetParam.EvalTargetType, experiment_convertor.SupportedOpenAPIEvalTargetTypesString())))
+		}
+	}
+
+	createEvalTargetParam, err := experiment_convertor.OpenAPICreateEvalTargetParamDTO2Domain(req.EvalTargetParam)
+	if err != nil {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(err.Error()))
+	}
+
 	createReq := &exptpb.SubmitExperimentRequest{
 		WorkspaceID:             req.GetWorkspaceID(),
 		EvalSetVersionID:        gptr.Of(versions[0].ID),
@@ -1059,7 +1077,7 @@ func (e *EvalOpenAPIApplication) SubmitExperimentOApi(ctx context.Context, req *
 		EvaluatorFieldMapping:   experiment_convertor.OpenAPIEvaluatorFieldMappingDTO2Domain(req.EvaluatorFieldMapping, evaluatorMap),
 		ItemConcurNum:           req.ItemConcurNum,
 		TargetRuntimeParam:      experiment_convertor.OpenAPIRuntimeParamDTO2Domain(req.TargetRuntimeParam),
-		CreateEvalTargetParam:   experiment_convertor.OpenAPICreateEvalTargetParamDTO2Domain(req.EvalTargetParam),
+		CreateEvalTargetParam:   createEvalTargetParam,
 		EvaluatorIDVersionList:  experiment_convertor.OpenAPIEvaluatorParamsDTO2Domain(req.EvaluatorParams),
 		ItemRetryNum:            req.ItemRetryNum,
 		TriggerType:             gptr.Of(domain_expt.OpenAPI),

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -1055,9 +1055,9 @@ func (e *EvalOpenAPIApplication) SubmitExperimentOApi(ctx context.Context, req *
 	// clear param error and lists the supported types for the caller.
 	if req.EvalTargetParam != nil && req.EvalTargetParam.EvalTargetType != nil {
 		if !experiment_convertor.IsSupportedOpenAPIEvalTargetType(*req.EvalTargetParam.EvalTargetType) {
-			return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(
-				fmt.Sprintf("unsupported eval target type: %s. supported: [%s]",
-					*req.EvalTargetParam.EvalTargetType, experiment_convertor.SupportedOpenAPIEvalTargetTypesString())))
+			msg := fmt.Sprintf("unsupported eval target type: %s. supported: [%s]",
+				*req.EvalTargetParam.EvalTargetType, experiment_convertor.SupportedOpenAPIEvalTargetTypesString())
+			return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(msg))
 		}
 	}
 

--- a/backend/modules/evaluation/application/eval_openapi_app_test.go
+++ b/backend/modules/evaluation/application/eval_openapi_app_test.go
@@ -20,6 +20,7 @@ import (
 	domainexpt "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain/expt"
 	"github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain_openapi/common"
 	"github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain_openapi/eval_set"
+	openapiEvalTarget "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain_openapi/eval_target"
 	openapiEvaluator "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain_openapi/evaluator"
 	openapiExperiment "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain_openapi/experiment"
 	exptpb "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/expt"
@@ -1852,6 +1853,33 @@ func TestEvalOpenAPIApplication_SubmitExperimentOApi(t *testing.T) {
 				evaluatorSvc.EXPECT().ListEvaluatorVersion(gomock.Any(), gomock.AssignableToTypeOf(&entity.ListEvaluatorVersionRequest{})).Return(nil, int64(0), nil)
 			},
 			wantErr: errno.ResourceNotFoundCode,
+		},
+		{
+			name: "unsupported eval target type",
+			buildReq: func() *openapi.SubmitExperimentOApiRequest {
+				req := buildBaseReq()
+				// faas_http is an AccessProtocol, not an EvalTargetType.
+				req.EvalTargetParam = &openapi.SubmitExperimentEvalTargetParam{
+					SourceTargetID: gptr.Of("1"),
+					EvalTargetType: gptr.Of(openapiEvalTarget.EvalTargetType("faas_http")),
+				}
+				return req
+			},
+			setup: func(req *openapi.SubmitExperimentOApiRequest, auth *rpcmocks.MockIAuthProvider, manager *servicemocks.MockIExptManager, versionSvc *servicemocks.MockEvaluationSetVersionService, evaluatorSvc *servicemocks.MockEvaluatorService, _ *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.AssignableToTypeOf(&rpc.AuthorizationParam{})).Return(nil)
+				manager.EXPECT().CheckName(gomock.Any(), req.GetName(), req.GetWorkspaceID(), gomock.AssignableToTypeOf(&entity.Session{})).Return(true, nil)
+				versionSvc.EXPECT().ListEvaluationSetVersions(gomock.Any(), gomock.AssignableToTypeOf(&entity.ListEvaluationSetVersionsParam{})).Return([]*entity.EvaluationSetVersion{{ID: evaluatorVersionID}}, nil, nil, nil)
+				evaluator := &entity.Evaluator{
+					EvaluatorType: entity.EvaluatorTypePrompt,
+					PromptEvaluatorVersion: &entity.PromptEvaluatorVersion{
+						ID:          evaluatorVersionID,
+						EvaluatorID: evaluatorID,
+						Version:     "1.0",
+					},
+				}
+				evaluatorSvc.EXPECT().ListEvaluatorVersion(gomock.Any(), gomock.AssignableToTypeOf(&entity.ListEvaluatorVersionRequest{})).Return([]*entity.Evaluator{evaluator}, int64(1), nil)
+			},
+			wantErr: errno.CommonInvalidParamCode,
 		},
 		{
 			name:     "success",


### PR DESCRIPTION
## What

  The OpenAPI experiment-create path (`SubmitExperimentOApi`) silently accepted an unsupported `eval_target_type`.
  `OpenAPICreateEvalTargetParamDTO2Domain` discarded the "unsupported eval target type" error from `mapOpenAPIEvalTargetType` and
  returned a nil param, so no error propagated and the experiment was created without the intended target (e.g. a caller passing
  `faas_http`, which is an AccessProtocol — not an EvalTargetType).

  Meego: 7328626066

  ## Changes

  - `OpenAPICreateEvalTargetParamDTO2Domain` now returns `(param, error)` and propagates convertor errors instead of swallowing
  them to nil.
  - `SubmitExperimentOApi` validates `EvalTargetType` up front and returns a `CommonInvalidParamCode` error listing the supported
  types, so the caller can self-correct.
  - `mapOpenAPIEvalTargetType`'s error now lists supported types; added exported `IsSupportedOpenAPIEvalTargetType` /
  `SupportedOpenAPIEvalTargetTypesString`.
  - Updated affected unit tests; added a `SubmitExperimentOApi` case for an unsupported target type.

  ## Test

  - `go test ./modules/evaluation/application/...` passes.
  - Verified end-to-end on PPE lane `ppe_7328626066`:
    - `faas_http` → `601200202 unsupported eval target type: faas_http. supported: [coze_bot, coze_loop_prompt, trace,
  coze_workflow, volcengine_agent, custom_rpc_server]`
    - `coze_loop_prompt` → passes target-type validation (proceeds past it).