### PR TITLE
[fix][evaluation] fix export URL encoding, add upload retry, trajectory lower-bound, goroutine leak & long-conn target validation

### DIFF
--- a/backend/infra/backoff/backoff.go
+++ b/backend/infra/backoff/backoff.go
@@ -58,7 +58,7 @@ func RetryWithElapsedTime(ctx context.Context, maxElapsedTime time.Duration, fn 
 	return backoffFn(ctx, fn, policy)
 }
 
-func backoffFn(ctx context.Context, fn func() error, policy *backoff.ExponentialBackOff) error {
+func backoffFn(ctx context.Context, fn func() error, policy backoff.BackOff) error {
 	ctxWithCancel, cancelFn := context.WithCancel(ctx)
 	defer cancelFn()
 
@@ -69,4 +69,11 @@ func backoffFn(ctx context.Context, fn func() error, policy *backoff.Exponential
 
 func RetryWithMaxTimes(ctx context.Context, max int, fn func() error) error {
 	return backoff.Retry(fn, backoff.WithMaxRetries(&backoff.ZeroBackOff{}, uint64(max)))
+}
+
+// RetryWithMaxTimesAndInterval 以固定间隔 interval 最多重试 maxRetries 次（即总尝试次数为 maxRetries+1），
+// 适用于依赖偶发抖动（如对象存储/上传服务单实例迁移）时的止血重试：固定间隔而非指数退避，次数可控。
+func RetryWithMaxTimesAndInterval(ctx context.Context, maxRetries int, interval time.Duration, fn func() error) error {
+	policy := backoff.WithMaxRetries(backoff.NewConstantBackOff(interval), uint64(maxRetries))
+	return backoffFn(ctx, fn, policy)
 }

--- a/backend/infra/backoff/backoff_test.go
+++ b/backend/infra/backoff/backoff_test.go
@@ -65,3 +65,52 @@ func TestRetryWithMaxTimes(t *testing.T) {
 		assert.Equal(t, 4, count)
 	})
 }
+
+func TestRetryWithMaxTimesAndInterval(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("succeeds after retries within max", func(t *testing.T) {
+		attempts := 0
+		err := RetryWithMaxTimesAndInterval(ctx, 2, 10*time.Millisecond, func() error {
+			attempts++
+			if attempts < 3 {
+				return fmt.Errorf("transient err")
+			}
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 3, attempts) // 1 initial + 2 retries
+	})
+
+	t.Run("fails after exhausting max retries", func(t *testing.T) {
+		attempts := 0
+		err := RetryWithMaxTimesAndInterval(ctx, 2, 10*time.Millisecond, func() error {
+			attempts++
+			return fmt.Errorf("always err")
+		})
+		assert.Error(t, err)
+		assert.Equal(t, 3, attempts) // 1 initial + 2 retries, then give up
+	})
+
+	t.Run("succeeds on first try, no retry", func(t *testing.T) {
+		attempts := 0
+		err := RetryWithMaxTimesAndInterval(ctx, 3, 10*time.Millisecond, func() error {
+			attempts++
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, attempts)
+	})
+
+	t.Run("respects the fixed interval between attempts", func(t *testing.T) {
+		start := time.Now()
+		attempts := 0
+		_ = RetryWithMaxTimesAndInterval(ctx, 2, 50*time.Millisecond, func() error {
+			attempts++
+			return fmt.Errorf("err")
+		})
+		// 2 retries × ~50ms 固定间隔,总耗时应 >= 80ms(留裕度)
+		assert.GreaterOrEqual(t, time.Since(start), 80*time.Millisecond)
+		assert.Equal(t, 3, attempts)
+	})
+}

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -248,15 +248,16 @@ func IsSupportedOpenAPIEvalTargetType(t openapiEvalTarget.EvalTargetType) bool {
 	return err == nil
 }
 
-// ValidateOpenAPIEvalTargetClusterEnv validates the required cluster/env for
-// long-connection eval targets (custom_agent / a2a_agent / custom_rpc_server).
-// These are resolved to a live RPC/frontier client at run time, so a missing
-// cluster/env passes creation silently and only fails later with an opaque RPC
-// error. Rejecting it up front yields a clear param error with common values.
-//   - custom_agent / a2a_agent: both cluster and env are caller-supplied → required.
-//   - custom_rpc_server: cluster comes from the app config, only env is required.
+// ValidateOpenAPIEvalTargetClusterEnv validates the required cluster/env for the
+// long-connection custom_agent eval target. custom_agent is resolved to a live
+// RPC/frontier client at run time, so a missing cluster/env passes creation
+// silently and only fails later with an opaque RPC error; rejecting it up front
+// yields a clear param error with common values.
+//   - custom_agent: cluster and env are required, UNLESS an explicit AgentConnection
+//     (frontier direct-connect) is provided — direct-connect does not use cluster/env.
+//   - a2a_agent / custom_rpc_server: intentionally NOT validated for now.
 //
-// Returns nil when param/type is nil or the type is not a long-connection target.
+// Returns nil when param/type is nil or the type is not custom_agent.
 func ValidateOpenAPIEvalTargetClusterEnv(param *openapi.SubmitExperimentEvalTargetParam) error {
 	if param == nil || param.EvalTargetType == nil {
 		return nil

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -267,11 +267,11 @@ func ValidateOpenAPIEvalTargetClusterEnv(param *openapi.SubmitExperimentEvalTarg
 			return fmt.Errorf("cluster is required for eval target type %s (e.g. \"default\")", *param.EvalTargetType)
 		}
 		if param.GetEnv() == "" {
-			return fmt.Errorf("env is required for eval target type %s (e.g. \"cn\")", *param.EvalTargetType)
+			return fmt.Errorf("env is required for eval target type %s (lane/env identifier, e.g. \"ppe_fornax_eval\")", *param.EvalTargetType)
 		}
 	case openapiEvalTarget.EvalTargetTypeCustomRPCServer:
 		if param.GetEnv() == "" {
-			return fmt.Errorf("env is required for eval target type %s (e.g. \"cn\")", *param.EvalTargetType)
+			return fmt.Errorf("env is required for eval target type %s (lane/env identifier, e.g. \"ppe_fornax_eval\")", *param.EvalTargetType)
 		}
 	}
 	return nil

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -261,8 +261,9 @@ func ValidateOpenAPIEvalTargetClusterEnv(param *openapi.SubmitExperimentEvalTarg
 	if param == nil || param.EvalTargetType == nil {
 		return nil
 	}
-	switch *param.EvalTargetType {
-	case openapiEvalTarget.EvalTargetTypeCustomAgent, openapiEvalTarget.EvalTargetTypeA2Agent:
+	// Only validate custom_agent (the in-house long-connection agent). a2a_agent /
+	// custom_rpc_server are intentionally left un-validated for now.
+	if *param.EvalTargetType == openapiEvalTarget.EvalTargetTypeCustomAgent {
 		// When an explicit AgentConnection (frontier direct-connect) is provided, the target
 		// is dispatched by the frontier tuple (ProductID/AppID/UserID/DeviceID) and cluster/env
 		// are not used at run time, so do not require them here — requiring them would wrongly
@@ -273,10 +274,6 @@ func ValidateOpenAPIEvalTargetClusterEnv(param *openapi.SubmitExperimentEvalTarg
 		if param.GetCluster() == "" {
 			return fmt.Errorf("cluster is required for eval target type %s (e.g. \"default\")", *param.EvalTargetType)
 		}
-		if param.GetEnv() == "" {
-			return fmt.Errorf("env is required for eval target type %s (lane/env identifier, e.g. \"ppe_fornax_eval\")", *param.EvalTargetType)
-		}
-	case openapiEvalTarget.EvalTargetTypeCustomRPCServer:
 		if param.GetEnv() == "" {
 			return fmt.Errorf("env is required for eval target type %s (lane/env identifier, e.g. \"ppe_fornax_eval\")", *param.EvalTargetType)
 		}

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -248,6 +248,35 @@ func IsSupportedOpenAPIEvalTargetType(t openapiEvalTarget.EvalTargetType) bool {
 	return err == nil
 }
 
+// ValidateOpenAPIEvalTargetClusterEnv validates the required cluster/env for
+// long-connection eval targets (custom_agent / a2a_agent / custom_rpc_server).
+// These are resolved to a live RPC/frontier client at run time, so a missing
+// cluster/env passes creation silently and only fails later with an opaque RPC
+// error. Rejecting it up front yields a clear param error with common values.
+//   - custom_agent / a2a_agent: both cluster and env are caller-supplied → required.
+//   - custom_rpc_server: cluster comes from the app config, only env is required.
+//
+// Returns nil when param/type is nil or the type is not a long-connection target.
+func ValidateOpenAPIEvalTargetClusterEnv(param *openapi.SubmitExperimentEvalTargetParam) error {
+	if param == nil || param.EvalTargetType == nil {
+		return nil
+	}
+	switch *param.EvalTargetType {
+	case openapiEvalTarget.EvalTargetTypeCustomAgent, openapiEvalTarget.EvalTargetTypeA2Agent:
+		if param.GetCluster() == "" {
+			return fmt.Errorf("cluster is required for eval target type %s (e.g. \"default\")", *param.EvalTargetType)
+		}
+		if param.GetEnv() == "" {
+			return fmt.Errorf("env is required for eval target type %s (e.g. \"cn\")", *param.EvalTargetType)
+		}
+	case openapiEvalTarget.EvalTargetTypeCustomRPCServer:
+		if param.GetEnv() == "" {
+			return fmt.Errorf("env is required for eval target type %s (e.g. \"cn\")", *param.EvalTargetType)
+		}
+	}
+	return nil
+}
+
 func mapOpenAPIEvalTargetType(openapiType openapiEvalTarget.EvalTargetType) (domaindoEvalTarget.EvalTargetType, error) {
 	switch openapiType {
 	case openapiEvalTarget.EvalTargetTypeCozeBot:

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -263,6 +263,13 @@ func ValidateOpenAPIEvalTargetClusterEnv(param *openapi.SubmitExperimentEvalTarg
 	}
 	switch *param.EvalTargetType {
 	case openapiEvalTarget.EvalTargetTypeCustomAgent, openapiEvalTarget.EvalTargetTypeA2Agent:
+		// When an explicit AgentConnection (frontier direct-connect) is provided, the target
+		// is dispatched by the frontier tuple (ProductID/AppID/UserID/DeviceID) and cluster/env
+		// are not used at run time, so do not require them here — requiring them would wrongly
+		// reject the legitimate direct-connect path.
+		if param.IsSetAgentConnection() {
+			return nil
+		}
 		if param.GetCluster() == "" {
 			return fmt.Errorf("cluster is required for eval target type %s (e.g. \"default\")", *param.EvalTargetType)
 		}

--- a/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
@@ -3864,18 +3864,14 @@ func TestValidateOpenAPIEvalTargetClusterEnv(t *testing.T) {
 			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomAgent), AgentConnection: &openapiEvalTarget.AgentConnection{}},
 		},
 		{
-			name:    "a2a_agent missing cluster",
-			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeA2Agent), Env: gptr.Of("cn")},
-			wantErr: "cluster is required",
+			// a2a_agent is intentionally not validated for now → no error even without cluster/env.
+			name:  "a2a_agent not validated",
+			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeA2Agent)},
 		},
 		{
-			name:  "custom_rpc_server only needs env (cluster from app config)",
-			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomRPCServer), Env: gptr.Of("cn")},
-		},
-		{
-			name:    "custom_rpc_server missing env",
-			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomRPCServer)},
-			wantErr: "env is required",
+			// custom_rpc_server is intentionally not validated for now → no error even without env.
+			name:  "custom_rpc_server not validated",
+			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomRPCServer)},
 		},
 	}
 	for _, tt := range tests {

--- a/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
@@ -3859,6 +3859,11 @@ func TestValidateOpenAPIEvalTargetClusterEnv(t *testing.T) {
 			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomAgent), Cluster: gptr.Of("default"), Env: gptr.Of("cn")},
 		},
 		{
+			// direct-connect (AgentConnection) exempts cluster/env — must not require them.
+			name:  "custom_agent with AgentConnection exempts cluster/env",
+			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomAgent), AgentConnection: &openapiEvalTarget.AgentConnection{}},
+		},
+		{
 			name:    "a2a_agent missing cluster",
 			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeA2Agent), Env: gptr.Of("cn")},
 			wantErr: "cluster is required",

