### PR TITLE
[fix][backend] populate FieldData key from dataset schema in data reflow

### DIFF
--- a/backend/modules/observability/domain/task/service/taskexe/processor/auto_evaluate.go
+++ b/backend/modules/observability/domain/task/service/taskexe/processor/auto_evaluate.go
@@ -127,6 +127,9 @@ func (p *AutoEvaluateProcessor) Invoke(ctx context.Context, trigger *taskexe.Tri
 
 	mapping := p.buildFieldMappings(trigger.Task)
 
+	schemaJSON := taskRun.GetTaskRunConfig().GetAutoEvaluateRunConfig().GetSchema()
+	fillDatasetKeysFromSchema(ctx, mapping, schemaJSON)
+
 	turns := buildItems(ctx, []*loop_span.Span{trigger.Span}, mapping, strconv.FormatInt(taskRun.ID, 10))
 	if len(turns) == 0 {
 		logs.CtxInfo(ctx, "[task-debug] AutoEvaluateProcessor Invoke, turns is empty")
@@ -210,6 +213,9 @@ func (p *AutoEvaluateProcessor) BatchInvoke(ctx context.Context, trigger *taskex
 
 	// 构建 field mapping
 	mapping := p.buildFieldMappings(trigger.Task)
+
+	schemaJSON := taskRun.GetTaskRunConfig().GetAutoEvaluateRunConfig().GetSchema()
+	fillDatasetKeysFromSchema(ctx, mapping, schemaJSON)
 
 	// 为每条 span 构建评测项
 	taskRunIDStr := strconv.FormatInt(taskRun.ID, 10)

--- a/backend/modules/observability/domain/task/service/taskexe/processor/auto_evaluate_test.go
+++ b/backend/modules/observability/domain/task/service/taskexe/processor/auto_evaluate_test.go
@@ -1784,3 +1784,102 @@ func TestAutoEvaluateProcessor_BatchInvoke(t *testing.T) {
 		assert.Nil(t, evalMock.lastInvoke)
 	})
 }
+
+func TestAutoEvaluateProcessor_Invoke_KeyFromSchema(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	taskObj := buildTestTask(t)
+	taskObj.Sampler.SampleSize = 100
+
+	schemaJSON := `[{"Key":"schema_key_1","Name":"field_1","ContentType":"text","TextSchema":"{}"}]`
+
+	trigger := &taskexe.Trigger{
+		Task: taskObj,
+		Span: buildSpan("hello world"),
+		TaskRun: &taskentity.TaskRun{
+			ID:            3001,
+			TaskID:        taskObj.ID,
+			WorkspaceID:   taskObj.WorkspaceID,
+			TaskType:      taskentity.TaskRunTypeNewData,
+			RunStatus:     taskentity.TaskRunStatusRunning,
+			TaskRunConfig: buildTaskRunConfig(schemaJSON),
+		},
+	}
+
+	repoMock := repomocks.NewMockITaskRepo(ctrl)
+	repoAdapter := &taskRepoMockAdapter{MockITaskRepo: repoMock}
+	repoMock.EXPECT().IncrTaskCount(gomock.Any(), taskObj.ID, gomock.Any()).Return(nil)
+	repoMock.EXPECT().IncrTaskRunCount(gomock.Any(), taskObj.ID, trigger.TaskRun.ID, gomock.Any()).Return(nil)
+	repoMock.EXPECT().GetTaskCount(gomock.Any(), taskObj.ID).Return(int64(1), nil)
+	repoMock.EXPECT().GetTaskRunCount(gomock.Any(), taskObj.ID, trigger.TaskRun.ID).Return(int64(1), nil)
+
+	evalMock := &fakeEvaluationAdapter{}
+	evalMock.invokeResp.addedItems = 1
+
+	proc := &AutoEvaluateProcessor{evaluationSvc: evalMock, taskRepo: repoAdapter}
+	err := proc.Invoke(context.Background(), trigger)
+	assert.NoError(t, err)
+
+	require.NotNil(t, evalMock.lastInvoke)
+	require.NotEmpty(t, evalMock.lastInvoke.Items)
+	item := evalMock.lastInvoke.Items[0]
+	require.NotEmpty(t, item.Turns)
+	turn := item.Turns[0]
+	// FieldDataList: [trace_id, span_id, run_id, field_1]
+	require.Len(t, turn.FieldDataList, 4)
+	assert.Equal(t, "schema_key_1", turn.FieldDataList[3].GetKey())
+	assert.Equal(t, "field_1", turn.FieldDataList[3].GetName())
+}
+
+func TestAutoEvaluateProcessor_BatchInvoke_KeyFromSchema(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	taskObj := buildTestTask(t)
+	taskObj.Sampler.SampleSize = 100
+
+	schemaJSON := `[{"Key":"batch_key","Name":"field_1","ContentType":"text","TextSchema":"{}"}]`
+
+	spans := []*loop_span.Span{
+		{TraceID: "trace1", SpanID: "span1", Input: "data1", StartTime: time.Now().UnixMilli()},
+	}
+
+	trigger := &taskexe.BatchTrigger{
+		Task:  taskObj,
+		Spans: spans,
+		TaskRun: &taskentity.TaskRun{
+			ID:            3002,
+			TaskID:        taskObj.ID,
+			WorkspaceID:   taskObj.WorkspaceID,
+			TaskType:      taskentity.TaskRunTypeNewData,
+			RunStatus:     taskentity.TaskRunStatusRunning,
+			TaskRunConfig: buildTaskRunConfig(schemaJSON),
+		},
+	}
+
+	repoMock := repomocks.NewMockITaskRepo(ctrl)
+	repoAdapter := &taskRepoMockAdapter{MockITaskRepo: repoMock}
+	repoMock.EXPECT().IncrTaskCount(gomock.Any(), taskObj.ID, gomock.Any()).Return(nil).AnyTimes()
+	repoMock.EXPECT().IncrTaskRunCount(gomock.Any(), taskObj.ID, trigger.TaskRun.ID, gomock.Any()).Return(nil).AnyTimes()
+	repoMock.EXPECT().GetTaskCount(gomock.Any(), taskObj.ID).Return(int64(1), nil)
+	repoMock.EXPECT().GetTaskRunCount(gomock.Any(), taskObj.ID, trigger.TaskRun.ID).Return(int64(1), nil)
+
+	evalMock := &fakeEvaluationAdapter{}
+	evalMock.invokeResp.addedItems = 1
+
+	proc := &AutoEvaluateProcessor{evaluationSvc: evalMock, taskRepo: repoAdapter}
+	err := proc.BatchInvoke(context.Background(), trigger)
+	assert.NoError(t, err)
+
+	require.NotNil(t, evalMock.lastInvoke)
+	require.Len(t, evalMock.lastInvoke.Items, 1)
+	item := evalMock.lastInvoke.Items[0]
+	require.NotEmpty(t, item.Turns)
+	turn := item.Turns[0]
+	require.Len(t, turn.FieldDataList, 4)
+	assert.Equal(t, "batch_key", turn.FieldDataList[3].GetKey())
+	assert.Equal(t, "field_1", turn.FieldDataList[3].GetName())
+}

--- a/backend/modules/observability/domain/task/service/taskexe/processor/utils.go
+++ b/backend/modules/observability/domain/task/service/taskexe/processor/utils.go
@@ -194,9 +194,34 @@ func buildItem(ctx context.Context, span *loop_span.Span, fieldMappings []*task_
 			return nil
 		}
 		fieldDatas = append(fieldDatas, &eval_set.FieldData{
+			Key:     mapping.DatasetKey,
 			Name:    mapping.EvalSetName,
 			Content: evaluationset.ConvertContentDO2DTO(content),
 		})
 	}
 	return fieldDatas
