### PR TITLE
[feat][backend]: add logid param to GetTrace API

### DIFF
--- a/backend/kitex_gen/coze/loop/observability/trace/coze.loop.observability.trace.go
+++ b/backend/kitex_gen/coze/loop/observability/trace/coze.loop.observability.trace.go
@@ -2722,12 +2722,13 @@ func (p *TraceAdvanceInfo) Field2DeepEqual(src *TokenCost) bool {
 }
 
 type GetTraceRequest struct {
-	WorkspaceID int64  `thrift:"workspace_id,1,required" frugal:"1,required,i64" json:"workspace_id" query:"workspace_id,required" `
-	TraceID     string `thrift:"trace_id,2,required" frugal:"2,required,string" json:"trace_id,required" path:"trace_id,required"`
+	WorkspaceID int64   `thrift:"workspace_id,1,required" frugal:"1,required,i64" json:"workspace_id" query:"workspace_id,required" `
+	TraceID     *string `thrift:"trace_id,2,optional" frugal:"2,optional,string" json:"trace_id,omitempty" path:"trace_id"`
 	// ms
 	StartTime int64 `thrift:"start_time,3,required" frugal:"3,required,i64" json:"start_time" query:"start_time,required" `
 	// ms
 	EndTime      int64                `thrift:"end_time,4,required" frugal:"4,required,i64" json:"end_time" query:"end_time,required" `
+	Logid        *string              `thrift:"logid,5,optional" frugal:"5,optional,string" json:"logid,omitempty" query:"logid"`
 	PlatformType *common.PlatformType `thrift:"platform_type,8,optional" frugal:"8,optional,string" json:"platform_type,omitempty" query:"platform_type"`
 	SpanIds      []string             `thrift:"span_ids,9,optional" frugal:"9,optional,list<string>" json:"span_ids,omitempty" query:"span_ids"`
 	Filters      *filter.FilterFields `thrift:"filters,10,optional" frugal:"10,optional,filter.FilterFields" json:"filters,omitempty" query:"filters"`
@@ -2750,11 +2751,16 @@ func (p *GetTraceRequest) GetWorkspaceID() (v int64) {
 	return
 }
 
+var GetTraceRequest_TraceID_DEFAULT string
+
 func (p *GetTraceRequest) GetTraceID() (v string) {
-	if p != nil {
-		return p.TraceID
+	if p == nil {
+		return
 	}
-	return
+	if !p.IsSetTraceID() {
+		return GetTraceRequest_TraceID_DEFAULT
+	}
+	return *p.TraceID
 }
 
 func (p *GetTraceRequest) GetStartTime() (v int64) {
@@ -2769,6 +2775,18 @@ func (p *GetTraceRequest) GetEndTime() (v int64) {
 		return p.EndTime
 	}
 	return
+}
+
+var GetTraceRequest_Logid_DEFAULT string
+
+func (p *GetTraceRequest) GetLogid() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetLogid() {
+		return GetTraceRequest_Logid_DEFAULT
+	}
+	return *p.Logid
 }
 
 var GetTraceRequest_PlatformType_DEFAULT common.PlatformType
@@ -2845,7 +2863,7 @@ func (p *GetTraceRequest) GetBase() (v *base.Base) {
 func (p *GetTraceRequest) SetWorkspaceID(val int64) {
 	p.WorkspaceID = val
 }
-func (p *GetTraceRequest) SetTraceID(val string) {
+func (p *GetTraceRequest) SetTraceID(val *string) {
 	p.TraceID = val
 }
 func (p *GetTraceRequest) SetStartTime(val int64) {
@@ -2853,6 +2871,9 @@ func (p *GetTraceRequest) SetStartTime(val int64) {
 }
 func (p *GetTraceRequest) SetEndTime(val int64) {
 	p.EndTime = val
+}
+func (p *GetTraceRequest) SetLogid(val *string) {
+	p.Logid = val
 }
 func (p *GetTraceRequest) SetPlatformType(val *common.PlatformType) {
 	p.PlatformType = val
@@ -2878,12 +2899,21 @@ var fieldIDToName_GetTraceRequest = map[int16]string{
 	2:   "trace_id",
 	3:   "start_time",
 	4:   "end_time",
+	5:   "logid",
 	8:   "platform_type",
 	9:   "span_ids",
 	10:  "filters",
 	11:  "page_size",
 	12:  "page_token",
 	255: "Base",
+}
+
+func (p *GetTraceRequest) IsSetTraceID() bool {
+	return p.TraceID != nil
+}
+
+func (p *GetTraceRequest) IsSetLogid() bool {
+	return p.Logid != nil
 }
 
 func (p *GetTraceRequest) IsSetPlatformType() bool {
@@ -2914,7 +2944,6 @@ func (p *GetTraceRequest) Read(iprot thrift.TProtocol) (err error) {
 	var fieldTypeId thrift.TType
 	var fieldId int16
 	var issetWorkspaceID bool = false
-	var issetTraceID bool = false
 	var issetStartTime bool = false
 	var issetEndTime bool = false
 
@@ -2946,7 +2975,6 @@ func (p *GetTraceRequest) Read(iprot thrift.TProtocol) (err error) {
 				if err = p.ReadField2(iprot); err != nil {
 					goto ReadFieldError
 				}
-				issetTraceID = true
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
 				goto SkipFieldError
 			}
@@ -2965,6 +2993,14 @@ func (p *GetTraceRequest) Read(iprot thrift.TProtocol) (err error) {
 					goto ReadFieldError
 				}
 				issetEndTime = true
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 5:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField5(iprot); err != nil {
+					goto ReadFieldError
+				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
 				goto SkipFieldError
 			}
@@ -3034,11 +3070,6 @@ func (p *GetTraceRequest) Read(iprot thrift.TProtocol) (err error) {
 		goto RequiredFieldNotSetError
 	}
 
-	if !issetTraceID {
-		fieldId = 2
-		goto RequiredFieldNotSetError
-	}
-
 	if !issetStartTime {
 		fieldId = 3
 		goto RequiredFieldNotSetError
@@ -3079,11 +3110,11 @@ func (p *GetTraceRequest) ReadField1(iprot thrift.TProtocol) error {
 }
 func (p *GetTraceRequest) ReadField2(iprot thrift.TProtocol) error {
 
-	var _field string
+	var _field *string
 	if v, err := iprot.ReadString(); err != nil {
 		return err
 	} else {
-		_field = v
+		_field = &v
 	}
 	p.TraceID = _field
 	return nil
@@ -3108,6 +3139,17 @@ func (p *GetTraceRequest) ReadField4(iprot thrift.TProtocol) error {
 		_field = v
 	}
 	p.EndTime = _field
+	return nil
+}
+func (p *GetTraceRequest) ReadField5(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Logid = _field
 	return nil
 }
 func (p *GetTraceRequest) ReadField8(iprot thrift.TProtocol) error {
@@ -3205,6 +3247,10 @@ func (p *GetTraceRequest) Write(oprot thrift.TProtocol) (err error) {
 			fieldId = 4
 			goto WriteFieldError
 		}
+		if err = p.writeField5(oprot); err != nil {
+			fieldId = 5
+			goto WriteFieldError
+		}
 		if err = p.writeField8(oprot); err != nil {
 			fieldId = 8
 			goto WriteFieldError
@@ -3264,14 +3310,16 @@ WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
 }
 func (p *GetTraceRequest) writeField2(oprot thrift.TProtocol) (err error) {
-	if err = oprot.WriteFieldBegin("trace_id", thrift.STRING, 2); err != nil {
-		goto WriteFieldBeginError
-	}
-	if err := oprot.WriteString(p.TraceID); err != nil {
-		return err
-	}
-	if err = oprot.WriteFieldEnd(); err != nil {
-		goto WriteFieldEndError
+	if p.IsSetTraceID() {
+		if err = oprot.WriteFieldBegin("trace_id", thrift.STRING, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.TraceID); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
 	}
 	return nil
 WriteFieldBeginError:
@@ -3310,6 +3358,24 @@ WriteFieldBeginError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 4 begin error: ", p), err)
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 4 end error: ", p), err)
+}
+func (p *GetTraceRequest) writeField5(oprot thrift.TProtocol) (err error) {
+	if p.IsSetLogid() {
+		if err = oprot.WriteFieldBegin("logid", thrift.STRING, 5); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Logid); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 5 end error: ", p), err)
 }
 func (p *GetTraceRequest) writeField8(oprot thrift.TProtocol) (err error) {
 	if p.IsSetPlatformType() {
@@ -3454,6 +3520,9 @@ func (p *GetTraceRequest) DeepEqual(ano *GetTraceRequest) bool {
 	if !p.Field4DeepEqual(ano.EndTime) {
 		return false
 	}
+	if !p.Field5DeepEqual(ano.Logid) {
+		return false
+	}
 	if !p.Field8DeepEqual(ano.PlatformType) {
 		return false
 	}
@@ -3482,9 +3551,14 @@ func (p *GetTraceRequest) Field1DeepEqual(src int64) bool {
 	}
 	return true
 }
-func (p *GetTraceRequest) Field2DeepEqual(src string) bool {
+func (p *GetTraceRequest) Field2DeepEqual(src *string) bool {
 
-	if strings.Compare(p.TraceID, src) != 0 {
+	if p.TraceID == src {
+		return true
+	} else if p.TraceID == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.TraceID, *src) != 0 {
 		return false
 	}
 	return true
@@ -3499,6 +3573,18 @@ func (p *GetTraceRequest) Field3DeepEqual(src int64) bool {
 func (p *GetTraceRequest) Field4DeepEqual(src int64) bool {
 
 	if p.EndTime != src {
+		return false
+	}
+	return true
+}
+func (p *GetTraceRequest) Field5DeepEqual(src *string) bool {
+
+	if p.Logid == src {
+		return true
+	} else if p.Logid == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Logid, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/observability/trace/k-coze.loop.observability.trace.go
+++ b/backend/kitex_gen/coze/loop/observability/trace/k-coze.loop.observability.trace.go
@@ -2059,7 +2059,6 @@ func (p *GetTraceRequest) FastRead(buf []byte) (int, error) {
 	var fieldTypeId thrift.TType
 	var fieldId int16
 	var issetWorkspaceID bool = false
-	var issetTraceID bool = false
 	var issetStartTime bool = false
 	var issetEndTime bool = false
 	for {
@@ -2094,7 +2093,6 @@ func (p *GetTraceRequest) FastRead(buf []byte) (int, error) {
 				if err != nil {
 					goto ReadFieldError
 				}
-				issetTraceID = true
 			} else {
 				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 				offset += l
@@ -2125,6 +2123,20 @@ func (p *GetTraceRequest) FastRead(buf []byte) (int, error) {
 					goto ReadFieldError
 				}
 				issetEndTime = true
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 5:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField5(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
 			} else {
 				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 				offset += l
@@ -2230,11 +2242,6 @@ func (p *GetTraceRequest) FastRead(buf []byte) (int, error) {
 		goto RequiredFieldNotSetError
 	}
 
-	if !issetTraceID {
-		fieldId = 2
-		goto RequiredFieldNotSetError
-	}
-
 	if !issetStartTime {
 		fieldId = 3
 		goto RequiredFieldNotSetError
@@ -2272,12 +2279,12 @@ func (p *GetTraceRequest) FastReadField1(buf []byte) (int, error) {
 func (p *GetTraceRequest) FastReadField2(buf []byte) (int, error) {
 	offset := 0
 
-	var _field string
+	var _field *string
 	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
 		return offset, err
 	} else {
 		offset += l
-		_field = v
+		_field = &v
 	}
 	p.TraceID = _field
 	return offset, nil
@@ -2308,6 +2315,20 @@ func (p *GetTraceRequest) FastReadField4(buf []byte) (int, error) {
 		_field = v
 	}
 	p.EndTime = _field
+	return offset, nil
+}
+
+func (p *GetTraceRequest) FastReadField5(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.Logid = _field
 	return offset, nil
 }
 
@@ -2413,6 +2434,7 @@ func (p *GetTraceRequest) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int
 		offset += p.fastWriteField4(buf[offset:], w)
 		offset += p.fastWriteField11(buf[offset:], w)
 		offset += p.fastWriteField2(buf[offset:], w)
+		offset += p.fastWriteField5(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
 		offset += p.fastWriteField9(buf[offset:], w)
 		offset += p.fastWriteField10(buf[offset:], w)
@@ -2430,6 +2452,7 @@ func (p *GetTraceRequest) BLength() int {
 		l += p.field2Length()
 		l += p.field3Length()
 		l += p.field4Length()
+		l += p.field5Length()
 		l += p.field8Length()
 		l += p.field9Length()
 		l += p.field10Length()
@@ -2450,8 +2473,10 @@ func (p *GetTraceRequest) fastWriteField1(buf []byte, w thrift.NocopyWriter) int
 
 func (p *GetTraceRequest) fastWriteField2(buf []byte, w thrift.NocopyWriter) int {
 	offset := 0
-	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 2)
-	offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, p.TraceID)
+	if p.IsSetTraceID() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 2)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.TraceID)
+	}
 	return offset
 }
 
@@ -2466,6 +2491,15 @@ func (p *GetTraceRequest) fastWriteField4(buf []byte, w thrift.NocopyWriter) int
 	offset := 0
 	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 4)
 	offset += thrift.Binary.WriteI64(buf[offset:], p.EndTime)
+	return offset
+}
+
+func (p *GetTraceRequest) fastWriteField5(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetLogid() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 5)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.Logid)
+	}
 	return offset
 }
 
@@ -2539,8 +2573,10 @@ func (p *GetTraceRequest) field1Length() int {
 
 func (p *GetTraceRequest) field2Length() int {
 	l := 0
-	l += thrift.Binary.FieldBeginLength()
-	l += thrift.Binary.StringLengthNocopy(p.TraceID)
+	if p.IsSetTraceID() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.TraceID)
+	}
 	return l
 }
 
@@ -2555,6 +2591,15 @@ func (p *GetTraceRequest) field4Length() int {
 	l := 0
 	l += thrift.Binary.FieldBeginLength()
 	l += thrift.Binary.I64Length()
+	return l
+}
+
+func (p *GetTraceRequest) field5Length() int {
+	l := 0
+	if p.IsSetLogid() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.Logid)
+	}
 	return l
 }
 
@@ -2624,13 +2669,25 @@ func (p *GetTraceRequest) DeepCopy(s interface{}) error {
 
 	p.WorkspaceID = src.WorkspaceID
 
-	if src.TraceID != "" {
-		p.TraceID = kutils.StringDeepCopy(src.TraceID)
+	if src.TraceID != nil {
+		var tmp string
+		if *src.TraceID != "" {
+			tmp = kutils.StringDeepCopy(*src.TraceID)
+		}
+		p.TraceID = &tmp
 	}
 
 	p.StartTime = src.StartTime
 
 	p.EndTime = src.EndTime
+
+	if src.Logid != nil {
+		var tmp string
+		if *src.Logid != "" {
+			tmp = kutils.StringDeepCopy(*src.Logid)
+		}
+		p.Logid = &tmp
+	}
 
 	if src.PlatformType != nil {
 		tmp := *src.PlatformType

--- a/backend/modules/observability/application/trace.go
+++ b/backend/modules/observability/application/trace.go
@@ -302,8 +302,8 @@ func (t *TraceApplication) validateGetTraceReq(ctx context.Context, req *trace.G
 		return errorx.NewByCode(obErrorx.CommercialCommonInvalidParamCodeCode, errorx.WithExtraMsg("no request provided"))
 	} else if req.GetWorkspaceID() <= 0 {
 		return errorx.NewByCode(obErrorx.CommercialCommonInvalidParamCodeCode, errorx.WithExtraMsg("invalid workspace_id"))
-	} else if req.GetTraceID() == "" {
-		return errorx.NewByCode(obErrorx.CommercialCommonInvalidParamCodeCode, errorx.WithExtraMsg("invalid trace_id"))
+	} else if req.GetTraceID() == "" && req.GetLogid() == "" {
+		return errorx.NewByCode(obErrorx.CommercialCommonInvalidParamCodeCode, errorx.WithExtraMsg("at least need trace_id or logid"))
 	}
 	v := utils.DateValidator{
 		Start:        req.GetStartTime(),
@@ -323,6 +323,7 @@ func (t *TraceApplication) buildGetTraceSvcReq(req *trace.GetTraceRequest) (*ser
 	ret := &service.GetTraceReq{
 		WorkspaceID: req.GetWorkspaceID(),
 		TraceID:     req.GetTraceID(),
+		LogID:       req.GetLogid(),
 		StartTime:   req.GetStartTime(),
 		EndTime:     req.GetEndTime(),
 		SpanIDs:     req.GetSpanIds(),

--- a/backend/modules/observability/application/trace_test.go
+++ b/backend/modules/observability/application/trace_test.go
@@ -710,7 +710,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 				},
 			},
 			want: &trace.GetTraceResponse{
@@ -742,7 +742,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 				},
 			},
 			want:    nil,
@@ -766,7 +766,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 				},
 			},
 			want:    nil,
@@ -783,7 +783,60 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 0,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "query by logid only success case",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				mockSvc := svcmock.NewMockITraceService(ctrl)
+				mockAuth := rpcmock.NewMockIAuthProvider(ctrl)
+				mockCfg := confmock.NewMockITraceConfig(ctrl)
+				mockAuth.EXPECT().CheckWorkspacePermission(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockSvc.EXPECT().GetTrace(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req *service.GetTraceReq) (*service.GetTraceResp, error) {
+						assert.Equal(t, "log-123", req.LogID)
+						assert.Equal(t, "", req.TraceID)
+						return &service.GetTraceResp{}, nil
+					})
+				mockCfg.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(100))
+				return fields{
+					traceSvc: mockSvc,
+					auth:     mockAuth,
+					traceCfg: mockCfg,
+				}
+			},
+			args: args{
+				ctx: context.Background(),
+				req: &trace.GetTraceRequest{
+					WorkspaceID: 12,
+					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
+					EndTime:     time.Now().UnixMilli(),
+					Logid:       ptr.Of("log-123"),
+				},
+			},
+			want: &trace.GetTraceResponse{
+				Spans: make([]*span.OutputSpan, 0),
+				TracesAdvanceInfo: &trace.TraceAdvanceInfo{
+					Tokens: &trace.TokenCost{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing both trace_id and logid error case",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				return fields{}
+			},
+			args: args{
+				ctx: context.Background(),
+				req: &trace.GetTraceRequest{
+					WorkspaceID: 12,
+					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
+					EndTime:     time.Now().UnixMilli(),
 				},
 			},
 			want:    nil,
@@ -810,7 +863,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 					SpanIds:     []string{"123"},
 				},
 			},
@@ -846,7 +899,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 					PageSize:    ptr.Of(int32(10)),
 				},
 			},
@@ -884,7 +937,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 					PageToken:   ptr.Of("some_token"),
 					Filters: &filter.FilterFields{
 						FilterFields: []*filter.FilterField{
@@ -923,7 +976,7 @@ func TestTraceApplication_GetTrace(t *testing.T) {
 					WorkspaceID: 12,
 					StartTime:   time.Now().Add(-time.Hour).UnixMilli(),
 					EndTime:     time.Now().UnixMilli(),
-					TraceID:     "123",
+					TraceID:     ptr.Of("123"),
 					Filters: &filter.FilterFields{
 						FilterFields: []*filter.FilterField{
 							{

--- a/idl/thrift/coze/loop/observability/coze.loop.observability.trace.thrift
+++ b/idl/thrift/coze/loop/observability/coze.loop.observability.trace.thrift
@@ -64,9 +64,10 @@ struct TraceAdvanceInfo {
 
 struct GetTraceRequest {
     1: required i64 workspace_id (api.js_conv='true', go.tag='json:"workspace_id"', api.query="workspace_id")
-    2: required string trace_id (api.path="trace_id")
+    2: optional string trace_id (api.path="trace_id")
     3: required i64 start_time (api.js_conv='true', go.tag='json:"start_time"', api.query="start_time") // ms
     4: required i64 end_time (api.js_conv='true', go.tag='json:"end_time"', api.query="end_time") // ms
+    5: optional string logid (api.query="logid")
     8: optional common.PlatformType platform_type (api.query="platform_type")
     9: optional list<string> span_ids (api.query="span_ids")
     10: optional filter.FilterFields filters (api.query="filters")


### PR DESCRIPTION
Make trace_id optional and add logid query param so a trace can be fetched by either trace_id or logid, aligning with SearchTraceOApi.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