--- a/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi_test.go
@@ -3830,3 +3830,58 @@ func TestDomainFilterLogicOpToOpenAPI(t *testing.T) {
 	assert.Equal(t, "or", domainFilterLogicOpToOpenAPI(domainExpt.FilterLogicOp_Or))
 	assert.Equal(t, "999", domainFilterLogicOpToOpenAPI(domainExpt.FilterLogicOp(999)))
 }
+
+func TestValidateOpenAPIEvalTargetClusterEnv(t *testing.T) {
+	tp := func(v openapiEvalTarget.EvalTargetType) *openapiEvalTarget.EvalTargetType { return &v }
+	tests := []struct {
+		name    string
+		param   *openapi.SubmitExperimentEvalTargetParam
+		wantErr string // 空=期望无错; 否则 err 应包含该子串
+	}{
+		{name: "nil param", param: nil},
+		{name: "nil type", param: &openapi.SubmitExperimentEvalTargetParam{}},
+		{
+			name:  "non long-connection type skipped (coze_loop_prompt)",
+			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCozeLoopPrompt)},
+		},
+		{
+			name:    "custom_agent missing cluster",
+			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomAgent), Env: gptr.Of("cn")},
+			wantErr: "cluster is required",
+		},
+		{
+			name:    "custom_agent missing env",
+			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomAgent), Cluster: gptr.Of("default")},
+			wantErr: "env is required",
+		},
+		{
+			name:  "custom_agent both present",
+			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomAgent), Cluster: gptr.Of("default"), Env: gptr.Of("cn")},
+		},
+		{
+			name:    "a2a_agent missing cluster",
+			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeA2Agent), Env: gptr.Of("cn")},
+			wantErr: "cluster is required",
+		},
+		{
+			name:  "custom_rpc_server only needs env (cluster from app config)",
+			param: &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomRPCServer), Env: gptr.Of("cn")},
+		},
+		{
+			name:    "custom_rpc_server missing env",
+			param:   &openapi.SubmitExperimentEvalTargetParam{EvalTargetType: tp(openapiEvalTarget.EvalTargetTypeCustomRPCServer)},
+			wantErr: "env is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOpenAPIEvalTargetClusterEnv(tt.param)
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -887,6 +887,7 @@ func (e *EvalOpenAPIApplication) ReportEvalTargetInvokeResult_(ctx context.Conte
 		Status:                  target.ToTargetRunStatsDO(req.GetStatus()),
 		Session:                 actx.Session,
 		EnableExtractTrajectory: actx.EnableExtractTrajectory,
+		AsyncUnixMS:             actx.AsyncUnixMS,
 	}); err != nil {
 		return nil, err
 	}

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -1065,6 +1065,13 @@ func (e *EvalOpenAPIApplication) SubmitExperimentOApi(ctx context.Context, req *
 		}
 	}
 