+}
+
+func fillDatasetKeysFromSchema(ctx context.Context, mappings []*task_entity.EvaluateFieldMapping, schemaJSON string) {
+	if schemaJSON == "" {
+		return
+	}
+	var fieldSchemas []entity.FieldSchema
+	if err := sonic.UnmarshalString(schemaJSON, &fieldSchemas); err != nil {
+		logs.CtxWarn(ctx, "[auto_task] unmarshal schema failed, err:%v", err)
+		return
+	}
+	nameToKey := make(map[string]string, len(fieldSchemas))
+	for _, fs := range fieldSchemas {
+		if fs.Key != nil && *fs.Key != "" {
+			nameToKey[fs.Name] = *fs.Key
+		}
+	}
+	for _, m := range mappings {
+		if m.EvalSetName != nil {
+			if key, ok := nameToKey[*m.EvalSetName]; ok {
+				m.DatasetKey = &key
+			}
+		}
+	}
 }

--- a/backend/modules/observability/domain/task/service/taskexe/processor/utils_test.go
+++ b/backend/modules/observability/domain/task/service/taskexe/processor/utils_test.go
@@ -201,6 +201,76 @@ func TestConvertContentTypeDTO2DO(t *testing.T) {
 	}
 }
 
+func TestFillDatasetKeysFromSchema(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("empty schema JSON is no-op", func(t *testing.T) {
+		t.Parallel()
+		mappings := []*taskentity.EvaluateFieldMapping{
+			{EvalSetName: gptr.Of("field_a")},
+		}
+		fillDatasetKeysFromSchema(ctx, mappings, "")
+		assert.Nil(t, mappings[0].DatasetKey)
+	})
+
+	t.Run("invalid JSON is no-op", func(t *testing.T) {
+		t.Parallel()
+		mappings := []*taskentity.EvaluateFieldMapping{
+			{EvalSetName: gptr.Of("field_a")},
+		}
+		fillDatasetKeysFromSchema(ctx, mappings, "not valid json")
+		assert.Nil(t, mappings[0].DatasetKey)
+	})
+
+	t.Run("populates key from schema by name match", func(t *testing.T) {
+		t.Parallel()
+		schemaJSON := `[{"Key":"key_input","Name":"输入","ContentType":"text"},{"Key":"key_output","Name":"输出","ContentType":"text"}]`
+		mappings := []*taskentity.EvaluateFieldMapping{
+			{EvalSetName: gptr.Of("输入")},
+			{EvalSetName: gptr.Of("输出")},
+			{EvalSetName: gptr.Of("不存在的字段")},
+		}
+		fillDatasetKeysFromSchema(ctx, mappings, schemaJSON)
+		assert.Equal(t, "key_input", *mappings[0].DatasetKey)
+		assert.Equal(t, "key_output", *mappings[1].DatasetKey)
+		assert.Nil(t, mappings[2].DatasetKey)
+	})
+
+	t.Run("overwrites existing DatasetKey", func(t *testing.T) {
+		t.Parallel()
+		schemaJSON := `[{"Key":"real_key","Name":"field_a","ContentType":"text"}]`
+		oldKey := "stale_key"
+		mappings := []*taskentity.EvaluateFieldMapping{
+			{EvalSetName: gptr.Of("field_a"), DatasetKey: &oldKey},
+		}
+		fillDatasetKeysFromSchema(ctx, mappings, schemaJSON)
+		assert.Equal(t, "real_key", *mappings[0].DatasetKey)
+	})
+
+	t.Run("skips schema entries with nil or empty key", func(t *testing.T) {
+		t.Parallel()
+		schemaJSON := `[{"Key":"","Name":"field_a","ContentType":"text"},{"Name":"field_b","ContentType":"text"}]`
+		mappings := []*taskentity.EvaluateFieldMapping{
+			{EvalSetName: gptr.Of("field_a")},
+			{EvalSetName: gptr.Of("field_b")},
+		}
+		fillDatasetKeysFromSchema(ctx, mappings, schemaJSON)
+		assert.Nil(t, mappings[0].DatasetKey)
+		assert.Nil(t, mappings[1].DatasetKey)
+	})
+
+	t.Run("nil EvalSetName mapping is skipped", func(t *testing.T) {
+		t.Parallel()
+		schemaJSON := `[{"Key":"key_a","Name":"field_a","ContentType":"text"}]`
+		mappings := []*taskentity.EvaluateFieldMapping{
+			{EvalSetName: nil},
+		}
+		fillDatasetKeysFromSchema(ctx, mappings, schemaJSON)
+		assert.Nil(t, mappings[0].DatasetKey)
+	})
+}
+
 func TestBuildItem(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -214,6 +284,7 @@ func TestBuildItem(t *testing.T) {
 		TraceFieldKey:      "Input",
 		TraceFieldJsonpath: "",
 		EvalSetName:        gptr.Of("field_1"),
+		DatasetKey:         gptr.Of("my_key"),
 	}
 
 	span := &loop_span.Span{TraceID: "1234567890abcdef1234567890abcdef", SpanID: "feedbeeffeedbeef", Input: "hello"}
@@ -222,6 +293,7 @@ func TestBuildItem(t *testing.T) {
 	assert.Equal(t, "trace_id", data[0].GetKey())
 	assert.Equal(t, "span_id", data[1].GetKey())
 	assert.Equal(t, "run_id", data[2].GetKey())
+	assert.Equal(t, "my_key", data[3].GetKey())
 	assert.Equal(t, "field_1", data[3].GetName())
 	assert.Equal(t, "hello", data[3].GetContent().GetText())
 

--- a/backend/modules/observability/domain/trace/service/trace_export_service.go
+++ b/backend/modules/observability/domain/trace/service/trace_export_service.go
@@ -584,7 +584,8 @@ func (r *TraceExportServiceImpl) buildItem(ctx context.Context, span *loop_span.
 			continue
 		}
 
-		item.AddFieldData("", mapping.FieldSchema.Name, content)
+		key := dataset.GetFieldSchemaKeyByName(mapping.FieldSchema.Name)
+		item.AddFieldData(key, mapping.FieldSchema.Name, content)
 	}
 	return item
 }

