### PR TITLE
[fix][backend] ignore CheckTraceBenefit error in expire error processor

### DIFF
--- a/backend/modules/observability/domain/trace/service/trace/span_processor/expire_error_processor.go
+++ b/backend/modules/observability/domain/trace/service/trace/span_processor/expire_error_processor.go
@@ -32,10 +32,10 @@ func (c *ExpireErrorProcessor) Transform(ctx context.Context, spans loop_span.Sp
 	})
 	if err != nil {
 		logs.CtxWarn(ctx, "fail to check trace benefit, %v", err)
-		return nil, errorx.WrapByCode(err, obErrorx.ExpiredTraceErrorCode)
+		return spans, nil
 	} else if res == nil {
 		logs.CtxWarn(ctx, "fail to get trace benefit, got nil response")
-		return nil, errorx.NewByCode(obErrorx.ExpiredTraceErrorCode)
+		return spans, nil
 	}
 	earliestTime := time.Now().UnixMilli() - (24 * time.Duration(res.StorageDuration) * time.Hour).Milliseconds()
 	if c.queryEndTime < earliestTime {

--- a/backend/modules/observability/domain/trace/service/trace/span_processor/expire_error_processor_test.go
+++ b/backend/modules/observability/domain/trace/service/trace/span_processor/expire_error_processor_test.go
@@ -76,7 +76,7 @@ func TestExpireErrorProcessor_Transform(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "transform failed when benefit check returns error",
+			name: "transform returns spans when benefit check returns error",
 			fieldsGetter: func(ctrl *gomock.Controller) fields {
 				benefitMock := benefitmock.NewMockIBenefitService(ctrl)
 				benefitMock.EXPECT().CheckTraceBenefit(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("benefit error"))
@@ -91,8 +91,27 @@ func TestExpireErrorProcessor_Transform(t *testing.T) {
 				ctx:   context.Background(),
 				spans: loop_span.SpanList{},
 			},
-			want:    nil,
-			wantErr: true,
+			want:    loop_span.SpanList{},
+			wantErr: false,
+		},
+		{
+			name: "transform returns spans when benefit check returns nil response",
+			fieldsGetter: func(ctrl *gomock.Controller) fields {
+				benefitMock := benefitmock.NewMockIBenefitService(ctrl)
+				benefitMock.EXPECT().CheckTraceBenefit(gomock.Any(), gomock.Any()).Return(nil, nil)
+				return fields{
+					platformType: loop_span.PlatformCozeLoop,
+					queryEndTime: time.Now().UnixMilli(),
+					workspaceId:  1,
+					benefitSvc:   benefitMock,
+				}
+			},
+			args: args{
+				ctx:   context.Background(),
+				spans: loop_span.SpanList{},
+			},
+			want:    loop_span.SpanList{},
+			wantErr: false,
 		},
 		{
 			name: "transform failed when query time expired",


### PR DESCRIPTION
The CheckTraceBenefit error and nil response should not block trace queries. Changed to log warning and return spans as-is instead of returning an error.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
