### PR TITLE
[feat][evaluation] support a2a_agent and custom_agent eval target types on the OpenAPI experiment-create path

### DIFF
--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -226,6 +226,8 @@ var supportedOpenAPIEvalTargetTypes = []openapiEvalTarget.EvalTargetType{
 	openapiEvalTarget.EvalTargetTypeCozeWorkflow,
 	openapiEvalTarget.EvalTargetTypeVolcengineAgent,
 	openapiEvalTarget.EvalTargetTypeCustomRPCServer,
+	openapiEvalTarget.EvalTargetTypeA2Agent,
+	openapiEvalTarget.EvalTargetTypeCustomAgent,
 }
 
 func supportedOpenAPIEvalTargetTypesString() string {
@@ -260,6 +262,10 @@ func mapOpenAPIEvalTargetType(openapiType openapiEvalTarget.EvalTargetType) (dom
 		return domaindoEvalTarget.EvalTargetType_VolcengineAgent, nil
 	case openapiEvalTarget.EvalTargetTypeCustomRPCServer:
 		return domaindoEvalTarget.EvalTargetType_CustomRPCServer, nil
+	case openapiEvalTarget.EvalTargetTypeA2Agent:
+		return domaindoEvalTarget.EvalTargetType_A2AAgent, nil
+	case openapiEvalTarget.EvalTargetTypeCustomAgent:
+		return domaindoEvalTarget.EvalTargetType_CustomAgent, nil
 	default:
 		return 0, fmt.Errorf("unsupported eval target type: %s. supported: [%s]", openapiType, supportedOpenAPIEvalTargetTypesString())
 	}

--- a/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
@@ -278,6 +278,8 @@ func TestMapOpenAPIEvalTargetType(t *testing.T) {
 		{"workflow", openapiEvalTarget.EvalTargetTypeCozeWorkflow, domaindoEvalTarget.EvalTargetType_CozeWorkflow, false},
 		{"volcengine", openapiEvalTarget.EvalTargetTypeVolcengineAgent, domaindoEvalTarget.EvalTargetType_VolcengineAgent, false},
 		{"rpc", openapiEvalTarget.EvalTargetTypeCustomRPCServer, domaindoEvalTarget.EvalTargetType_CustomRPCServer, false},
+		{"a2a_agent", openapiEvalTarget.EvalTargetTypeA2Agent, domaindoEvalTarget.EvalTargetType_A2AAgent, false},
+		{"custom_agent", openapiEvalTarget.EvalTargetTypeCustomAgent, domaindoEvalTarget.EvalTargetType_CustomAgent, false},
 		{"invalid", openapiEvalTarget.EvalTargetType("invalid"), 0, true},
 	}
 
@@ -2973,6 +2975,55 @@ func TestOpenAPICreateEvalTargetParamDTO2Domain_WithClusterAndAgentConnection(t 
 		assert.Nil(t, converted2.Cluster)
 		assert.Nil(t, converted2.AgentConnection)
 	}
+}
+
+// TestOpenAPICreateEvalTargetParamDTO2Domain_AgentTypes verifies the OpenAPI
+// experiment-create path accepts the two agent eval target types that the web
+// link already supports: a2a_agent (type=9) and custom_agent (type=10, the
+// in-house long-connection agent). The convertor must translate the string
+// type to the int domain enum and carry the agent connection info.
+func TestOpenAPICreateEvalTargetParamDTO2Domain_AgentTypes(t *testing.T) {
+	t.Parallel()
+
+	// custom_agent (长链接 Agent): submitted with cluster + agent_connection.
+	customAgentType := openapiEvalTarget.EvalTargetTypeCustomAgent
+	customAgentParam := &openapi.SubmitExperimentEvalTargetParam{
+		SourceTargetID: gptr.Of("custom-agent-1"),
+		EvalTargetType: &customAgentType,
+		Cluster:        gptr.Of("cluster-loong"),
+		AgentConnection: &openapiEvalTarget.AgentConnection{
+			Psm: gptr.Of("agent.psm"),
+			FrontierInfo: &openapiEvalTarget.FrontierInfo{
+				AppID: gptr.Of(int64(100)),
+			},
+		},
+	}
+	convertedCustom, errCustom := OpenAPICreateEvalTargetParamDTO2Domain(customAgentParam)
+	assert.NoError(t, errCustom)
+	if assert.NotNil(t, convertedCustom) {
+		assert.Equal(t, domaindoEvalTarget.EvalTargetType_CustomAgent, gptr.Indirect(convertedCustom.EvalTargetType))
+		assert.Equal(t, gptr.Of("cluster-loong"), convertedCustom.Cluster)
+		if assert.NotNil(t, convertedCustom.AgentConnection) {
+			assert.Equal(t, gptr.Of("agent.psm"), convertedCustom.AgentConnection.Psm)
+		}
+	}
+
+	// a2a_agent: referenced by source_target_id (pre-registered Application).
+	a2aType := openapiEvalTarget.EvalTargetTypeA2Agent
+	a2aParam := &openapi.SubmitExperimentEvalTargetParam{
+		SourceTargetID: gptr.Of("a2a-agent-1"),
+		EvalTargetType: &a2aType,
+	}
+	convertedA2A, errA2A := OpenAPICreateEvalTargetParamDTO2Domain(a2aParam)
+	assert.NoError(t, errA2A)
+	if assert.NotNil(t, convertedA2A) {
+		assert.Equal(t, domaindoEvalTarget.EvalTargetType_A2AAgent, gptr.Indirect(convertedA2A.EvalTargetType))
+		assert.Equal(t, "a2a-agent-1", gptr.Indirect(convertedA2A.SourceTargetID))
+	}
+
+	// Both agent types must pass the up-front validation gate.
+	assert.True(t, IsSupportedOpenAPIEvalTargetType(openapiEvalTarget.EvalTargetTypeA2Agent))
+	assert.True(t, IsSupportedOpenAPIEvalTargetType(openapiEvalTarget.EvalTargetTypeCustomAgent))
 }
 
 func TestOpenapiAgentConnectionDTO2Domain_Nil(t *testing.T) {


### PR DESCRIPTION
 #### What type of PR is this? 
feat

  #### Check the PR title

  - [x] This PR title match the format: [<type>][<scope>] <description>.
  - [x] The description of this PR title is user-oriented and clear enough for others to understand.
  - [x] Add documentation if the current PR requires user awareness at the usage level.
  - [x] This PR is written in English. PRs not in English will not be reviewed.

  #### (Optional) Translate the PR title into Chinese

  [feat][evaluation] OpenAPI 创建实验链路支持 a2a_agent 与 custom_agent 评测对象类型

  #### (Optional) More detailed description for this PR

  en:
  The web link already supports two eval target types — A2A Agent (`a2a_agent`, type=9) and the in-house
  long-connection agent (`custom_agent`, type=10) — and their execution operators are registered downstream. The
  OpenAPI experiment-create path, however, rejected them: `mapOpenAPIEvalTargetType` only handled 6 types, so
  `a2a_agent` / `custom_agent` fell through to `default` and were blocked both by the up-front
  `SubmitExperimentOApi` validation and by the convertor.

  This PR wires the OpenAPI path to the same service layer the web link uses:
  - `mapOpenAPIEvalTargetType`: add cases `a2a_agent -> A2AAgent`, `custom_agent -> CustomAgent`.
  - `supportedOpenAPIEvalTargetTypes`: add both so the up-front validation and the error message (the
  supported-types list) stay in sync.
  - Unit tests for the two new mappings, plus an end-to-end convertor test covering `custom_agent` (cluster +
  agent_connection passthrough) and `a2a_agent` (source_target_id reference).

  No IDL change (the OpenAPI string enums and `EvalTargetContent` sub-fields already exist) and no operator
  change (already registered downstream). `faas_http` (an AccessProtocol, not an EvalTargetType) is still
  correctly rejected.

  Verified on a PPE swimlane: `a2a_agent` / `custom_agent` experiments are created successfully (with field
  mappings), and `faas_http` is rejected with the supported-types list now containing all 8 types.

  zh(optional):
  网页端已支持 A2A Agent（`a2a_agent`，type=9）和内场长链接
  Agent（`custom_agent`，type=10），执行算子也已在下游注册，但 OpenAPI
  创建实验链路一直拒绝这两类——`mapOpenAPIEvalTargetType` 只处理 6 类，a2a/custom 落入 default 被拦。本 PR
  在转换层补两个 case + 同步白名单，让 OpenAPI 链路接到与网页端相同的服务层。不改 IDL、不改算子；faas_http
  仍正确被拒。已在 PPE 泳道验证：a2a/custom 实验创建成功，faas_http 报错且枚举列表已含 8 类。
