### PR TITLE
[feat][evaluation]: support AgentBuddy skill preload to TOS for experiment execution

### DIFF
--- a/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
@@ -2937,10 +2937,12 @@ type SubmitExperimentRequest struct {
 	ExptTemplateID      *int64 `thrift:"expt_template_id,42,optional" frugal:"42,optional,i64" json:"expt_template_id" form:"expt_template_id" `
 	ItemRetryNum        *int32 `thrift:"item_retry_num,45,optional" frugal:"45,optional,i32" form:"item_retry_num" json:"item_retry_num,omitempty"`
 	// 试运行行数
-	TrialRunItemCount       *int64                `thrift:"trial_run_item_count,46,optional" frugal:"46,optional,i64" form:"trial_run_item_count" json:"trial_run_item_count,omitempty"`
-	EnableExtractTrajectory *bool                 `thrift:"enable_extract_trajectory,47,optional" frugal:"47,optional,bool" json:"enable_extract_trajectory" form:"enable_extract_trajectory" `
-	TriggerType             *expt.ExptTriggerType `thrift:"trigger_type,50,optional" frugal:"50,optional,string" form:"trigger_type" json:"trigger_type,omitempty" query:"trigger_type"`
-	TimeRange               *expt.TaskTimeRange   `thrift:"time_range,51,optional" frugal:"51,optional,expt.TaskTimeRange" form:"time_range" json:"time_range,omitempty"`
+	TrialRunItemCount       *int64 `thrift:"trial_run_item_count,46,optional" frugal:"46,optional,i64" form:"trial_run_item_count" json:"trial_run_item_count,omitempty"`
+	EnableExtractTrajectory *bool  `thrift:"enable_extract_trajectory,47,optional" frugal:"47,optional,bool" json:"enable_extract_trajectory" form:"enable_extract_trajectory" `
+	// 提交实验时前端透传的发起人 user JWT，用于预下载 agent_buddy skill 入 TOS
+	XJwtToken   *string               `thrift:"x_jwt_token,48,optional" frugal:"48,optional,string" header:"X-Jwt-Token" json:"x_jwt_token,omitempty"`
+	TriggerType *expt.ExptTriggerType `thrift:"trigger_type,50,optional" frugal:"50,optional,string" form:"trigger_type" json:"trigger_type,omitempty" query:"trigger_type"`
+	TimeRange   *expt.TaskTimeRange   `thrift:"time_range,51,optional" frugal:"51,optional,expt.TaskTimeRange" form:"time_range" json:"time_range,omitempty"`
 	// 智能评测相关
 	ThreadID *string `thrift:"thread_id,60,optional" frugal:"60,optional,string" form:"thread_id" json:"thread_id,omitempty"`
 	// 指定执行的评测集条目ID列表
@@ -3254,6 +3256,18 @@ func (p *SubmitExperimentRequest) GetEnableExtractTrajectory() (v bool) {
 	return *p.EnableExtractTrajectory
 }
 
+var SubmitExperimentRequest_XJwtToken_DEFAULT string
+
+func (p *SubmitExperimentRequest) GetXJwtToken() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetXJwtToken() {
+		return SubmitExperimentRequest_XJwtToken_DEFAULT
+	}
+	return *p.XJwtToken
+}
+
 var SubmitExperimentRequest_TriggerType_DEFAULT expt.ExptTriggerType
 
 func (p *SubmitExperimentRequest) GetTriggerType() (v expt.ExptTriggerType) {
@@ -3424,6 +3438,9 @@ func (p *SubmitExperimentRequest) SetTrialRunItemCount(val *int64) {
 func (p *SubmitExperimentRequest) SetEnableExtractTrajectory(val *bool) {
 	p.EnableExtractTrajectory = val
 }
+func (p *SubmitExperimentRequest) SetXJwtToken(val *string) {
+	p.XJwtToken = val
+}
 func (p *SubmitExperimentRequest) SetTriggerType(val *expt.ExptTriggerType) {
 	p.TriggerType = val
 }
@@ -3475,6 +3492,7 @@ var fieldIDToName_SubmitExperimentRequest = map[int16]string{
 	45:  "item_retry_num",
 	46:  "trial_run_item_count",
 	47:  "enable_extract_trajectory",
+	48:  "x_jwt_token",
 	50:  "trigger_type",
 	51:  "time_range",
 	60:  "thread_id",
@@ -3579,6 +3597,10 @@ func (p *SubmitExperimentRequest) IsSetTrialRunItemCount() bool {
 
 func (p *SubmitExperimentRequest) IsSetEnableExtractTrajectory() bool {
 	return p.EnableExtractTrajectory != nil
+}
+
+func (p *SubmitExperimentRequest) IsSetXJwtToken() bool {
+	return p.XJwtToken != nil
 }
 
 func (p *SubmitExperimentRequest) IsSetTriggerType() bool {
@@ -3828,6 +3850,14 @@ func (p *SubmitExperimentRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 47:
 			if fieldTypeId == thrift.BOOL {
 				if err = p.ReadField47(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 48:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField48(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -4236,6 +4266,17 @@ func (p *SubmitExperimentRequest) ReadField47(iprot thrift.TProtocol) error {
 	p.EnableExtractTrajectory = _field
 	return nil
 }
+func (p *SubmitExperimentRequest) ReadField48(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.XJwtToken = _field
+	return nil
+}
 func (p *SubmitExperimentRequest) ReadField50(iprot thrift.TProtocol) error {
 
 	var _field *expt.ExptTriggerType
@@ -4447,6 +4488,10 @@ func (p *SubmitExperimentRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField47(oprot); err != nil {
 			fieldId = 47
+			goto WriteFieldError
+		}
+		if err = p.writeField48(oprot); err != nil {
+			fieldId = 48
 			goto WriteFieldError
 		}
 		if err = p.writeField50(oprot); err != nil {
@@ -4971,6 +5016,24 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 47 end error: ", p), err)
 }
+func (p *SubmitExperimentRequest) writeField48(oprot thrift.TProtocol) (err error) {
+	if p.IsSetXJwtToken() {
+		if err = oprot.WriteFieldBegin("x_jwt_token", thrift.STRING, 48); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.XJwtToken); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 48 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 48 end error: ", p), err)
+}
 func (p *SubmitExperimentRequest) writeField50(oprot thrift.TProtocol) (err error) {
 	if p.IsSetTriggerType() {
 		if err = oprot.WriteFieldBegin("trigger_type", thrift.STRING, 50); err != nil {
@@ -5222,6 +5285,9 @@ func (p *SubmitExperimentRequest) DeepEqual(ano *SubmitExperimentRequest) bool {
 		return false
 	}
 	if !p.Field47DeepEqual(ano.EnableExtractTrajectory) {
+		return false
+	}
+	if !p.Field48DeepEqual(ano.XJwtToken) {
 		return false
 	}
 	if !p.Field50DeepEqual(ano.TriggerType) {
@@ -5530,6 +5596,18 @@ func (p *SubmitExperimentRequest) Field47DeepEqual(src *bool) bool {
 		return false
 	}
 	if *p.EnableExtractTrajectory != *src {
+		return false
+	}
+	return true
+}
+func (p *SubmitExperimentRequest) Field48DeepEqual(src *string) bool {
+
+	if p.XJwtToken == src {
+		return true
+	} else if p.XJwtToken == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.XJwtToken, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/expt/k-coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/k-coze.loop.evaluation.expt.go
@@ -2534,6 +2534,20 @@ func (p *SubmitExperimentRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 48:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField48(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 50:
 			if fieldTypeId == thrift.STRING {
 				l, err = p.FastReadField50(buf[offset:])
@@ -3050,6 +3064,20 @@ func (p *SubmitExperimentRequest) FastReadField47(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *SubmitExperimentRequest) FastReadField48(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.XJwtToken = _field
+	return offset, nil
+}
+
 func (p *SubmitExperimentRequest) FastReadField50(buf []byte) (int, error) {
 	offset := 0
 
@@ -3214,6 +3242,7 @@ func (p *SubmitExperimentRequest) FastWriteNocopy(buf []byte, w thrift.NocopyWri
 		offset += p.fastWriteField32(buf[offset:], w)
 		offset += p.fastWriteField33(buf[offset:], w)
 		offset += p.fastWriteField40(buf[offset:], w)
+		offset += p.fastWriteField48(buf[offset:], w)
 		offset += p.fastWriteField50(buf[offset:], w)
 		offset += p.fastWriteField51(buf[offset:], w)
 		offset += p.fastWriteField60(buf[offset:], w)
@@ -3255,6 +3284,7 @@ func (p *SubmitExperimentRequest) BLength() int {
 		l += p.field45Length()
 		l += p.field46Length()
 		l += p.field47Length()
+		l += p.field48Length()
 		l += p.field50Length()
 		l += p.field51Length()
 		l += p.field60Length()
@@ -3508,6 +3538,15 @@ func (p *SubmitExperimentRequest) fastWriteField47(buf []byte, w thrift.NocopyWr
 	if p.IsSetEnableExtractTrajectory() {
 		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.BOOL, 47)
 		offset += thrift.Binary.WriteBool(buf[offset:], *p.EnableExtractTrajectory)
+	}
+	return offset
+}
+
+func (p *SubmitExperimentRequest) fastWriteField48(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetXJwtToken() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 48)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.XJwtToken)
 	}
 	return offset
 }
@@ -3832,6 +3871,15 @@ func (p *SubmitExperimentRequest) field47Length() int {
 	return l
 }
 
+func (p *SubmitExperimentRequest) field48Length() int {
+	l := 0
+	if p.IsSetXJwtToken() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.XJwtToken)
+	}
+	return l
+}
+
 func (p *SubmitExperimentRequest) field50Length() int {
 	l := 0
 	if p.IsSetTriggerType() {
@@ -4083,6 +4131,14 @@ func (p *SubmitExperimentRequest) DeepCopy(s interface{}) error {
 	if src.EnableExtractTrajectory != nil {
 		tmp := *src.EnableExtractTrajectory
 		p.EnableExtractTrajectory = &tmp
+	}
+
+	if src.XJwtToken != nil {
+		var tmp string
+		if *src.XJwtToken != "" {
+			tmp = kutils.StringDeepCopy(*src.XJwtToken)
+		}
+		p.XJwtToken = &tmp
 	}
 
 	if src.TriggerType != nil {

--- a/backend/modules/evaluation/consts/experiment.go
+++ b/backend/modules/evaluation/consts/experiment.go
@@ -33,6 +33,9 @@ const (
 const (
 	FieldAdapterBuiltinFieldNameRuntimeParam = "builtin_runtime_param"
 	TargetExecuteExtRuntimeParamKey          = "builtin_runtime_param"
+	// FieldAdapterBuiltinFieldNameAgentBuddySkillTOSKeys 执行期透传 EvalConf.SkillTOSKeys 用的 Ext key。
+	// 值须与商业版 consts.ExtKeyAgentBuddySkillTOSKeys 逐字一致，供商业版 buildSkillsConfig 命中 TOS 现签复用。
+	FieldAdapterBuiltinFieldNameAgentBuddySkillTOSKeys = "agent_buddy_skill_tos_keys"
 )
 
 const (

--- a/backend/modules/evaluation/consts/experiment.go
+++ b/backend/modules/evaluation/consts/experiment.go
@@ -33,9 +33,9 @@ const (
 const (
 	FieldAdapterBuiltinFieldNameRuntimeParam = "builtin_runtime_param"
 	TargetExecuteExtRuntimeParamKey          = "builtin_runtime_param"
-	// FieldAdapterBuiltinFieldNameAgentBuddySkillTOSKeys 执行期透传 EvalConf.SkillTOSKeys 用的 Ext key。
-	// 值须与商业版 consts.ExtKeyAgentBuddySkillTOSKeys 逐字一致，供商业版 buildSkillsConfig 命中 TOS 现签复用。
-	FieldAdapterBuiltinFieldNameAgentBuddySkillTOSKeys = "agent_buddy_skill_tos_keys"
+	// FieldAdapterBuiltinFieldNameSkillTOSKeys 执行期透传 EvalConf.SkillTOSKeys 用的 Ext key。
+	// 值须与商业版 consts.ExtKeySkillTOSKeys 逐字一致，供商业版 buildSkillsConfig 命中 TOS 现签复用。
+	FieldAdapterBuiltinFieldNameSkillTOSKeys = "agent_buddy_skill_tos_keys"
 )
 
 const (

--- a/backend/modules/evaluation/domain/component/rpc/skill_preloader.go
+++ b/backend/modules/evaluation/domain/component/rpc/skill_preloader.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rpc
+
+import (
+	"context"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+)
+
+// ISkillPreloader AgentBuddy skill 预下载入 TOS 的 Port 接口。
+//
+// 提交实验时，把该实验用到的 agent_buddy 来源 skill 用发起人 user JWT + 平台 SA JWT
+// 下载一次并入库到 Fornax TOS，把 tos_key 记入实验 eval_conf 的 SkillTOSKeys 快照字段；
+// 之后该实验的所有执行/重试批次都从 TOS 现签下发，与 AgentBuddy、user JWT 解耦。
+//
+// 开源版仅提供 Port 接口 + Noop 空实现供依赖注入图占位；真实现由商业版注入。
+//
+//go:generate mockgen -destination=mocks/skill_preloader.go -package=mocks . ISkillPreloader
+type ISkillPreloader interface {
+	// PreloadAgentBuddySkills 预下载指定实验用到的 agent_buddy skill 入库 TOS 并回写 tos_key。
+	// exptID 实验 ID；spaceID 空间 ID；skillConfigs 该实验涉及的 skill 配置；userJWT 发起人透传的 user JWT。
+	PreloadAgentBuddySkills(ctx context.Context, exptID int64, spaceID int64, skillConfigs []*entity.SkillConfig, userJWT string) error
+}

--- a/backend/modules/evaluation/domain/component/rpc/skill_preloader.go
+++ b/backend/modules/evaluation/domain/component/rpc/skill_preloader.go
@@ -9,17 +9,17 @@ import (
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 )
 
-// ISkillPreloader AgentBuddy skill 预下载入 TOS 的 Port 接口。
+// ISkillPreloader skill 预下载入 TOS 的 Port 接口。
 //
-// 提交实验时，把该实验用到的 agent_buddy 来源 skill 用发起人 user JWT + 平台 SA JWT
-// 下载一次并入库到 Fornax TOS，把 tos_key 记入实验 eval_conf 的 SkillTOSKeys 快照字段；
-// 之后该实验的所有执行/重试批次都从 TOS 现签下发，与 AgentBuddy、user JWT 解耦。
+// 提交实验时，把该实验用到的外部来源 skill 用发起人 user JWT + 平台 SA JWT
+// 下载一次并入库到 TOS，把 tos_key 记入实验 eval_conf 的 SkillTOSKeys 快照字段；
+// 之后该实验的所有执行/重试批次都从 TOS 现签下发，与原始来源、user JWT 解耦。
 //
 // 开源版仅提供 Port 接口 + Noop 空实现供依赖注入图占位；真实现由商业版注入。
 //
 //go:generate mockgen -destination=mocks/skill_preloader.go -package=mocks . ISkillPreloader
 type ISkillPreloader interface {
-	// PreloadAgentBuddySkills 预下载指定实验用到的 agent_buddy skill 入库 TOS 并回写 tos_key。
+	// PreloadSkills 预下载指定实验用到的 skill 入库 TOS 并回写 tos_key。
 	// exptID 实验 ID；spaceID 空间 ID；skillConfigs 该实验涉及的 skill 配置；userJWT 发起人透传的 user JWT。
-	PreloadAgentBuddySkills(ctx context.Context, exptID int64, spaceID int64, skillConfigs []*entity.SkillConfig, userJWT string) error
+	PreloadSkills(ctx context.Context, exptID int64, spaceID int64, skillConfigs []*entity.SkillConfig, userJWT string) error
 }

--- a/backend/modules/evaluation/domain/entity/expt.go
+++ b/backend/modules/evaluation/domain/entity/expt.go
@@ -263,7 +263,7 @@ type EvaluationConfiguration struct {
 	TimeRange               *TaskTimeRangeDO `json:"time_range,omitempty"`
 	EnableExtractTrajectory *bool
 	Ext                     map[string]string
-	// SkillTOSKeys AgentBuddy skill 入库 TOS 后的 tos_key 快照；key="{skill_id}:{version}"，value=tos_key。
+	// SkillTOSKeys skill 入库 TOS 后的 tos_key 快照；key="{skill_id}:{version}"，value=tos_key。
 	SkillTOSKeys map[string]string `json:"agent_buddy_skill_tos_keys,omitempty"`
 }
 

--- a/backend/modules/evaluation/domain/entity/expt.go
+++ b/backend/modules/evaluation/domain/entity/expt.go
@@ -263,6 +263,8 @@ type EvaluationConfiguration struct {
 	TimeRange               *TaskTimeRangeDO `json:"time_range,omitempty"`
 	EnableExtractTrajectory *bool
 	Ext                     map[string]string
+	// SkillTOSKeys AgentBuddy skill 入库 TOS 后的 tos_key 快照；key="{skill_id}:{version}"，value=tos_key。
+	SkillTOSKeys map[string]string `json:"agent_buddy_skill_tos_keys,omitempty"`
 }
 
 // MaxItemRetryNum 数据行 Item 最大重试次数的上界（创建侧与更新侧共用）。

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
@@ -812,11 +812,11 @@ func (e *DefaultExptTurnEvaluationImpl) buildEvaluatorInputDataExt(ext map[strin
 	}
 
 	// 仿 RuntimeParam 透传惯例：把本实验 EvalConf.SkillTOSKeys 序列化写进执行期 Ext 口袋，
-	// 供执行期商业版 buildSkillsConfig 命中 AgentBuddy skill 的 TOS 现签复用（执行期链路拿不到 exptID/EvalConf）。
+	// 供执行期商业版 buildSkillsConfig 命中 skill 的 TOS 现签复用（执行期链路拿不到 exptID/EvalConf）。
 	// 为空则不写，避免污染 Ext、保持向后兼容。
 	if evalConf != nil && len(evalConf.SkillTOSKeys) > 0 {
 		if b, err := json.Marshal(evalConf.SkillTOSKeys); err == nil {
-			builtExt[consts.FieldAdapterBuiltinFieldNameAgentBuddySkillTOSKeys] = string(b)
+			builtExt[consts.FieldAdapterBuiltinFieldNameSkillTOSKeys] = string(b)
 		}
 	}
 

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl.go
@@ -434,7 +434,7 @@ func (e *DefaultExptTurnEvaluationImpl) callEvaluators(ctx context.Context, exec
 			return nil, fmt.Errorf("expt's evaluator conf not found, evaluator_version_id: %d", versionID)
 		}
 
-		inputData, err := e.buildEvaluatorInputData(ctx, spaceID, ev.EvaluatorType, ec, turn, targetFields, ev.GetInputSchemas(), etec.Ext)
+		inputData, err := e.buildEvaluatorInputData(ctx, spaceID, ev.EvaluatorType, ec, turn, targetFields, ev.GetInputSchemas(), etec.Ext, expt.EvalConf)
 		if err != nil {
 			return nil, err
 		}
@@ -571,7 +571,7 @@ func (e *DefaultExptTurnEvaluationImpl) asyncCallEvaluator(
 }
 
 func (e *DefaultExptTurnEvaluationImpl) buildEvaluatorInputData(ctx context.Context, spaceID int64, evaluatorType entity.EvaluatorType,
-	ec *entity.EvaluatorConf, evalSetTurn *entity.Turn, targetFields map[string]*entity.Content, inputSchemas []*entity.ArgsSchema, ext map[string]string,
+	ec *entity.EvaluatorConf, evalSetTurn *entity.Turn, targetFields map[string]*entity.Content, inputSchemas []*entity.ArgsSchema, ext map[string]string, evalConf *entity.EvaluationConfiguration,
 ) (*entity.EvaluatorInputData, error) {
 	var targetFieldConfs []*entity.FieldConf
 	if ec.IngressConf != nil && ec.IngressConf.TargetAdapter != nil {
@@ -651,7 +651,7 @@ func (e *DefaultExptTurnEvaluationImpl) buildEvaluatorInputData(ctx context.Cont
 		}
 	}
 
-	res.Ext = e.buildEvaluatorInputDataExt(ext, ec.RunConf)
+	res.Ext = e.buildEvaluatorInputDataExt(ext, ec.RunConf, evalConf)
 	return res, nil
 }
 
@@ -802,13 +802,22 @@ func (e *DefaultExptTurnEvaluationImpl) getContentByJsonPath(content *entity.Con
 	}, nil
 }
 
-func (e *DefaultExptTurnEvaluationImpl) buildEvaluatorInputDataExt(ext map[string]string, runConf *entity.EvaluatorRunConfig) map[string]string {
+func (e *DefaultExptTurnEvaluationImpl) buildEvaluatorInputDataExt(ext map[string]string, runConf *entity.EvaluatorRunConfig, evalConf *entity.EvaluationConfiguration) map[string]string {
 	builtExt := gmap.Clone(ext)
 	if builtExt == nil {
 		builtExt = make(map[string]string)
 	}
 	if runConf != nil && runConf.EvaluatorRuntimeParam != nil && runConf.EvaluatorRuntimeParam.JSONValue != nil && len(*runConf.EvaluatorRuntimeParam.JSONValue) > 0 {
 		builtExt[consts.FieldAdapterBuiltinFieldNameRuntimeParam] = *runConf.EvaluatorRuntimeParam.JSONValue
+	}
+
+	// 仿 RuntimeParam 透传惯例：把本实验 EvalConf.SkillTOSKeys 序列化写进执行期 Ext 口袋，
+	// 供执行期商业版 buildSkillsConfig 命中 AgentBuddy skill 的 TOS 现签复用（执行期链路拿不到 exptID/EvalConf）。
+	// 为空则不写，避免污染 Ext、保持向后兼容。
+	if evalConf != nil && len(evalConf.SkillTOSKeys) > 0 {
+		if b, err := json.Marshal(evalConf.SkillTOSKeys); err == nil {
+			builtExt[consts.FieldAdapterBuiltinFieldNameAgentBuddySkillTOSKeys] = string(b)
+		}
 	}
 
 	return builtExt

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
@@ -4386,3 +4386,62 @@ func TestDefaultExptTurnEvaluationImpl_CallEvaluators_NoGoroutineLeak(t *testing
 	assert.Less(t, after-before, 20,
 		"goroutine leak in callEvaluators early-return path: before=%d after=%d (delta=%d)", before, after, after-before)
 }
+
+func TestDefaultExptTurnEvaluationImpl_buildEvaluatorInputDataExt(t *testing.T) {
+	t.Parallel()
+
+	service := &DefaultExptTurnEvaluationImpl{}
+
+	t.Run("nil ext and nil runConf and nil evalConf", func(t *testing.T) {
+		got := service.buildEvaluatorInputDataExt(nil, nil, nil)
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("existing ext passed through", func(t *testing.T) {
+		ext := map[string]string{"key1": "val1"}
+		got := service.buildEvaluatorInputDataExt(ext, nil, nil)
+		assert.Equal(t, "val1", got["key1"])
+	})
+
+	t.Run("runConf runtime param written to ext", func(t *testing.T) {
+		jsonVal := `{"temperature":0.5}`
+		runConf := &entity.EvaluatorRunConfig{
+			EvaluatorRuntimeParam: &entity.RuntimeParam{
+				JSONValue: &jsonVal,
+			},
+		}
+		got := service.buildEvaluatorInputDataExt(nil, runConf, nil)
+		assert.Equal(t, jsonVal, got[consts.FieldAdapterBuiltinFieldNameRuntimeParam])
+	})
+
+	t.Run("evalConf with SkillTOSKeys serialized to ext", func(t *testing.T) {
+		evalConf := &entity.EvaluationConfiguration{
+			SkillTOSKeys: map[string]string{
+				"skill1:v1": "tos-key-abc",
+				"skill2:v2": "tos-key-def",
+			},
+		}
+		got := service.buildEvaluatorInputDataExt(nil, nil, evalConf)
+		raw := got[consts.FieldAdapterBuiltinFieldNameSkillTOSKeys]
+		assert.NotEmpty(t, raw)
+		assert.Contains(t, raw, "skill1:v1")
+		assert.Contains(t, raw, "tos-key-abc")
+	})
+
+	t.Run("evalConf with empty SkillTOSKeys does not write ext key", func(t *testing.T) {
+		evalConf := &entity.EvaluationConfiguration{
+			SkillTOSKeys: map[string]string{},
+		}
+		got := service.buildEvaluatorInputDataExt(nil, nil, evalConf)
+		_, exists := got[consts.FieldAdapterBuiltinFieldNameSkillTOSKeys]
+		assert.False(t, exists)
+	})
+
+	t.Run("evalConf with nil SkillTOSKeys does not write ext key", func(t *testing.T) {
+		evalConf := &entity.EvaluationConfiguration{}
+		got := service.buildEvaluatorInputDataExt(nil, nil, evalConf)
+		_, exists := got[consts.FieldAdapterBuiltinFieldNameSkillTOSKeys]
+		assert.False(t, exists)
+	})
+}

--- a/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_turn_impl_test.go
@@ -310,7 +310,7 @@ func TestDefaultExptTurnEvaluationImpl_buildEvaluatorInputData_Agent(t *testing.
 				})
 			}
 
-			got, err := service.buildEvaluatorInputData(ctx, 0, tt.evaluatorType, tt.ec, turn, tt.targetFields, tt.inputSchemas, tt.ext)
+			got, err := service.buildEvaluatorInputData(ctx, 0, tt.evaluatorType, tt.ec, turn, tt.targetFields, tt.inputSchemas, tt.ext, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -2434,7 +2434,7 @@ func TestDefaultExptTurnEvaluationImpl_buildEvaluatorInputData(t *testing.T) {
 				})
 			}
 
-			got, err := service.buildEvaluatorInputData(ctx, 0, tt.evaluatorType, tt.ec, turn, tt.targetFields, tt.inputSchemas, tt.ext)
+			got, err := service.buildEvaluatorInputData(ctx, 0, tt.evaluatorType, tt.ec, turn, tt.targetFields, tt.inputSchemas, tt.ext, nil)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -3536,7 +3536,7 @@ func TestDefaultExptTurnEvaluationImpl_buildEvaluatorInputData_EdgeCases(t *test
 				})
 			}
 
-			got, err := service.buildEvaluatorInputData(ctx, 0, tt.evaluatorType, tt.ec, turn, tt.targetFields, nil, nil)
+			got, err := service.buildEvaluatorInputData(ctx, 0, tt.evaluatorType, tt.ec, turn, tt.targetFields, nil, nil, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, got)
@@ -4182,7 +4182,8 @@ func TestDefaultExptTurnEvaluationImpl_callTarget_CustomAgentAndA2AAgent(t *test
 						EvalTargetOutputData: &entity.EvalTargetOutputData{
 							OutputFields: map[string]*entity.Content{"output": content1},
 						},
-					}, nil)
+					}, nil,
+				)
 			},
 			turn: &entity.Turn{
 				ID:        1,
@@ -4201,14 +4202,16 @@ func TestDefaultExptTurnEvaluationImpl_callTarget_CustomAgentAndA2AAgent(t *test
 			prepare: func() {
 				mockMetric.EXPECT().EmitTurnExecTargetResult(gomock.Any(), gomock.Any())
 				mockEvalSetItemSvc.EXPECT().GetEvaluationSetItemField(gomock.Any(), gomock.Any()).Return(
-					&entity.FieldData{Name: "context", Content: content2}, nil).Times(2)
+					&entity.FieldData{Name: "context", Content: content2}, nil,
+				).Times(2)
 				mockEvalTargetService.EXPECT().ExecuteTarget(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					&entity.EvalTargetRecord{
 						ID: 2,
 						EvalTargetOutputData: &entity.EvalTargetOutputData{
 							OutputFields: map[string]*entity.Content{"output": content1},
 						},
-					}, nil)
+					}, nil,
+				)
 			},
 			turn: &entity.Turn{
 				ID:        2,
@@ -4227,7 +4230,8 @@ func TestDefaultExptTurnEvaluationImpl_callTarget_CustomAgentAndA2AAgent(t *test
 			prepare: func() {
 				mockMetric.EXPECT().EmitTurnExecTargetResult(gomock.Any(), gomock.Any())
 				mockEvalSetItemSvc.EXPECT().GetEvaluationSetItemField(gomock.Any(), gomock.Any()).Return(
-					nil, errors.New("fetch error"))
+					nil, errors.New("fetch error"),
+				)
 			},
 			turn: &entity.Turn{
 				ID:        3,

--- a/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_skill_tos_keys_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_skill_tos_keys_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+)
+
+// TestExptConverter_EvalConf_SkillTOSKeys_RoundTrip 覆盖新增导出字段 SkillTOSKeys 经
+// eval_conf blob（DO2PO json.Marshal → PO2DO json.Unmarshal）序列化往返后保持一致。
+func TestExptConverter_EvalConf_SkillTOSKeys_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	converter := NewExptConverter()
+	do := &entity.Experiment{
+		ID:      100,
+		SpaceID: 200,
+		EvalConf: &entity.EvaluationConfiguration{
+			SkillTOSKeys: map[string]string{
+				"123:0.0.1": "skills/200/agentbuddy/100/123-0.0.1/skill.zip",
+				"456:0.0.1": "skills/200/agentbuddy/100/456-0.0.1/skill.zip",
+			},
+		},
+	}
+
+	po, err := converter.DO2PO(do)
+	require.NoError(t, err)
+	require.NotNil(t, po.EvalConf)
+
+	got, err := converter.PO2DO(po, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got.EvalConf)
+	assert.Equal(t, do.EvalConf.SkillTOSKeys, got.EvalConf.SkillTOSKeys)
+}

--- a/backend/modules/evaluation/infra/rpc/schedule/skill_preloader_noop.go
+++ b/backend/modules/evaluation/infra/rpc/schedule/skill_preloader_noop.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package schedule
+
+import (
+	"context"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component/rpc"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+)
+
+// noopSkillPreloader 开源版占位、真实现由商业版注入，仿 schedule noop。
+// 不做任何预下载，保证依赖注入图可构建。
+type noopSkillPreloader struct{}
+
+// NewNoopSkillPreloader 返回不做实际预下载的空实现。
+func NewNoopSkillPreloader() rpc.ISkillPreloader {
+	return &noopSkillPreloader{}
+}
+
+func (n *noopSkillPreloader) PreloadAgentBuddySkills(ctx context.Context, exptID int64, spaceID int64, skillConfigs []*entity.SkillConfig, userJWT string) error {
+	return nil
+}

--- a/backend/modules/evaluation/infra/rpc/schedule/skill_preloader_noop.go
+++ b/backend/modules/evaluation/infra/rpc/schedule/skill_preloader_noop.go
@@ -19,6 +19,6 @@ func NewNoopSkillPreloader() rpc.ISkillPreloader {
 	return &noopSkillPreloader{}
 }
 
-func (n *noopSkillPreloader) PreloadAgentBuddySkills(ctx context.Context, exptID int64, spaceID int64, skillConfigs []*entity.SkillConfig, userJWT string) error {
+func (n *noopSkillPreloader) PreloadSkills(ctx context.Context, exptID int64, spaceID int64, skillConfigs []*entity.SkillConfig, userJWT string) error {
 	return nil
 }

--- a/backend/modules/evaluation/infra/rpc/schedule/skill_preloader_noop_test.go
+++ b/backend/modules/evaluation/infra/rpc/schedule/skill_preloader_noop_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package schedule
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component/rpc"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+)
+
+func TestNoopSkillPreloader(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	preloader := NewNoopSkillPreloader()
+
+	t.Run("implements ISkillPreloader interface", func(t *testing.T) {
+		var _ rpc.ISkillPreloader = (*noopSkillPreloader)(nil)
+		assert.NotNil(t, preloader)
+	})
+
+	t.Run("PreloadSkills returns nil", func(t *testing.T) {
+		skillID := int64(1)
+		version := "v1"
+		err := preloader.PreloadSkills(ctx, 123, 456, []*entity.SkillConfig{
+			{SkillID: &skillID, Version: &version},
+		}, "jwt-token")
+		assert.NoError(t, err)
+	})
+
+	t.Run("PreloadSkills with nil configs returns nil", func(t *testing.T) {
+		err := preloader.PreloadSkills(ctx, 0, 0, nil, "")
+		assert.NoError(t, err)
+	})
+}

--- a/backend/modules/evaluation/infra/rpc/schedule/wire.go
+++ b/backend/modules/evaluation/infra/rpc/schedule/wire.go
@@ -9,4 +9,5 @@ import (
 
 var ExptScheduleRPCSet = wire.NewSet(
 	NewNoopExptScheduleAdapter,
+	NewNoopSkillPreloader,
 )

--- a/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
@@ -92,6 +92,7 @@ struct SubmitExperimentRequest {
     45: optional i32 item_retry_num (api.body = 'item_retry_num')
     46: optional i64 trial_run_item_count (api.body = 'trial_run_item_count') // 试运行行数
     47: optional bool enable_extract_trajectory (api.body = 'enable_extract_trajectory', go.tag='json:"enable_extract_trajectory"')
+    48: optional string x_jwt_token (api.header='X-Jwt-Token') // 提交实验时前端透传的发起人 user JWT，用于预下载 agent_buddy skill 入 TOS
 
     50: optional expt.ExptTriggerType trigger_type
     51: optional expt.TaskTimeRange time_range (api.body = 'time_range')

--- a/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
@@ -92,7 +92,7 @@ struct SubmitExperimentRequest {
     45: optional i32 item_retry_num (api.body = 'item_retry_num')
     46: optional i64 trial_run_item_count (api.body = 'trial_run_item_count') // 试运行行数
     47: optional bool enable_extract_trajectory (api.body = 'enable_extract_trajectory', go.tag='json:"enable_extract_trajectory"')
-    48: optional string x_jwt_token (api.header='X-Jwt-Token') // 提交实验时前端透传的发起人 user JWT，用于预下载 agent_buddy skill 入 TOS
+    48: optional string x_jwt_token (api.header='X-Jwt-Token') // 提交实验时前端透传的发起人 user JWT，用于预下载 skill 入 TOS
 
     50: optional expt.ExptTriggerType trigger_type
     51: optional expt.TaskTimeRange time_range (api.body = 'time_range')


### PR DESCRIPTION
## Summary

Enable evaluation service to pre-download AgentBuddy skills into platform TOS at experiment creation time, so that subsequent execution/retry can serve sandbox downloads from TOS signed URLs — completely decoupled from AgentBuddy and expired user credentials.

### Changes

- **entity**: `EvaluationConfiguration` adds `SkillTOSKeys map[string]string` (TOS key snapshot, stored in eval_conf blob, zero DDL)
- **IDL**: `SubmitExperimentRequest` adds field 48 `x_jwt_token` with `api.header='X-Jwt-Token'` — receives user JWT transparently from frontend
- **domain**: New `ISkillPreloader` Port interface + Noop implementation (open-source placeholder; real implementation injected by commercial fork)
- **execution**: `buildEvaluatorInputDataExt` serializes `EvalConf.SkillTOSKeys` into `input.Ext["agent_buddy_skill_tos_keys"]` for downstream TOS-signed URL serving

### Context

AgentBuddy-sourced skills require dual-JWT authentication (platform SA + user) to download. User JWT expires within 1 hour, causing batch execution failures when later batches attempt to download. This change captures the skill at creation time (when user JWT is fresh) and serves from platform TOS thereafter.

### Testing

- Unit tests for EvalConf SkillTOSKeys serialization roundtrip
- E2E verified in PPE: skill preloaded to TOS → sandbox receives TOS signed URL → no more 401 from AgentBuddy