### PR TITLE
[feat][evaluation]: webhook 通知支持多环境泳道 header (Meego 7346083025)

### DIFF
--- a/backend/kitex_gen/coze/loop/evaluation/domain/expt/expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/expt/expt.go
@@ -343,6 +343,54 @@ func (p *SourceType) Value() (driver.Value, error) {
 	return int64(*p), nil
 }
 
+type WebhookEnvironment int64
+
+const (
+	// 默认，不加任何路由 header
+	WebhookEnvironment_Prod WebhookEnvironment = 1
+	WebhookEnvironment_PPE  WebhookEnvironment = 2
+	WebhookEnvironment_BOE  WebhookEnvironment = 3
+)
+
+func (p WebhookEnvironment) String() string {
+	switch p {
+	case WebhookEnvironment_Prod:
+		return "Prod"
+	case WebhookEnvironment_PPE:
+		return "PPE"
+	case WebhookEnvironment_BOE:
+		return "BOE"
+	}
+	return "<UNSET>"
+}
+
+func WebhookEnvironmentFromString(s string) (WebhookEnvironment, error) {
+	switch s {
+	case "Prod":
+		return WebhookEnvironment_Prod, nil
+	case "PPE":
+		return WebhookEnvironment_PPE, nil
+	case "BOE":
+		return WebhookEnvironment_BOE, nil
+	}
+	return WebhookEnvironment(0), fmt.Errorf("not a valid WebhookEnvironment string")
+}
+
+func WebhookEnvironmentPtr(v WebhookEnvironment) *WebhookEnvironment { return &v }
+func (p *WebhookEnvironment) Scan(value interface{}) (err error) {
+	var result sql.NullInt64
+	err = result.Scan(value)
+	*p = WebhookEnvironment(result.Int64)
+	return
+}
+
+func (p *WebhookEnvironment) Value() (driver.Value, error) {
+	if p == nil {
+		return nil, nil
+	}
+	return int64(*p), nil
+}
+
 type ExptRetryMode int64
 
 const (
@@ -11475,6 +11523,10 @@ type WebhookNotificationConf struct {
 	Enable bool `thrift:"enable,1,required" frugal:"1,required,bool" form:"enable,required" json:"enable,required" query:"enable,required"`
 	// Webhook URL 列表，多个用逗号分隔
 	Urls *string `thrift:"urls,2,optional" frugal:"2,optional,string" form:"urls" json:"urls,omitempty" query:"urls"`
+	// 缺省 => Prod（向后兼容）
+	Environment *WebhookEnvironment `thrift:"environment,3,optional" frugal:"3,optional,WebhookEnvironment" form:"environment" json:"environment,omitempty" query:"environment"`
+	// ppe/boe 泳道名；prod 时忽略
+	Lane *string `thrift:"lane,4,optional" frugal:"4,optional,string" form:"lane" json:"lane,omitempty" query:"lane"`
 }
 
 func NewWebhookNotificationConf() *WebhookNotificationConf {
@@ -11502,20 +11554,60 @@ func (p *WebhookNotificationConf) GetUrls() (v string) {
 	}
 	return *p.Urls
 }
+
+var WebhookNotificationConf_Environment_DEFAULT WebhookEnvironment
+
+func (p *WebhookNotificationConf) GetEnvironment() (v WebhookEnvironment) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetEnvironment() {
+		return WebhookNotificationConf_Environment_DEFAULT
+	}
+	return *p.Environment
+}
+
+var WebhookNotificationConf_Lane_DEFAULT string
+
+func (p *WebhookNotificationConf) GetLane() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetLane() {
+		return WebhookNotificationConf_Lane_DEFAULT
+	}
+	return *p.Lane
+}
 func (p *WebhookNotificationConf) SetEnable(val bool) {
 	p.Enable = val
 }
 func (p *WebhookNotificationConf) SetUrls(val *string) {
 	p.Urls = val
 }
