### PR TITLE
[fix][backend] add MaxBytes limit to ListSpansRepeat to prevent…

### DIFF
--- a/backend/modules/observability/domain/component/config/config.go
+++ b/backend/modules/observability/domain/component/config/config.go
@@ -149,6 +149,8 @@ type BackfillConfig struct {
 	CkQueryLimit SpaceAwareParam[int] `mapstructure:"ck_query_limit" json:"ck_query_limit"`
 	// BatchDispatchGray 批量分发灰度配置
 	BatchDispatchGray *BatchGrayConfig `mapstructure:"batch_dispatch_gray" json:"batch_dispatch_gray"`
+	// TrajectoryMaxBytes 单次 GetTrajectories 中 ListSpansRepeat 的内存上限（字节），0 表示不限制
+	TrajectoryMaxBytes SpaceAwareParam[int64] `mapstructure:"trajectory_max_bytes" json:"trajectory_max_bytes"`
 }
 
 // GetDispatchBatchSize 获取指定 workspace 的分发批大小
@@ -164,6 +166,11 @@ func (c *BackfillConfig) GetDispatchIntervalMs(workspaceID int64) int {
 // GetCkQueryLimit 获取指定 workspace 的 CK 查询页大小
 func (c *BackfillConfig) GetCkQueryLimit(workspaceID int64) int {
 	return c.CkQueryLimit.Get(workspaceID)
+}
+
+// GetTrajectoryMaxBytes 获取指定 workspace 的 trajectory 内存上限
+func (c *BackfillConfig) GetTrajectoryMaxBytes(workspaceID int64) int64 {
+	return c.TrajectoryMaxBytes.Get(workspaceID)
 }
 
 // BatchGrayConfig 批量处理灰度开关配置

--- a/backend/modules/observability/domain/trace/repo/trace.go
+++ b/backend/modules/observability/domain/trace/repo/trace.go
@@ -5,10 +5,13 @@ package repo
 
 import (
 	"context"
+	"errors"
 
 	"github.com/coze-dev/coze-loop/backend/modules/observability/domain/trace/entity"
 	"github.com/coze-dev/coze-loop/backend/modules/observability/domain/trace/entity/loop_span"
 )
+
+var ErrMaxBytesExceeded = errors.New("ListSpansRepeat: max bytes exceeded")
 
 type GetTraceParam struct {
 	WorkSpaceID        string
@@ -46,6 +49,7 @@ type ListSpansParam struct {
 	NotQueryAnnotation bool
 	OmitColumns        []string // omit specific columns
 	SelectColumns      []string // select specific columns, default select all columns
+	MaxBytes           int64    // max total bytes for ListSpansRepeat, 0 means no limit
 }
 
 type ListSpansResult struct {

--- a/backend/modules/observability/domain/trace/service/trace_service.go
+++ b/backend/modules/observability/domain/trace/service/trace_service.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -2489,6 +2490,11 @@ func (r *TraceServiceImpl) GetTrajectories(ctx context.Context, workspaceID int6
 		metaRules = metaCfg.Spaces[workspaceID]
 	}
 
+	var maxBytes int64
+	if backfillCfg := r.traceConfig.GetBackfillConfig(ctx); backfillCfg != nil {
+		maxBytes = backfillCfg.GetTrajectoryMaxBytes(workspaceID)
+	}
+
 	allSpans, err := r.traceRepo.ListSpansRepeat(ctx, &repo.ListSpansParam{
 		Tenants: tenant,
 		Filters: &loop_span.FilterFields{
@@ -2506,8 +2512,13 @@ func (r *TraceServiceImpl) GetTrajectories(ctx context.Context, workspaceID int6
 		Limit:              1000,
 		NotQueryAnnotation: true,
 		SelectColumns:      []string{loop_span.SpanFieldTraceId, loop_span.SpanFieldSpanId, loop_span.SpanFieldParentID, loop_span.SpanFieldSpaceId, loop_span.SpanFieldSpanName},
+		MaxBytes:           maxBytes,
 	})
 	if err != nil {
+		if errors.Is(err, repo.ErrMaxBytesExceeded) {
+			logs.CtxWarn(ctx, "GetTrajectories skipped: allSpans exceeded max bytes, traceIDs:%v, maxBytes:%d", traceIDs, maxBytes)
+			return map[string]*loop_span.Trajectory{}, nil
+		}
 		logs.CtxError(ctx, "Failed to list all spans, err:%+v", err)
 		return nil, err
 	}
@@ -2520,8 +2531,13 @@ func (r *TraceServiceImpl) GetTrajectories(ctx context.Context, workspaceID int6
 		EndAt:              endTime,
 		Limit:              100,
 		NotQueryAnnotation: true,
+		MaxBytes:           maxBytes,
 	})
 	if err != nil {
+		if errors.Is(err, repo.ErrMaxBytesExceeded) {
+			logs.CtxWarn(ctx, "GetTrajectories skipped: selectedSpans exceeded max bytes, traceIDs:%v, maxBytes:%d", traceIDs, maxBytes)
+			return map[string]*loop_span.Trajectory{}, nil
+		}
 		logs.CtxError(ctx, "Failed to list selected spans, err:%+v", err)
 		return nil, err
 	}

--- a/backend/modules/observability/domain/trace/service/trace_trajectory_service_test.go
+++ b/backend/modules/observability/domain/trace/service/trace_trajectory_service_test.go
@@ -129,6 +129,7 @@ func TestTraceServiceImpl_GetTrajectories_and_ListTrajectory(t *testing.T) {
 	repoMock.EXPECT().GetTrajectoryConfig(gomock.Any(), repo.GetTrajectoryConfigParam{WorkspaceId: 1}).Return(nil, nil).AnyTimes()
 	traceConfigMock := configmocks.NewMockITraceConfig(ctrl)
 	traceConfigMock.EXPECT().GetTrajectoryMetadataConfig(gomock.Any()).Return(nil).AnyTimes()
+	traceConfigMock.EXPECT().GetBackfillConfig(gomock.Any()).Return(nil).AnyTimes()
 
 	svc := &TraceServiceImpl{traceRepo: repoMock, buildHelper: builder, tenantProvider: tenantProviderMock, traceConfig: traceConfigMock}
 	// mock list all spans

--- a/backend/modules/observability/infra/repo/trace.go
+++ b/backend/modules/observability/infra/repo/trace.go
@@ -296,12 +296,22 @@ func (t *TraceRepoImpl) ListSpansRepeat(ctx context.Context, req *repo.ListSpans
 
 	clonedReq := *req
 	totalSpans := loop_span.SpanList{}
+	var totalBytes int64
 
 	for {
 		resp, err := t.ListSpans(ctx, &clonedReq)
 		if err != nil {
 			return nil, err
 		}
+
+		if req.MaxBytes > 0 {
+			pageBytes := int64(loop_span.SizeofSpans(resp.Spans))
+			if totalBytes+pageBytes > req.MaxBytes {
+				return nil, repo.ErrMaxBytesExceeded
+			}
+			totalBytes += pageBytes
+		}
+
 		totalSpans = append(totalSpans, resp.Spans...)
 		if !resp.HasMore || resp.PageToken == "" {
 			break


### PR DESCRIPTION
… OOM in trajectory backfill

When a traceID contains a large number of spans, ListSpansRepeat would fetch all pages into memory without any bound, potentially causing OOM in TCE instances during backfill tasks.

This adds a configurable MaxBytes parameter to ListSpansRepeat. When the accumulated span size exceeds the limit, it returns ErrMaxBytesExceeded. GetTrajectories catches this error, logs a warning, and returns an empty trajectory map to skip oversized traces gracefully.

The limit is configured per workspace via BackfillConfig.TrajectoryMaxBytes. When unset (0), the original unlimited behavior is preserved.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