--- a/backend/modules/observability/domain/trace/service/trace_export_service_test.go
+++ b/backend/modules/observability/domain/trace/service/trace_export_service_test.go
@@ -604,8 +604,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 					WorkspaceID: 123,
 					DatasetID:   0,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}
 
@@ -661,8 +661,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 					WorkspaceID: 123,
 					DatasetID:   0,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}},
 				Errors: []entity.ItemErrorGroup{},
@@ -699,8 +699,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 					WorkspaceID: 123,
 					DatasetID:   100,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}
 
@@ -758,8 +758,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 					WorkspaceID: 123,
 					DatasetID:   100,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}},
 				Errors: []entity.ItemErrorGroup{},
@@ -796,8 +796,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 					WorkspaceID: 123,
 					DatasetID:   100,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}
 
@@ -855,8 +855,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 					WorkspaceID: 123,
 					DatasetID:   100,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}},
 				Errors: []entity.ItemErrorGroup{},
@@ -2148,8 +2148,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset_Additional(t *testi
 					WorkspaceID: 123,
 					DatasetID:   0,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}
 
@@ -2205,8 +2205,8 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset_Additional(t *testi
 					WorkspaceID: 123,
 					DatasetID:   0,
 					FieldData: []*entity.FieldData{
-						{Key: "", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
-						{Key: "", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "input", Name: "input", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
+						{Key: "output", Name: "output", Content: &entity.Content{ContentType: entity.ContentType_Text, Text: ""}},
 					},
 				}},
 				Errors: []entity.ItemErrorGroup{},

--- a/backend/modules/observability/domain/trace/service/trace_export_service_test.go
+++ b/backend/modules/observability/domain/trace/service/trace_export_service_test.go
@@ -287,6 +287,96 @@ func TestTraceExportServiceImpl_ExportTracesToDataset(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "export traces to dataset uses key from dataset schema",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				repoMock := repomocks.NewMockITraceRepo(ctrl)
+				tenantMock := tenantmocks.NewMockITenantProvider(ctrl)
+				datasetProviderMock := rpcmocks.NewMockIDatasetProvider(ctrl)
+				confMock := confmocks.NewMockITraceConfig(ctrl)
+				traceProducerMock := mqmocks.NewMockITraceProducer(ctrl)
+				annotationProducerMock := mqmocks.NewMockIAnnotationProducer(ctrl)
+				metricsMock := metricmocks.NewMockITraceMetrics(ctrl)
+				filterFactoryMock := filtermocks.NewMockPlatformFilterFactory(ctrl)
+				buildHelper := NewTraceFilterProcessorBuilder(filterFactoryMock, map[entity.ProcessorScene][]span_processor.Factory{entity.SceneGetTrace: {}, entity.SceneListSpans: {}, entity.SceneAdvanceInfo: {}, entity.SceneIngestTrace: {}, entity.SceneSearchTraceOApi: {}, entity.SceneListSpansOApi: {}})
+				adaptor := NewDatasetServiceAdaptor()
+				adaptor.Register(entity.DatasetCategory_General, datasetProviderMock)
+
+				tenantMock.EXPECT().GetTenantsByPlatformType(gomock.Any(), loop_span.PlatformCozeLoop).Return([]string{"tenant1"}, nil)
+				repoMock.EXPECT().ListSpans(gomock.Any(), gomock.Any()).Return(&repo.ListSpansResult{
+					Spans: []*loop_span.Span{
+						{
+							TraceID:     "trace-key",
+							SpanID:      "span-key",
+							WorkspaceID: "123",
+							Input:       "hello",
+							Output:      "world",
+						},
+					},
+				}, nil)
+				datasetProviderMock.EXPECT().CreateDataset(gomock.Any(), gomock.Any()).Return(int64(200), nil)
+				datasetProviderMock.EXPECT().GetDataset(gomock.Any(), int64(123), int64(200), entity.DatasetCategory_General).Return(&entity.Dataset{
+					ID:              200,
+					Name:            "key-test-dataset",
+					DatasetCategory: entity.DatasetCategory_General,
+					DatasetVersion: entity.DatasetVersion{
+						DatasetSchema: entity.DatasetSchema{
+							FieldSchemas: []entity.FieldSchema{
+								{Name: "输入", Key: ptr.Of("input_key_abc")},
+								{Name: "输出", Key: ptr.Of("output_key_xyz")},
+							},
+						},
+					},
+				}, nil)
+				datasetProviderMock.EXPECT().AddDatasetItems(gomock.Any(), int64(200), entity.DatasetCategory_General, gomock.Any()).DoAndReturn(
+					func(ctx context.Context, datasetID int64, category entity.DatasetCategory, items []*entity.DatasetItem) ([]*entity.DatasetItem, []entity.ItemErrorGroup, error) {
+						assert.Len(t, items, 1)
+						item := items[0]
+						assert.Len(t, item.FieldData, 2)
+						assert.Equal(t, "input_key_abc", item.FieldData[0].Key)
+						assert.Equal(t, "输入", item.FieldData[0].Name)
+						assert.Equal(t, "output_key_xyz", item.FieldData[1].Key)
+						assert.Equal(t, "输出", item.FieldData[1].Name)
+						return items, []entity.ItemErrorGroup{}, nil
+					})
+
+				return fields{
+					traceRepo:             repoMock,
+					traceConfig:           confMock,
+					traceProducer:         traceProducerMock,
+					annotationProducer:    annotationProducerMock,
+					metrics:               metricsMock,
+					tenantProvider:        tenantMock,
+					DatasetServiceAdaptor: adaptor,
+					buildHelper:           buildHelper,
+					traceService:          &stubTraceService{},
+				}
+			},
+			args: args{
+				ctx: context.Background(),
+				req: &ExportTracesToDatasetRequest{
+					WorkspaceID:  123,
+					SpanIds:      []SpanID{{TraceID: "trace-key", SpanID: "span-key"}},
+					Category:     entity.DatasetCategory_General,
+					Config:       DatasetConfig{IsNewDataset: true, DatasetName: ptr.Of("key-test-dataset"), DatasetSchema: entity.DatasetSchema{FieldSchemas: []entity.FieldSchema{{Name: "输入"}, {Name: "输出"}}}},
+					StartTime:    time.Now().Unix() - 3600,
+					EndTime:      time.Now().Unix(),
+					PlatformType: loop_span.PlatformCozeLoop,
+					ExportType:   ExportType_Append,
+					FieldMappings: []entity.FieldMapping{
+						{TraceFieldKey: "input", FieldSchema: entity.FieldSchema{Name: "输入"}},
+						{TraceFieldKey: "output", FieldSchema: entity.FieldSchema{Name: "输出"}},
+					},
+				},
+			},
+			want: &ExportTracesToDatasetResponse{
+				SuccessCount: 1,
+				DatasetID:    200,
+				DatasetName:  "key-test-dataset",
+				Errors:       []entity.ItemErrorGroup{},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Previously, buildItem and buildDatasetItem passed empty string as FieldData.Key when constructing dataset items. This caused:
- Evaluation set items to be silently dropped (due to fd.Key != "" filter)
- Dataset items to potentially mismatch schema when column names contain CJK characters or spaces

Fix by retrieving the real key from dataset/evaluation-set schema:
- trace_export_service: use dataset.GetFieldSchemaKeyByName in buildItem
- auto_evaluate processor: parse schema JSON from TaskRun config to get real keys via fillDatasetKeysFromSchema, avoiding extra RPC calls

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