+func (p *WebhookNotificationConf) SetEnvironment(val *WebhookEnvironment) {
+	p.Environment = val
+}
+func (p *WebhookNotificationConf) SetLane(val *string) {
+	p.Lane = val
+}
 
 var fieldIDToName_WebhookNotificationConf = map[int16]string{
 	1: "enable",
 	2: "urls",
+	3: "environment",
+	4: "lane",
 }
 
 func (p *WebhookNotificationConf) IsSetUrls() bool {
 	return p.Urls != nil
+}
+
+func (p *WebhookNotificationConf) IsSetEnvironment() bool {
+	return p.Environment != nil
+}
+
+func (p *WebhookNotificationConf) IsSetLane() bool {
+	return p.Lane != nil
 }
 
 func (p *WebhookNotificationConf) Read(iprot thrift.TProtocol) (err error) {
@@ -11549,6 +11641,22 @@ func (p *WebhookNotificationConf) Read(iprot thrift.TProtocol) (err error) {
 		case 2:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 3:
+			if fieldTypeId == thrift.I32 {
+				if err = p.ReadField3(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 4:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField4(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -11611,6 +11719,29 @@ func (p *WebhookNotificationConf) ReadField2(iprot thrift.TProtocol) error {
 	p.Urls = _field
 	return nil
 }
+func (p *WebhookNotificationConf) ReadField3(iprot thrift.TProtocol) error {
+
+	var _field *WebhookEnvironment
+	if v, err := iprot.ReadI32(); err != nil {
+		return err
+	} else {
+		tmp := WebhookEnvironment(v)
+		_field = &tmp
+	}
+	p.Environment = _field
+	return nil
+}
+func (p *WebhookNotificationConf) ReadField4(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Lane = _field
+	return nil
+}
 
 func (p *WebhookNotificationConf) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -11624,6 +11755,14 @@ func (p *WebhookNotificationConf) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField2(oprot); err != nil {
 			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField3(oprot); err != nil {
+			fieldId = 3
+			goto WriteFieldError
+		}
+		if err = p.writeField4(oprot); err != nil {
+			fieldId = 4
 			goto WriteFieldError
 		}
 	}
@@ -11678,6 +11817,42 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
 }
+func (p *WebhookNotificationConf) writeField3(oprot thrift.TProtocol) (err error) {
+	if p.IsSetEnvironment() {
+		if err = oprot.WriteFieldBegin("environment", thrift.I32, 3); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI32(int32(*p.Environment)); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 3 end error: ", p), err)
+}
+func (p *WebhookNotificationConf) writeField4(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLane() {
+		if err = oprot.WriteFieldBegin("lane", thrift.STRING, 4); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Lane); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 4 end error: ", p), err)
+}
 
 func (p *WebhookNotificationConf) String() string {
 	if p == nil {
@@ -11699,6 +11874,12 @@ func (p *WebhookNotificationConf) DeepEqual(ano *WebhookNotificationConf) bool {
 	if !p.Field2DeepEqual(ano.Urls) {
 		return false
 	}
+	if !p.Field3DeepEqual(ano.Environment) {
+		return false
+	}
+	if !p.Field4DeepEqual(ano.Lane) {
+		return false
+	}
 	return true
 }
 
@@ -11717,6 +11898,30 @@ func (p *WebhookNotificationConf) Field2DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.Urls, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *WebhookNotificationConf) Field3DeepEqual(src *WebhookEnvironment) bool {
+
+	if p.Environment == src {
+		return true
+	} else if p.Environment == nil || src == nil {
+		return false
+	}
+	if *p.Environment != *src {
+		return false
+	}
+	return true
+}
+func (p *WebhookNotificationConf) Field4DeepEqual(src *string) bool {
+
+	if p.Lane == src {
+		return true
+	} else if p.Lane == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Lane, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/domain/expt/k-expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/expt/k-expt.go
@@ -7598,6 +7598,34 @@ func (p *WebhookNotificationConf) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 3:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField3(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 4:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField4(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -7650,6 +7678,36 @@ func (p *WebhookNotificationConf) FastReadField2(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *WebhookNotificationConf) FastReadField3(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *WebhookEnvironment
+	if v, l, err := thrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+
+		tmp := WebhookEnvironment(v)
+		_field = &tmp
+	}
+	p.Environment = _field
+	return offset, nil
+}
+
+func (p *WebhookNotificationConf) FastReadField4(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.Lane = _field
+	return offset, nil
+}
+
 func (p *WebhookNotificationConf) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -7659,6 +7717,8 @@ func (p *WebhookNotificationConf) FastWriteNocopy(buf []byte, w thrift.NocopyWri
 	if p != nil {
 		offset += p.fastWriteField1(buf[offset:], w)
 		offset += p.fastWriteField2(buf[offset:], w)
+		offset += p.fastWriteField3(buf[offset:], w)
+		offset += p.fastWriteField4(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
 	return offset
@@ -7669,6 +7729,8 @@ func (p *WebhookNotificationConf) BLength() int {
 	if p != nil {
 		l += p.field1Length()
 		l += p.field2Length()
+		l += p.field3Length()
+		l += p.field4Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -7690,6 +7752,24 @@ func (p *WebhookNotificationConf) fastWriteField2(buf []byte, w thrift.NocopyWri
 	return offset
 }
 
+func (p *WebhookNotificationConf) fastWriteField3(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetEnvironment() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I32, 3)
+		offset += thrift.Binary.WriteI32(buf[offset:], int32(*p.Environment))
+	}
+	return offset
+}
+
+func (p *WebhookNotificationConf) fastWriteField4(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetLane() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 4)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.Lane)
+	}
+	return offset
+}
+
 func (p *WebhookNotificationConf) field1Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
@@ -7702,6 +7782,24 @@ func (p *WebhookNotificationConf) field2Length() int {
 	if p.IsSetUrls() {
 		l += thrift.Binary.FieldBeginLength()
 		l += thrift.Binary.StringLengthNocopy(*p.Urls)
+	}
+	return l
+}
+
+func (p *WebhookNotificationConf) field3Length() int {
+	l := 0
+	if p.IsSetEnvironment() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I32Length()
+	}
+	return l
+}
+
+func (p *WebhookNotificationConf) field4Length() int {
+	l := 0
+	if p.IsSetLane() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.Lane)
 	}
 	return l
 }
@@ -7720,6 +7818,19 @@ func (p *WebhookNotificationConf) DeepCopy(s interface{}) error {
 			tmp = kutils.StringDeepCopy(*src.Urls)
 		}
 		p.Urls = &tmp
+	}
+
+	if src.Environment != nil {
+		tmp := *src.Environment
+		p.Environment = &tmp
+	}
+
+	if src.Lane != nil {
+		var tmp string
+		if *src.Lane != "" {
+			tmp = kutils.StringDeepCopy(*src.Lane)
+		}
+		p.Lane = &tmp
 	}
 
 	return nil

--- a/backend/modules/evaluation/application/convertor/experiment/expt.go
+++ b/backend/modules/evaluation/application/convertor/experiment/expt.go
@@ -636,8 +636,10 @@ func NotificationConfDTO2DO(conf *domain_expt.ExptNotificationConf) (*entity.Exp
 	}
 	if conf.Webhook != nil {
 		result.Webhook = &entity.WebhookNotificationConf{
-			Enable: conf.Webhook.Enable,
-			Urls:   conf.Webhook.Urls,
+			Enable:      conf.Webhook.Enable,
+			Urls:        conf.Webhook.Urls,
+			Environment: webhookEnvironmentDTO2Domain(conf.Webhook.Environment),
+			Lane:        conf.Webhook.Lane,
 		}
 	}
 	if conf.FeishuNotification != nil {
@@ -647,6 +649,25 @@ func NotificationConfDTO2DO(conf *domain_expt.ExptNotificationConf) (*entity.Exp
 		}
 	}
 	return result, nil
+}
+
+// webhookEnvironmentDTO2Domain 将 IDL 生成的 WebhookEnvironment 指针转换为领域枚举指针。
+// nil 透传 nil（=> 领域侧按 Prod 处理，向后兼容）。
+func webhookEnvironmentDTO2Domain(env *domain_expt.WebhookEnvironment) *entity.WebhookEnvironment {
+	if env == nil {
+		return nil
+	}
+	de := entity.WebhookEnvironment(*env)
+	return &de
+}
+
+// webhookEnvironmentDomain2DTO 将领域枚举指针转换回 IDL 生成的 WebhookEnvironment 指针。
+func webhookEnvironmentDomain2DTO(env *entity.WebhookEnvironment) *domain_expt.WebhookEnvironment {
+	if env == nil {
+		return nil
+	}
+	de := domain_expt.WebhookEnvironment(*env)
+	return &de
 }
 
 func validateNotificationOperator(op entity.NotificationOperatorType) error {
@@ -715,8 +736,10 @@ func notificationConfDO2DTO(conf *entity.ExptNotificationConf) *domain_expt.Expt
 	}
 	if conf.Webhook != nil {
 		result.Webhook = &domain_expt.WebhookNotificationConf{
-			Enable: conf.Webhook.Enable,
-			Urls:   conf.Webhook.Urls,
+			Enable:      conf.Webhook.Enable,
+			Urls:        conf.Webhook.Urls,
+			Environment: webhookEnvironmentDomain2DTO(conf.Webhook.Environment),
+			Lane:        conf.Webhook.Lane,
 		}
 	}
 	if conf.FeishuNotification != nil {

--- a/backend/modules/evaluation/domain/entity/event.go
+++ b/backend/modules/evaluation/domain/entity/event.go
@@ -214,6 +214,10 @@ type WebhookRetryEvent struct {
 	WebhookURL string `json:"webhook_url"`
 	Payload    string `json:"payload"`     // JSON string of the webhook body
 	AttemptNum int    `json:"attempt_num"` // 当前第几次重试 (1/2/3)
+	// Environment / Lane 携带首发时的环境语义，保证重试请求附加相同的泳道路由 header。
+	// 旧消息（无此字段）反序列化后为 nil => 按 Prod 处理，向后兼容不 panic。
+	Environment *WebhookEnvironment `json:"environment,omitempty"`
+	Lane        *string             `json:"lane,omitempty"`
 }
 
 type ExportScene int

--- a/backend/modules/evaluation/domain/entity/notification.go
+++ b/backend/modules/evaluation/domain/entity/notification.go
@@ -51,10 +51,24 @@ const (
 	NotificationOperatorType_NotIn    NotificationOperatorType = 8 // 不包含于
 )
 
+// WebhookEnvironment Webhook 目标环境（决定是否附加泳道路由 header）
+// 取值与 IDL enum WebhookEnvironment 对齐：Prod=1 / PPE=2 / BOE=3。
+type WebhookEnvironment int64
+
+const (
+	WebhookEnvironment_Prod WebhookEnvironment = 1 // 默认，不加任何路由 header
+	WebhookEnvironment_PPE  WebhookEnvironment = 2
+	WebhookEnvironment_BOE  WebhookEnvironment = 3
+)
+
 // WebhookNotificationConf Webhook 通知配置
 type WebhookNotificationConf struct {
 	Enable bool    `json:"enable"`
 	Urls   *string `json:"urls,omitempty"`
+	// Environment 缺省（nil）=> Prod（向后兼容，历史数据反序列化为未设置）
+	Environment *WebhookEnvironment `json:"environment,omitempty"`
+	// Lane ppe/boe 泳道名；prod / 未设置时忽略
+	Lane *string `json:"lane,omitempty"`
 }
 
 // FeishuNotificationConf 飞书通知配置

--- a/backend/modules/evaluation/domain/service/webhook_dispatcher.go
+++ b/backend/modules/evaluation/domain/service/webhook_dispatcher.go
@@ -121,16 +121,18 @@ func (d *WebhookDispatcher) Dispatch(ctx context.Context, event *entity.ExptLife
 
 	// 逐个调用 Webhook URL
 	for _, url := range urls {
-		if err := d.doPost(ctx, url, payloadBytes, timestamp, nonce, signature); err != nil {
+		if err := d.doPost(ctx, url, payloadBytes, timestamp, nonce, signature, webhook.Environment, webhook.Lane); err != nil {
 			logs.CtxError(ctx, "webhook_dispatcher: post failed, url: %v, expt_id: %v, err: %v", url, expt.ID, err)
 			// 发布重试事件
 			retryEvent := &entity.WebhookRetryEvent{
-				ExptID:     expt.ID,
-				SpaceID:    expt.SpaceID,
-				DeliveryID: deliveryID,
-				WebhookURL: url,
-				Payload:    payloadStr,
-				AttemptNum: 1,
+				ExptID:      expt.ID,
+				SpaceID:     expt.SpaceID,
+				DeliveryID:  deliveryID,
+				WebhookURL:  url,
+				Payload:     payloadStr,
+				AttemptNum:  1,
+				Environment: webhook.Environment,
+				Lane:        webhook.Lane,
 			}
 			retryDuration := 1 * time.Minute
 			if pubErr := d.publisher.PublishExptWebhookNotifyEvent(ctx, retryEvent, &retryDuration); pubErr != nil {
@@ -142,7 +144,7 @@ func (d *WebhookDispatcher) Dispatch(ctx context.Context, event *entity.ExptLife
 	return nil
 }
 
-func (d *WebhookDispatcher) doPost(ctx context.Context, url string, body []byte, timestamp, nonce, signature string) error {
+func (d *WebhookDispatcher) doPost(ctx context.Context, url string, body []byte, timestamp, nonce, signature string, env *entity.WebhookEnvironment, lane *string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
@@ -152,6 +154,11 @@ func (d *WebhookDispatcher) doPost(ctx context.Context, url string, body []byte,
 	req.Header.Set("X-CozeLoop-Timestamp", timestamp)
 	req.Header.Set("X-CozeLoop-Nonce", nonce)
 	req.Header.Set("X-CozeLoop-Signature", signature)
+
+	// 按环境附加泳道路由 header（在安全 header 之后，key 不冲突，不覆盖安全 header）
+	for k, v := range BuildLaneHeaders(env, lane) {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := d.httpClient.Do(req)
 	if err != nil {
@@ -164,6 +171,43 @@ func (d *WebhookDispatcher) doPost(ctx context.Context, url string, body []byte,
 		return fmt.Errorf("webhook returned non-2xx status: %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// BuildLaneHeaders 根据 webhook 目标环境与泳道名计算需附加的路由 header。
+// 首发（webhook_dispatcher）与重试（webhook_retry consumer）两处共用同一实现。
+//
+// 规则（design D3）：
+//   - PPE：{"x-tt-env": <lane>, "x-use-ppe": "1"}
+//   - BOE：{"x-tt-env": <lane>}
+//   - Prod / 未设置（nil）：无（返回 nil）
+//
+// 防御：env 为 PPE/BOE 但 lane 为 nil / 空 / trim 后为空时，保守降级为不产出
+// x-tt-env（返回空 map），避免发出空泳道头把请求打偏，且不 panic。
+func BuildLaneHeaders(env *entity.WebhookEnvironment, lane *string) map[string]string {
+	// Prod 或未设置：不加任何路由 header
+	if env == nil || *env == entity.WebhookEnvironment_Prod {
+		return nil
+	}
+
+	switch *env {
+	case entity.WebhookEnvironment_PPE, entity.WebhookEnvironment_BOE:
+		// 防御：lane 缺失或空白 -> 保守降级，不产出 x-tt-env
+		if lane == nil {
+			return map[string]string{}
+		}
+		laneVal := strings.TrimSpace(*lane)
+		if laneVal == "" {
+			return map[string]string{}
+		}
+		headers := map[string]string{"x-tt-env": laneVal}
+		if *env == entity.WebhookEnvironment_PPE {
+			headers["x-use-ppe"] = "1"
+		}
+		return headers
+	default:
+		// 未知环境值：保守不加路由 header
+		return nil
+	}
 }
 
 // computeHMACSHA256 计算 HMAC-SHA256 签名，返回 hex 编码

--- a/backend/modules/evaluation/domain/service/webhook_dispatcher_test.go
+++ b/backend/modules/evaluation/domain/service/webhook_dispatcher_test.go
@@ -348,6 +348,45 @@ func TestWebhookDispatcher_Dispatch_BitsUT(t *testing.T) {
 		err := d.Dispatch(context.Background(), event, expt)
 		assert.NoError(t, err)
 	})
+
+	t.Run("ppe conf -> request carries x-tt-env + x-use-ppe (end-to-end)", func(t *testing.T) {
+		t.Parallel()
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		var capturedHeaders http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedHeaders = r.Header.Clone()
+			w.WriteHeader(200)
+		}))
+		defer server.Close()
+
+		ppe := entity.WebhookEnvironment_PPE
+		d := NewWebhookDispatcher(mocks.NewMockExptEventPublisher(ctrl), NewNoopWebhookSecretProvider(), nil)
+		expt := &entity.Experiment{
+			ID: 42, SpaceID: 100, Name: "ppe-lane-test",
+			NotificationConf: &entity.ExptNotificationConf{
+				Webhook: &entity.WebhookNotificationConf{
+					Enable:      true,
+					Urls:        gptr.Of(server.URL),
+					Environment: &ppe,
+					Lane:        gptr.Of("ppe_lane_e2e"),
+				},
+			},
+		}
+		event := &entity.ExptLifecycleEvent{
+			ExptID: 42, SpaceID: 100, ExptRunID: gptr.Of(int64(7)),
+			FromStatus: entity.ExptStatus_Processing, ToStatus: entity.ExptStatus_Success,
+			IdempotentKey: "expt_42_7_3_11",
+		}
+
+		err := d.Dispatch(context.Background(), event, expt)
+		assert.NoError(t, err)
+		// 端到端：真实 HTTP 请求带上了泳道路由 header，且未破坏既有安全 header
+		assert.Equal(t, "ppe_lane_e2e", capturedHeaders.Get("x-tt-env"))
+		assert.Equal(t, "1", capturedHeaders.Get("x-use-ppe"))
+		assert.NotEmpty(t, capturedHeaders.Get("X-CozeLoop-Signature"))
+	})
 }
 
 func TestMapExptStatusToEventType_BitsUT(t *testing.T) {

--- a/backend/modules/evaluation/domain/service/webhook_dispatcher_test.go
+++ b/backend/modules/evaluation/domain/service/webhook_dispatcher_test.go
@@ -370,3 +370,56 @@ func TestMapExptStatusToEventType_BitsUT(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildLaneHeaders_BitsUT(t *testing.T) {
+	t.Parallel()
+
+	ppe := entity.WebhookEnvironment_PPE
+	boe := entity.WebhookEnvironment_BOE
+	prod := entity.WebhookEnvironment_Prod
+
+	t.Run("ppe with lane -> x-tt-env + x-use-ppe", func(t *testing.T) {
+		t.Parallel()
+		h := BuildLaneHeaders(&ppe, gptr.Of("ppe_lane_1"))
+		assert.Equal(t, "ppe_lane_1", h["x-tt-env"])
+		assert.Equal(t, "1", h["x-use-ppe"])
+		assert.Len(t, h, 2)
+	})
+
+	t.Run("boe with lane -> x-tt-env only", func(t *testing.T) {
+		t.Parallel()
+		h := BuildLaneHeaders(&boe, gptr.Of("boe_lane_2"))
+		assert.Equal(t, "boe_lane_2", h["x-tt-env"])
+		_, hasPPE := h["x-use-ppe"]
+		assert.False(t, hasPPE)
+		assert.Len(t, h, 1)
+	})
+
+	t.Run("prod -> no routing header", func(t *testing.T) {
+		t.Parallel()
+		h := BuildLaneHeaders(&prod, gptr.Of("ignored_lane"))
+		assert.Empty(t, h)
+	})
+
+	t.Run("nil env (未设置/历史数据) -> no routing header, no panic", func(t *testing.T) {
+		t.Parallel()
+		h := BuildLaneHeaders(nil, gptr.Of("some_lane"))
+		assert.Empty(t, h)
+	})
+
+	t.Run("ppe but lane nil -> defensive downgrade, no x-tt-env, no panic", func(t *testing.T) {
+		t.Parallel()
+		h := BuildLaneHeaders(&ppe, nil)
+		_, has := h["x-tt-env"]
+		assert.False(t, has)
+		assert.Empty(t, h)
+	})
+
+	t.Run("ppe but lane empty/whitespace -> defensive downgrade", func(t *testing.T) {
+		t.Parallel()
+		h := BuildLaneHeaders(&ppe, gptr.Of("   "))
+		_, has := h["x-tt-env"]
+		assert.False(t, has)
+		assert.Empty(t, h)
+	})
+}

--- a/backend/modules/evaluation/infra/mq/rocket/consumer/webhook_retry.go
+++ b/backend/modules/evaluation/infra/mq/rocket/consumer/webhook_retry.go
@@ -72,18 +72,20 @@ func (c *WebhookRetryConsumer) HandleMessage(ctx context.Context, msg *mq.Messag
 	signature := computeRetryHMACSHA256(secret, timestamp+"\n"+nonce+"\n")
 
 	// HTTP POST
-	if err := c.doPost(ctx, event.WebhookURL, []byte(event.Payload), timestamp, nonce, signature); err != nil {
+	if err := c.doPost(ctx, event.WebhookURL, []byte(event.Payload), timestamp, nonce, signature, event.Environment, event.Lane); err != nil {
 		logs.CtxWarn(ctx, "[WebhookRetryConsumer] retry attempt %d failed, url: %v, err: %v", event.AttemptNum, event.WebhookURL, err)
 
 		// 如果还有重试机会，发布下一次重试
 		if event.AttemptNum < len(retryDelays) {
 			nextEvent := &entity.WebhookRetryEvent{
-				ExptID:     event.ExptID,
-				SpaceID:    event.SpaceID,
-				DeliveryID: event.DeliveryID,
-				WebhookURL: event.WebhookURL,
-				Payload:    event.Payload,
-				AttemptNum: event.AttemptNum + 1,
+				ExptID:      event.ExptID,
+				SpaceID:     event.SpaceID,
+				DeliveryID:  event.DeliveryID,
+				WebhookURL:  event.WebhookURL,
+				Payload:     event.Payload,
+				AttemptNum:  event.AttemptNum + 1,
+				Environment: event.Environment,
+				Lane:        event.Lane,
 			}
 			delay := retryDelays[event.AttemptNum] // AttemptNum 从 1 开始，索引 [1] = 5min, [2] = 30min
 			if pubErr := c.publisher.PublishExptWebhookNotifyEvent(ctx, nextEvent, &delay); pubErr != nil {
@@ -101,7 +103,7 @@ func (c *WebhookRetryConsumer) HandleMessage(ctx context.Context, msg *mq.Messag
 	return nil
 }
 
-func (c *WebhookRetryConsumer) doPost(ctx context.Context, url string, body []byte, timestamp, nonce, signature string) error {
+func (c *WebhookRetryConsumer) doPost(ctx context.Context, url string, body []byte, timestamp, nonce, signature string, env *entity.WebhookEnvironment, lane *string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
 		return err
@@ -111,6 +113,11 @@ func (c *WebhookRetryConsumer) doPost(ctx context.Context, url string, body []by
 	req.Header.Set("X-CozeLoop-Timestamp", timestamp)
 	req.Header.Set("X-CozeLoop-Nonce", nonce)
 	req.Header.Set("X-CozeLoop-Signature", signature)
+
+	// 按环境附加泳道路由 header，与首发共用 service.BuildLaneHeaders（在安全 header 之后 set，不覆盖安全 header）
+	for k, v := range service.BuildLaneHeaders(env, lane) {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/idl/thrift/coze/loop/evaluation/domain/expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/domain/expt.thrift
@@ -262,9 +262,17 @@ struct ExptNotificationConf {
     11: optional FeishuNotificationConf feishu_notification
 }
 
+enum WebhookEnvironment {
+    Prod = 1   // 默认，不加任何路由 header
+    PPE  = 2
+    BOE  = 3
+}
+
 struct WebhookNotificationConf {
     1: required bool enable
     2: optional string urls             // Webhook URL 列表，多个用逗号分隔
+    3: optional WebhookEnvironment environment  // 缺省 => Prod（向后兼容）
+    4: optional string lane                     // ppe/boe 泳道名；prod 时忽略
 }
 
 struct FeishuNotificationConf {


### PR DESCRIPTION
## 背景 / Motivation

  来自 oncall（Meego 7346083025）：创建实验第四步的 Webhook 通知渠道，webhook 请求默认打到线上，用户在 ppe/boe 环境部署的接收端点收不到通知，无法联调。

  本 PR 让 webhook 支持按环境路由——用户可为 webhook 渠道选择目标环境（Prod/PPE/BOE）+ 泳道名，后端发送 webhook 时按环境附加泳道
  header，使请求可路由到对应环境的接收端点。

  ## 改动 / What Changes

  - **IDL** (`idl/thrift/coze/loop/evaluation/domain/expt.thrift`)：`WebhookNotificationConf` 新增 `environment`（枚举 `WebhookEnvironment`:
  Prod=1/PPE=2/BOE=3）与 `lane`（string）两个 optional 字段，向后兼容（缺省视为 Prod）。
  - **后端发送** (`domain/service/webhook_dispatcher.go`)：新增纯函数 `BuildLaneHeaders(env, lane)`，在首发 `doPost` 与重试 `webhook_retry.go`
  两处、于既有安全 header（Content-Type / X-CozeLoop-*）之后附加泳道路由 header：
    - PPE → `x-tt-env: <lane>` + `x-use-ppe: 1`
    - BOE → `x-tt-env: <lane>`
    - Prod / 未设置 → 不加（行为与现状一致）
    - 防御：ppe/boe 但 lane 为空时不产出 `x-tt-env`（保守降级，不发脏 header）。
  - **重试语义**：`WebhookRetryEvent` 扩展 environment/lane 字段，保证失败重试保持与首发相同的环境路由（旧消息缺字段时按 Prod 兼容）。
  - **DTO/entity 转换** (`application/convertor/experiment/expt.go`, `domain/entity/notification.go`)：补 environment/lane 的映射与持久化字段。
  - **单测** (`webhook_dispatcher_test.go`)：`BuildLaneHeaders` 覆盖 ppe/boe/prod/nil/空 lane 5 分支；新增端到端 mock httptest server 测试，验证配 PPE
  conf 时真实 HTTP 请求携带 `x-tt-env` + `x-use-ppe`，且不破坏安全 header。

  ## 测试 / Verification

  - 单测：`go test ./modules/evaluation/domain/service/... -run 'Webhook|LaneHeaders'` 全部通过（含端到端 mock server 验请求头）。
  - PPE 泳道端到端实测：真实创建 PPE webhook 实验 → 服务端进 PPE 泳道（实验日志 `_env=ppe_xxx`）→ webhook 从泳道 dispatch →
  接收端（webhook.site）收到干净的 `x-tt-env: ppe_xxx` + `x-use-ppe: 1`，全链路验证通过。
  - 向后兼容：历史 webhook 配置（无 environment/lane）反序列化按 Prod 处理，不加 header、不报错。

  ## 关联

  - Meego: https://meego.larkoffice.com/fornax/story/detail/7346083025
  - 配套改动：commercial 侧升级依赖到本 PR 合入后的 commit；前端（obric/coze-loop）第四步环境选择器 UI 单独 MR。