+	// Long-connection eval targets (custom_agent / a2a_agent / custom_rpc_server) require
+	// cluster/env to resolve a live client at run time. Validate up front so a missing value
+	// fails with a clear param error here instead of an opaque RPC error during experiment run.
+	if err := experiment_convertor.ValidateOpenAPIEvalTargetClusterEnv(req.EvalTargetParam); err != nil {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(err.Error()))
+	}
+
 	createEvalTargetParam, err := experiment_convertor.OpenAPICreateEvalTargetParamDTO2Domain(req.EvalTargetParam)
 	if err != nil {
 		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(err.Error()))

--- a/backend/modules/evaluation/domain/entity/param.go
+++ b/backend/modules/evaluation/domain/entity/param.go
@@ -457,6 +457,10 @@ type ReportTargetRecordParam struct {
 
 	Session                 *Session
 	EnableExtractTrajectory *bool
+	// AsyncUnixMS 异步评测对象「请求发起」的时间(unix ms),即提交异步调用之前的时刻。
+	// 用作抽取 trajectory 的时间下界:record.BaseInfo.CreatedAt 是异步返回后才 stamp 的,偏晚会漏掉
+	// 请求发起到返回之间的 span。为 0 时回退到 record.BaseInfo.CreatedAt。
+	AsyncUnixMS int64
 }
 
 type DebugTargetParam struct {

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
@@ -416,6 +416,10 @@ func (e *DefaultExptTurnEvaluationImpl) callEvaluators(ctx context.Context, exec
 	if err != nil {
 		return nil, err
 	}
+	// 立即绑定释放到 pool 生命周期:即使下方循环中途提前 return(如 conf 为 nil / buildEvaluatorInputData 失败)
+	// 跳过了 ExecAll,也能释放底层 ants pool 及其常驻协程(purge / ticktock),避免 goroutine 泄漏。
+	// Release 幂等,与 ExecAll 内部的释放不冲突。
+	defer pool.Release()
 
 	for idx := range expt.Evaluators {
 		ev := expt.Evaluators[idx]

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
@@ -4337,8 +4337,8 @@ func TestDefaultExptTurnEvaluationImpl_CallEvaluators_NoGoroutineLeak(t *testing
 					SpaceID: 2,
 					Evaluators: []*entity.Evaluator{
 						{
-							ID:            1,
-							EvaluatorType: entity.EvaluatorTypePrompt,
+							ID:                     1,
+							EvaluatorType:          entity.EvaluatorTypePrompt,
 							PromptEvaluatorVersion: &entity.PromptEvaluatorVersion{ID: 1},
 						},
 					},

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"errors"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -4291,4 +4292,93 @@ func TestDefaultExptTurnEvaluationImpl_callTarget_CustomAgentAndA2AAgent(t *test
 			}
 		})
 	}
+}
+
+// TestDefaultExptTurnEvaluationImpl_CallEvaluators_NoGoroutineLeak 在真实泄漏点 callEvaluators 直接验证:
+// 当 evaluator conf 缺失导致中途提前 return(跳过 pool.ExecAll)时,协程池仍被释放,不泄漏 goroutine。
+// 修复前(NewPool 后无 defer pool.Release()),每次调用会泄漏底层 ants pool 的 2 个常驻协程(purge/ticktock),
+// 此测试会因协程数持续增长而失败;修复后应保持平稳。
+func TestDefaultExptTurnEvaluationImpl_CallEvaluators_NoGoroutineLeak(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// evalTargetService 在提前 return 前不会被调用到(OutputFields 无 omitted 大字段),这里可留空 mock。
+	// benefitService 在 callEvaluators 之前的权益校验会被调用,mock 成功放行。
+	mockBenefit := benefitmocks.NewMockIBenefitService(ctrl)
+	mockBenefit.EXPECT().CheckAndDeductEvalBenefit(gomock.Any(), gomock.Any()).
+		Return(&benefit.CheckAndDeductEvalBenefitResult{}, nil).AnyTimes()
+	service := &DefaultExptTurnEvaluationImpl{
+		evalTargetService: svcmocks.NewMockIEvalTargetService(ctrl),
+		benefitService:    mockBenefit,
+		metric:            metricsmocks.NewMockExptMetric(ctrl),
+	}
+
+	target := &entity.EvalTargetRecord{
+		EvalTargetOutputData: &entity.EvalTargetOutputData{
+			OutputFields: map[string]*entity.Content{
+				"field1": {Text: gptr.Of("v")},
+			},
+		},
+	}
+
+	// 构造一个会触发 "evaluator conf not found" 提前 return 的 etec:
+	// Expt.Evaluators 里有 versionID=1 的 evaluator,但 EvaluatorsConf.EvaluatorConf 为空 → GetEvaluatorConf(1)=nil。
+	newEtec := func() *entity.ExptTurnEvalCtx {
+		return &entity.ExptTurnEvalCtx{
+			ExptItemEvalCtx: &entity.ExptItemEvalCtx{
+				EvalSetItem: &entity.EvaluationSetItem{ID: 1, ItemID: 2},
+				Event: &entity.ExptItemEvalEvent{
+					Session: &entity.Session{UserID: "u"},
+					ExptID:  1,
+					SpaceID: 2,
+				},
+				Expt: &entity.Experiment{
+					ID:      1,
+					SpaceID: 2,
+					Evaluators: []*entity.Evaluator{
+						{
+							ID:            1,
+							EvaluatorType: entity.EvaluatorTypePrompt,
+							PromptEvaluatorVersion: &entity.PromptEvaluatorVersion{ID: 1},
+						},
+					},
+					EvalConf: &entity.EvaluationConfiguration{
+						ItemConcurNum: gptr.Of(1),
+						ConnectorConf: entity.Connector{
+							EvaluatorsConf: &entity.EvaluatorsConf{
+								EvaluatorConcurNum: gptr.Of(1),
+								// 故意不放 versionID=1 的 conf → 触发 :433 提前 return
+								EvaluatorConf: []*entity.EvaluatorConf{},
+							},
+						},
+					},
+				},
+			},
+			ExptTurnRunResult: &entity.ExptTurnRunResult{},
+			Turn:              &entity.Turn{FieldDataList: []*entity.FieldData{}},
+		}
+	}
+
+	// 先跑一次预热(确保触发的是提前 return 路径),并让运行时协程稳定。
+	if _, err := service.CallEvaluators(context.Background(), newEtec(), target); err == nil {
+		t.Fatalf("expected evaluator-conf-not-found error to hit the early-return path")
+	}
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	const N = 50
+	for i := 0; i < N; i++ {
+		_, err := service.CallEvaluators(context.Background(), newEtec(), target)
+		assert.Error(t, err) // 每次都走 conf-not-found 提前 return
+	}
+
+	// 等底层 ants pool 的常驻协程随 Release 退出。
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	// 修复前:N 次泄漏 ≈ 2N=100 个常驻协程;修复后应基本持平,留少量裕度。
+	assert.Less(t, after-before, 20,
+		"goroutine leak in callEvaluators early-return path: before=%d after=%d (delta=%d)", before, after, after-before)
 }

--- a/backend/modules/evaluation/domain/service/target_impl.go
+++ b/backend/modules/evaluation/domain/service/target_impl.go
@@ -45,6 +45,10 @@ type EvalTargetServiceImpl struct {
 
 const evalTargetRecordPersistTimeout = 5 * time.Second
 
+// trajectoryStartTimeBufferMS 抽取 trajectory 时，时间下界额外向前预留的 buffer(1 分钟)，
+// 用于吸收请求发起时间与实际 span 上报时间之间可能的时钟/延迟误差，避免漏掉最早的 span。
+const trajectoryStartTimeBufferMS = int64(60 * 1000)
+
 func NewEvalTargetServiceImpl(evalTargetRepo repo.IEvalTargetRepo,
 	idgen idgen.IIDGenerator,
 	metric metrics.EvalTargetMetrics,
@@ -444,6 +448,11 @@ func (e *EvalTargetServiceImpl) ExecuteTarget(ctx context.Context, spaceID, targ
 func (e *EvalTargetServiceImpl) ExtractTrajectory(ctx context.Context, spaceID int64, traceID string, startTimeMS *int64) (*entity.Trajectory, error) {
 	if len(traceID) == 0 {
 		return nil, errorx.New("ExtractTrajectory with null traceID")
+	}
+	// 时间下界默认向前多减 1 分钟 buffer:防御请求发起时间与实际 span 时间之间可能存在的时钟/上报误差,
+	// 避免因下界略偏晚而漏掉最早的 span 导致轨迹拉不全。trace 查询按 traceID 精确匹配,放宽下界不会引入无关数据。
+	if startTimeMS != nil {
+		startTimeMS = gptr.Of(*startTimeMS - trajectoryStartTimeBufferMS)
 	}
 	trajectories, err := e.trajectoryAdapter.ListTrajectory(ctx, spaceID, []string{traceID}, startTimeMS)
 	if err != nil {

--- a/backend/modules/evaluation/domain/service/target_impl.go
+++ b/backend/modules/evaluation/domain/service/target_impl.go
@@ -725,7 +725,11 @@ func (e *EvalTargetServiceImpl) ReportInvokeRecords(ctx context.Context, param *
 
 	recordTrajectory := func() error {
 		var sms *int64
-		if record.BaseInfo != nil {
+		// 优先用「请求发起时间」作为抽取 trajectory 的时间下界;它比 record.BaseInfo.CreatedAt(异步返回后才 stamp)
+		// 更早,避免漏掉请求发起到返回之间的 span。为 0(未透传)时回退到 CreatedAt,保持向前兼容。
+		if param.AsyncUnixMS > 0 {
+			sms = gptr.Of(param.AsyncUnixMS)
+		} else if record.BaseInfo != nil {
 			sms = record.BaseInfo.CreatedAt
 		}
 		trajectory, err := e.ExtractTrajectory(ctx, param.SpaceID, record.TraceID, sms)

--- a/backend/modules/evaluation/domain/service/target_impl_test.go
+++ b/backend/modules/evaluation/domain/service/target_impl_test.go
@@ -1257,6 +1257,96 @@ func TestEvalTargetServiceImpl_ExtractTrajectory_EmptyTraceID(t *testing.T) {
 	assert.Nil(t, res)
 }
 
+// TestEvalTargetServiceImpl_ReportInvokeRecords_TrajectoryStartTime 验证抽取 trajectory 的时间下界选取:
+// 优先使用 param.AsyncUnixMS(请求发起时间),仅当其为 0 时才回退到 record.BaseInfo.CreatedAt(record 保存时间)。
+func TestEvalTargetServiceImpl_ReportInvokeRecords_TrajectoryStartTime(t *testing.T) {
+	// do not run in parallel: involves time.Sleep for the async trajectory goroutine
+	ctx := context.Background()
+	spaceID := int64(1)
+
+	const createdAtMS = int64(2_000_000)  // record 保存时间(偏晚)
+	const asyncUnixMS = int64(1_000_000)  // 请求发起时间(更早)
+
+	tests := []struct {
+		name          string
+		asyncUnixMS   int64
+		wantStartTime int64
+	}{
+		{name: "AsyncUnixMS 优先作为下界", asyncUnixMS: asyncUnixMS, wantStartTime: asyncUnixMS},
+		{name: "AsyncUnixMS 为0时回退 CreatedAt", asyncUnixMS: 0, wantStartTime: createdAtMS},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			repo := repomocks.NewMockIEvalTargetRepo(ctrl)
+			configer := componentmocks.NewMockIConfiger(ctrl)
+			trajectoryAdapter := trajectorymocks.NewMockITrajectoryAdapter(ctrl)
+
+			record := &entity.EvalTargetRecord{
+				ID:                   10,
+				SpaceID:              spaceID,
+				Status:               gptr.Of(entity.EvalTargetRunStatusAsyncInvoking),
+				EvalTargetOutputData: &entity.EvalTargetOutputData{},
+				TraceID:              "trace-id-1",
+				BaseInfo:             &entity.BaseInfo{CreatedAt: gptr.Of(createdAtMS)},
+			}
+
+			param := &entity.ReportTargetRecordParam{
+				SpaceID:     spaceID,
+				RecordID:    record.ID,
+				Status:      entity.EvalTargetRunStatusSuccess,
+				OutputData:  &entity.EvalTargetOutputData{},
+				AsyncUnixMS: tt.asyncUnixMS,
+			}
+
+			repo.EXPECT().GetEvalTargetRecordByIDAndSpaceID(ctx, param.SpaceID, param.RecordID).Return(record, nil)
+			repo.EXPECT().SaveEvalTargetRecord(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+			repo.EXPECT().UpdateEvalTargetRecord(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil)
+			configer.EXPECT().GetErrCtrl(gomock.Any()).Return(&entity.ExptErrCtrl{}).AnyTimes()
+			configer.EXPECT().GetTargetTrajectoryConf(gomock.Any()).AnyTimes().Return(&entity.TargetTrajectoryConf{
+				SpaceExtractIntervalSecond: map[int64]int64{spaceID: 1},
+			})
+
+			gotStartCh := make(chan int64, 1)
+			trajectoryAdapter.EXPECT().
+				ListTrajectory(gomock.Any(), spaceID, gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ int64, _ []string, startMS *int64) ([]*entity.Trajectory, error) {
+					var v int64
+					if startMS != nil {
+						v = *startMS
+					}
+					select {
+					case gotStartCh <- v:
+					default:
+					}
+					return []*entity.Trajectory{{ID: gptr.Of("traj")}}, nil
+				})
+
+			svc := &EvalTargetServiceImpl{
+				evalTargetRepo:    repo,
+				trajectoryAdapter: trajectoryAdapter,
+				configer:          configer,
+			}
+
+			err := svc.ReportInvokeRecords(ctx, param)
+			require.NoError(t, err)
+
+			// 等异步抽取 goroutine(sleep 1s interval)完成
+			time.Sleep(1200 * time.Millisecond)
+			select {
+			case got := <-gotStartCh:
+				assert.Equal(t, tt.wantStartTime, got, "trajectory 抽取时间下界不符合预期")
+			default:
+				t.Fatal("ListTrajectory was not called")
+			}
+		})
+	}
+}
+
 func TestEvalTargetServiceImpl_ValidateRuntimeParam(t *testing.T) {
 	t.Parallel()
 

--- a/backend/modules/evaluation/domain/service/target_impl_test.go
+++ b/backend/modules/evaluation/domain/service/target_impl_test.go
@@ -1257,6 +1257,46 @@ func TestEvalTargetServiceImpl_ExtractTrajectory_EmptyTraceID(t *testing.T) {
 	assert.Nil(t, res)
 }
 
+// TestEvalTargetServiceImpl_ExtractTrajectory_StartTimeBuffer 验证抽取 trajectory 时下界额外向前预留 1 分钟 buffer;
+// startTimeMS 为 nil 时保持 nil 不做偏移。
+func TestEvalTargetServiceImpl_ExtractTrajectory_StartTimeBuffer(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	const spaceID = int64(1)
+	const bufferMS = int64(60 * 1000)
+
+	tests := []struct {
+		name    string
+		in      *int64
+		wantOut *int64
+	}{
+		{name: "有下界时减去 1 分钟 buffer", in: gptr.Of(int64(5_000_000)), wantOut: gptr.Of(int64(5_000_000) - bufferMS)},
+		{name: "下界为 nil 时保持 nil", in: nil, wantOut: nil},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			adapter := trajectorymocks.NewMockITrajectoryAdapter(ctrl)
+			adapter.EXPECT().
+				ListTrajectory(gomock.Any(), spaceID, []string{"trace-x"}, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ int64, _ []string, got *int64) ([]*entity.Trajectory, error) {
+					if tt.wantOut == nil {
+						assert.Nil(t, got)
+					} else {
+						require.NotNil(t, got)
+						assert.Equal(t, *tt.wantOut, *got)
+					}
+					return nil, nil
+				})
+			svc := &EvalTargetServiceImpl{trajectoryAdapter: adapter}
+			_, err := svc.ExtractTrajectory(ctx, spaceID, "trace-x", tt.in)
+			require.NoError(t, err)
+		})
+	}
+}
+
 // TestEvalTargetServiceImpl_ReportInvokeRecords_TrajectoryStartTime 验证抽取 trajectory 的时间下界选取:
 // 优先使用 param.AsyncUnixMS(请求发起时间),仅当其为 0 时才回退到 record.BaseInfo.CreatedAt(record 保存时间)。
 func TestEvalTargetServiceImpl_ReportInvokeRecords_TrajectoryStartTime(t *testing.T) {
@@ -1266,14 +1306,15 @@ func TestEvalTargetServiceImpl_ReportInvokeRecords_TrajectoryStartTime(t *testin
 
 	const createdAtMS = int64(2_000_000)  // record 保存时间(偏晚)
 	const asyncUnixMS = int64(1_000_000)  // 请求发起时间(更早)
+	const bufferMS = int64(60 * 1000)     // ExtractTrajectory 额外预留的 1 分钟 buffer
 
 	tests := []struct {
 		name          string
 		asyncUnixMS   int64
 		wantStartTime int64
 	}{
-		{name: "AsyncUnixMS 优先作为下界", asyncUnixMS: asyncUnixMS, wantStartTime: asyncUnixMS},
-		{name: "AsyncUnixMS 为0时回退 CreatedAt", asyncUnixMS: 0, wantStartTime: createdAtMS},
+		{name: "AsyncUnixMS 优先作为下界", asyncUnixMS: asyncUnixMS, wantStartTime: asyncUnixMS - bufferMS},
+		{name: "AsyncUnixMS 为0时回退 CreatedAt", asyncUnixMS: 0, wantStartTime: createdAtMS - bufferMS},
 	}
 
 	for _, tt := range tests {

--- a/backend/modules/evaluation/domain/service/target_impl_test.go
+++ b/backend/modules/evaluation/domain/service/target_impl_test.go
@@ -1304,9 +1304,9 @@ func TestEvalTargetServiceImpl_ReportInvokeRecords_TrajectoryStartTime(t *testin
 	ctx := context.Background()
 	spaceID := int64(1)
 
-	const createdAtMS = int64(2_000_000)  // record 保存时间(偏晚)
-	const asyncUnixMS = int64(1_000_000)  // 请求发起时间(更早)
-	const bufferMS = int64(60 * 1000)     // ExtractTrajectory 额外预留的 1 分钟 buffer
+	const createdAtMS = int64(2_000_000) // record 保存时间(偏晚)
+	const asyncUnixMS = int64(1_000_000) // 请求发起时间(更早)
+	const bufferMS = int64(60 * 1000)    // ExtractTrajectory 额外预留的 1 分钟 buffer
 
 	tests := []struct {
 		name          string

--- a/backend/modules/evaluation/domain/service/url_processor_impl.go
+++ b/backend/modules/evaluation/domain/service/url_processor_impl.go
@@ -22,21 +22,44 @@ func NewDefaultURLProcessor() component.IURLProcessor {
 	return &DefaultURLProcessor{}
 }
 
-// ProcessSignURL 处理签名URL，包括URL解码和本地主机处理
+// ProcessSignURL 处理签名URL，包括本地主机处理
 func (p *DefaultURLProcessor) ProcessSignURL(ctx context.Context, signURL string) string {
 	logs.CtxInfo(ctx, "get export record sign url origin: %v", signURL)
-	unescaped, err := url.QueryUnescape(conv.UnescapeUnicode(signURL))
+	parsedURL, err := url.Parse(conv.UnescapeUnicode(signURL))
 	if err != nil {
-		logs.CtxWarn(ctx, "QueryUnescape fail, raw: %v", signURL)
-	} else {
-		signURL = unescaped
+		logs.CtxWarn(ctx, "Parse URL fail, raw: %v", signURL)
+		return signURL
 	}
-	logs.CtxInfo(ctx, "get export record sign url unescaped: %v", signURL)
-	parsedURL, err := url.Parse(signURL)
-	if err == nil {
-		if parsedURL.Host == localos.GetLocalOSHost() {
-			signURL = fmt.Sprintf("%s?%s", parsedURL.Path, parsedURL.RawQuery)
+
+	// 关键：签名 URL 的 path / query 必须与签名服务（对象存储/CDN）签发时的 percent-encoding 逐字节一致，
+	// 否则 ① x-signature 等签名是针对编码后的 path 计算的，path 一旦被改写签名即失效；
+	// ② 文件名里的 '/' 若被反转义会变成真正的路径分隔符，破坏 object key 结构导致 404。
+	// 历史实现为了让中文文件名“可读”对整个 URL 做了 QueryUnescape，对中文恰好不破坏 path 合法性，
+	// 但对实验名含 '[' ']' '/' 空格 等字符的场景会破坏 path 与签名，导致导出下载失败。
+	// 因此这里不再改动 path / query 的编码，原样透传签发结果；文件名展示交由下载响应头处理。
+	escapedPath := parsedURL.EscapedPath()
+	rawQuery := parsedURL.RawQuery
+
+	// localos（本地对象存储）场景下仅去掉 scheme+host，保留编码后的 path 与 query。
+	if parsedURL.Host == localos.GetLocalOSHost() {
+		if rawQuery != "" {
+			signURL = fmt.Sprintf("%s?%s", escapedPath, rawQuery)
+		} else {
+			signURL = escapedPath
 		}
+		logs.CtxInfo(ctx, "get export record sign url final(localos): %v", signURL)
+		return signURL
 	}
+
+	if parsedURL.Scheme != "" && parsedURL.Host != "" {
+		signURL = fmt.Sprintf("%s://%s%s", parsedURL.Scheme, parsedURL.Host, escapedPath)
+	} else {
+		signURL = escapedPath
+	}
+	if rawQuery != "" {
+		signURL = fmt.Sprintf("%s?%s", signURL, rawQuery)
+	}
+
+	logs.CtxInfo(ctx, "get export record sign url final: %v", signURL)
 	return signURL
 }

--- a/backend/modules/evaluation/domain/service/url_processor_impl_test.go
+++ b/backend/modules/evaluation/domain/service/url_processor_impl_test.go
@@ -58,8 +58,8 @@ func TestDefaultURLProcessor_ProcessSignURL(t *testing.T) {
 			want: "/api/download?token=abc",
 		},
 		{
-			name:    "URL解码 - Unicode转义",
-			signURL: "https://example.com/path\u0026file?param=value\u003d123",
+			name:    "Unicode转义还原(JSON \\uXXXX 字面量)",
+			signURL: "https://example.com/path&file?param=value=123",
 			setupEnv: func() {
 				_ = os.Setenv("COZE_LOOP_OSS_PROTOCOL", "https")
 				_ = os.Setenv("COZE_LOOP_OSS_DOMAIN", "other.com")
@@ -68,24 +68,16 @@ func TestDefaultURLProcessor_ProcessSignURL(t *testing.T) {
 			want: "https://example.com/path&file?param=value=123",
 		},
 		{
-			name:    "URL解码 - 普通URL编码",
+			// 修复后：path/query 的 percent-encoding 必须原样保留（不再反转义），
+			// 否则与签名服务签发时的编码不一致会破坏签名 / 路径结构。
+			name:    "保留path的percent编码(中文与空格)",
 			signURL: "https://example.com/path%20with%20spaces?param=%E4%B8%AD%E6%96%87",
 			setupEnv: func() {
 				_ = os.Setenv("COZE_LOOP_OSS_PROTOCOL", "https")
 				_ = os.Setenv("COZE_LOOP_OSS_DOMAIN", "other.com")
 				_ = os.Setenv("COZE_LOOP_OSS_PORT", "")
 			},
-			want: "https://example.com/path with spaces?param=中文",
-		},
-		{
-			name:    "URL解码 - 混合编码",
-			signURL: "https://example.com/path\u0020with%20spaces?param=value\u003d123%26end",
-			setupEnv: func() {
-				_ = os.Setenv("COZE_LOOP_OSS_PROTOCOL", "https")
-				_ = os.Setenv("COZE_LOOP_OSS_DOMAIN", "other.com")
-				_ = os.Setenv("COZE_LOOP_OSS_PORT", "")
-			},
-			want: "https://example.com/path with spaces?param=value=123&end",
+			want: "https://example.com/path%20with%20spaces?param=%E4%B8%AD%E6%96%87",
 		},
 		{
 			name:    "无效URL - 仍然返回原始值",
@@ -108,7 +100,7 @@ func TestDefaultURLProcessor_ProcessSignURL(t *testing.T) {
 			want: "",
 		},
 		{
-			name:    "URL解码失败 - 仍然继续处理",
+			name:    "非法百分号编码 - 原样保留",
 			signURL: "https://example.com/path%ZZinvalid?param=value",
 			setupEnv: func() {
 				_ = os.Setenv("COZE_LOOP_OSS_PROTOCOL", "https")
@@ -128,24 +120,27 @@ func TestDefaultURLProcessor_ProcessSignURL(t *testing.T) {
 			want: "https://external.com/path?param=value",
 		},
 		{
-			name:    "复杂路径和查询参数",
+			// 签名参数（signature=xyz%3D%3D）必须保持原始编码，不能被反转义成 xyz==。
+			name:    "复杂路径和查询参数 - 保留签名编码",
 			signURL: "https://test.com/api/v1/users/123/files/document.pdf?token=abc123&expires=1234567890&signature=xyz%3D%3D",
 			setupEnv: func() {
 				_ = os.Setenv("COZE_LOOP_OSS_PROTOCOL", "https")
 				_ = os.Setenv("COZE_LOOP_OSS_DOMAIN", "test.com")
 				_ = os.Setenv("COZE_LOOP_OSS_PORT", "")
 			},
-			want: "https://test.com/api/v1/users/123/files/document.pdf?token=abc123&expires=1234567890&signature=xyz==",
+			want: "https://test.com/api/v1/users/123/files/document.pdf?token=abc123&expires=1234567890&signature=xyz%3D%3D",
 		},
 		{
-			name:    "URL解码 - 只有Unicode转义",
-			signURL: "https://example.com/api\u002Ftest\u003Fparam\u003Dvalue",
+			// 复现并验证缺陷修复：实验名含 '[' ']' '/' 时，path 的 percent-encoding 必须保留，
+			// 不能被反转义成裸字符（否则签名失效，且 '/' 会破坏 object key 结构导致 404）。
+			name:    "保留特殊字符编码([] / 中文 与签名)",
+			signURL: "https://p9.byteimg.com/tos-cn-i-x/%5Bauto%5DPMO%2F%E9%A3%8E%E9%99%A9_%E5%AE%9E%E9%AA%8C%E6%8A%A5%E5%91%8A.csv~tplv-x-image.image?rk3s=eb124da7&x-signature=ab%2Bcd%3D",
 			setupEnv: func() {
 				_ = os.Setenv("COZE_LOOP_OSS_PROTOCOL", "https")
 				_ = os.Setenv("COZE_LOOP_OSS_DOMAIN", "other.com")
 				_ = os.Setenv("COZE_LOOP_OSS_PORT", "")
 			},
-			want: "https://example.com/api/test?param=value",
+			want: "https://p9.byteimg.com/tos-cn-i-x/%5Bauto%5DPMO%2F%E9%A3%8E%E9%99%A9_%E5%AE%9E%E9%AA%8C%E6%8A%A5%E5%91%8A.csv~tplv-x-image.image?rk3s=eb124da7&x-signature=ab%2Bcd%3D",
 		},
 	}
 

--- a/backend/modules/evaluation/infra/repo/evaluator/evaluator_record_impl_test.go
+++ b/backend/modules/evaluation/infra/repo/evaluator/evaluator_record_impl_test.go
@@ -197,7 +197,7 @@ func TestEvaluatorRecordRepoImpl_CreateEvaluatorRecord(t *testing.T) {
 		mockIDGen := idgenmocks.NewMockIIDGenerator(ctrl)
 
 		mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
-		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 		cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 		recordDataStorage := storage.NewRecordDataStorage(mockS3, &fakeEvaluatorRecordStorageConfiger{cfg: cfg})
 
@@ -323,7 +323,7 @@ func TestEvaluatorRecordRepoImpl_CorrectEvaluatorRecord(t *testing.T) {
 		mockIDGen := idgenmocks.NewMockIIDGenerator(ctrl)
 
 		mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
-		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 		cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 		recordDataStorage := storage.NewRecordDataStorage(mockS3, &fakeEvaluatorRecordStorageConfiger{cfg: cfg})
 

--- a/backend/modules/evaluation/infra/repo/target/eval_target_repo_impl_test.go
+++ b/backend/modules/evaluation/infra/repo/target/eval_target_repo_impl_test.go
@@ -2093,7 +2093,7 @@ func TestEvalTargetRepoImpl_SaveEvalTargetRecord(t *testing.T) {
 
 	t.Run("recordDataStorage SaveEvalTargetRecordData error returns err", func(t *testing.T) {
 		mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
-		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 		cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 		recordDataStorage := storage.NewRecordDataStorage(mockS3, &fakeRecordStorageConfiger{cfg: cfg})
 
@@ -2178,7 +2178,7 @@ func TestEvalTargetRepoImpl_UpdateEvalTargetRecord(t *testing.T) {
 
 	t.Run("recordDataStorage SaveEvalTargetRecordData error returns err", func(t *testing.T) {
 		mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
-		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+		mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 		cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 		recordDataStorage := storage.NewRecordDataStorage(mockS3, &fakeRecordStorageConfiger{cfg: cfg})
 

--- a/backend/modules/evaluation/infra/storage/record_data.go
+++ b/backend/modules/evaluation/infra/storage/record_data.go
@@ -7,11 +7,13 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"time"
 
 	"github.com/bytedance/gg/gptr"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
+	"github.com/coze-dev/coze-loop/backend/infra/backoff"
 	"github.com/coze-dev/coze-loop/backend/infra/fileserver"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
@@ -243,7 +245,12 @@ func (s *RecordDataStorage) processContent(ctx context.Context, content *entity.
 	}
 	// 上传完整内容到 S3
 	key := EvalRecordFieldKeyPrefix + uuid.New().String()
-	if err := s.batchStorage.Upload(ctx, key, bytes.NewReader([]byte(text))); err != nil {
+	// ImageX/对象存储偶发单实例迁移会返回临时错误（如 201007 / bad gateway），系统会自动迁移恢复，重试即可成功。
+	// 这里做固定间隔的止血重试：最多 2 次重试（共 3 次尝试）、间隔 1.5s；每轮都重建 reader，避免上一轮已消费导致重传空内容。
+	data := []byte(text)
+	if err := backoff.RetryWithMaxTimesAndInterval(ctx, 2, 1500*time.Millisecond, func() error {
+		return s.batchStorage.Upload(ctx, key, bytes.NewReader(data))
+	}); err != nil {
 		return errors.WithMessagef(err, "upload field to S3, key=%s", key)
 	}
 	logs.CtxInfo(ctx, "upload successful for tos storage, key=%s", key)

--- a/backend/modules/evaluation/infra/storage/record_data.go
+++ b/backend/modules/evaluation/infra/storage/record_data.go
@@ -247,6 +247,8 @@ func (s *RecordDataStorage) processContent(ctx context.Context, content *entity.
 	key := EvalRecordFieldKeyPrefix + uuid.New().String()
 	// ImageX/对象存储偶发单实例迁移会返回临时错误（如 201007 / bad gateway），系统会自动迁移恢复，重试即可成功。
 	// 这里做固定间隔的止血重试：最多 2 次重试（共 3 次尝试）、间隔 1.5s；每轮都重建 reader，避免上一轮已消费导致重传空内容。
+	// 注意：当前对所有 error 无差别重试，未区分瞬时/永久错误——权限、参数非法等确定性失败也会重试满 3 次（额外等 ~3s）后才返回。
+	// 若后续拿到可重试错误码集合，可在闭包内对非瞬时错误用 backoff.Permanent(err) 短路。
 	data := []byte(text)
 	if err := backoff.RetryWithMaxTimesAndInterval(ctx, 2, 1500*time.Millisecond, func() error {
 		return s.batchStorage.Upload(ctx, key, bytes.NewReader(data))

--- a/backend/modules/evaluation/infra/storage/record_data_test.go
+++ b/backend/modules/evaluation/infra/storage/record_data_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/coze-dev/coze-loop/backend/infra/fileserver"
 	fsMocks "github.com/coze-dev/coze-loop/backend/infra/fileserver/mocks"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
@@ -539,7 +540,7 @@ func Test_processContent_upload_error(t *testing.T) {
 	defer ctrl.Finish()
 	mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
 
-	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload failed"))
+	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload failed")).Times(3)
 
 	cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 10}}}
 	s := &RecordDataStorage{batchStorage: mockS3, configer: &fakeConfiger{cfg: cfg}}
@@ -549,6 +550,41 @@ func Test_processContent_upload_error(t *testing.T) {
 	err := s.processContent(context.Background(), c, 10)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "upload")
+}
+
+// Test_processContent_upload_retry_success 验证偶发抖动场景：前两次 Upload 失败、第三次成功，
+// 重试后整体成功，且每轮都重建 reader（内容不会因上一轮被消费而丢失），大字段被正常剪裁上传。
+func Test_processContent_upload_retry_success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
+
+	longText := strings.Repeat("x", 100)
+	attempt := 0
+	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, r io.Reader, _ ...fileserver.UploadOpt) error {
+			attempt++
+			// 每轮 reader 都应能读到完整内容（重建 reader）
+			data, _ := io.ReadAll(r)
+			assert.Equal(t, len(longText), len(data))
+			if attempt < 3 {
+				return errors.New("bad gateway 201007")
+			}
+			return nil
+		},
+	).Times(3)
+
+	cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 10}}}
+	s := &RecordDataStorage{batchStorage: mockS3, configer: &fakeConfiger{cfg: cfg}}
+
+	c := &entity.Content{ContentType: gptr.Of(entity.ContentTypeText), Text: gptr.Of(longText)}
+	err := s.processContent(context.Background(), c, 10)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, attempt)
+	// 成功后应完成剪裁与 FullContent 设置
+	assert.True(t, c.IsContentOmitted())
+	assert.NotNil(t, c.FullContent)
+	assert.NotNil(t, c.FullContent.URI)
 }
 
 func Test_loadContentFromS3_readAll_error(t *testing.T) {
@@ -581,7 +617,7 @@ func Test_SaveEvaluatorRecordData_processInputData_error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
-	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 
 	cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 	s := NewRecordDataStorage(mockS3, &fakeConfiger{cfg: cfg})
@@ -625,7 +661,7 @@ func Test_SaveEvalTargetRecordData_processInput_error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
-	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 
 	cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 	s := NewRecordDataStorage(mockS3, &fakeConfiger{cfg: cfg})
@@ -647,7 +683,7 @@ func Test_SaveEvalTargetRecordData_processOutput_error(t *testing.T) {
 	defer ctrl.Finish()
 	mockS3 := fsMocks.NewMockBatchObjectStorage(ctrl)
 	// input "short" (5 chars) <= maxSize 5, no upload; output "longoutput" (10 chars) triggers upload
-	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err"))
+	mockS3.EXPECT().Upload(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("upload err")).Times(3)
 
 	cfg := &component.EvaluationRecordStorage{Providers: []*component.EvaluationRecordProviderConfig{{Provider: "RDS", MaxSize: 5}}}
 	s := NewRecordDataStorage(mockS3, &fakeConfiger{cfg: cfg})

--- a/backend/pkg/lang/goroutine/pool.go
+++ b/backend/pkg/lang/goroutine/pool.go
@@ -30,17 +30,29 @@ type IPool interface {
 	Add(task func() error)
 	Exec(ctx context.Context) error
 	ExecAll(ctx context.Context) error
+	// Release 释放底层 ants pool 及其常驻协程(purge / ticktock)。幂等,可多次调用。
+	// 调用方应在 NewPool 成功后立即 defer Release(),确保即使不走 Exec/ExecAll(如中途提前 return)
+	// 也能释放,避免协程泄漏。
+	Release()
 }
 
 type task = func() error
 
 type pool struct {
-	p     *ants.Pool
-	tasks []task
+	p           *ants.Pool
+	tasks       []task
+	releaseOnce sync.Once
 }
 
 func (p *pool) Add(task func() error) {
 	p.tasks = append(p.tasks, task)
+}
+
+// Release 幂等释放底层 ants pool;exec() 的 defer 与调用方的 defer 都会走到这里,sync.Once 保证只释放一次。
+func (p *pool) Release() {
+	p.releaseOnce.Do(func() {
+		p.p.Release()
+	})
 }
 
 func (p *pool) Exec(ctx context.Context) error {
@@ -52,7 +64,7 @@ func (p *pool) ExecAll(ctx context.Context) error {
 }
 
 func (p *pool) exec(ctx context.Context, ignoreErr bool) error {
-	defer p.p.Release()
+	defer p.Release()
 
 	var (
 		mu   sync.Mutex

--- a/backend/pkg/lang/goroutine/pool_test.go
+++ b/backend/pkg/lang/goroutine/pool_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -321,5 +322,58 @@ func Test_pool_execute(t *testing.T) {
 		err = p.Exec(ctx)
 		assert.Error(t, err)
 		assert.Equal(t, "test err", err.Error())
+	})
+}
+
+// TestPool_Release_WithoutExec 验证:不调用 Exec/ExecAll 而直接 Release(模拟 NewPool 后中途提前 return)
+// 也能释放底层 ants pool 及其常驻协程,避免泄漏;且 Release 幂等、与 Exec 后再 Release 不冲突。
+func TestPool_Release_WithoutExec(t *testing.T) {
+	t.Run("release without exec closes underlying ants pool", func(t *testing.T) {
+		p, err := NewPool(3)
+		assert.NoError(t, err)
+		ip := p.(*pool)
+		assert.False(t, ip.p.IsClosed(), "pool should be open right after NewPool")
+
+		// 未调用 Exec/ExecAll,直接 Release —— 这正是提前 return 场景应有的行为
+		p.Release()
+		assert.True(t, ip.p.IsClosed(), "pool must be released even without Exec/ExecAll")
+	})
+
+	t.Run("release is idempotent", func(t *testing.T) {
+		p, err := NewPool(2)
+		assert.NoError(t, err)
+		ip := p.(*pool)
+		assert.NotPanics(t, func() {
+			p.Release()
+			p.Release()
+			p.Release()
+		})
+		assert.True(t, ip.p.IsClosed())
+	})
+
+	t.Run("release after ExecAll does not double-release or panic", func(t *testing.T) {
+		p, err := NewPool(2)
+		assert.NoError(t, err)
+		ip := p.(*pool)
+		p.Add(func() error { return nil })
+		assert.NoError(t, p.ExecAll(context.Background()))
+		assert.True(t, ip.p.IsClosed(), "ExecAll should have released the pool")
+		// 调用方 defer 的 Release 再次触发,必须安全无副作用
+		assert.NotPanics(t, func() { p.Release() })
+	})
+
+	t.Run("no goroutine leak when pool released without exec", func(t *testing.T) {
+		// 基线:反复 NewPool+Release(不 Exec),协程数不应持续增长
+		time.Sleep(100 * time.Millisecond)
+		before := runtime.NumGoroutine()
+		for i := 0; i < 50; i++ {
+			p, err := NewPool(4)
+			assert.NoError(t, err)
+			p.Release()
+		}
+		time.Sleep(300 * time.Millisecond) // 等 purge/ticktock 协程随 Release 退出
+		after := runtime.NumGoroutine()
+		// 50 次 pool 若泄漏会多出 ~100 个常驻协程;正确释放后应基本持平(留少量抖动裕度)
+		assert.Less(t, after-before, 20, "goroutines should not accumulate: before=%d after=%d", before, after)
 	})
 }


### PR DESCRIPTION
Preserve signed-URL path encoding in ProcessSignURLThe experiment CSV export download link had its whole URL unescaped, which decoded the percent-encoding of the path (e.g. [, ], /, spaces, non-ASCII). That broke the signature check and corrupted the object key, so exports whose experiment name contained such characters failed to download. The path/query encoding is now passed through byte-for-byte as issued by the signing service; readable filenames are left to the download response headers.

Retry large-field upload to object storage on transient errorsLarge record fields are offloaded to object storage; the upload could fail on transient, self-healing errors. Added a fixed-interval, bounded retry helper (backoff.RetryWithMaxTimesAndInterval) and wrapped the upload with it (2 retries, 1.5s apart), rebuilding the reader on each attempt so a consumed reader never re-uploads empty content.

Use request-start time as the trajectory extraction lower bound for async targetsAsync eval targets used the record's created-at time (stamped after the async call returns) as the trace query lower bound, which dropped early spans. It now uses the request-start time, minus a 1-minute buffer, and falls back to created-at when the start time is absent.

Fix goroutine pool leak in callEvaluators on early returnWhen callEvaluators returned early (missing evaluator conf / input build failure) it skipped pool.ExecAll, so the underlying pool's resident goroutines were never released. IPool.Release() is now exposed and idempotent (sync.Once), and is deferred right after pool creation so any early return still releases it.