### PR TITLE
[fix][evaluation] enforce authorization on eval-target debug/async-debug, template update, and evaluator   delete/draft-update

### DIFF
--- a/backend/modules/evaluation/application/eval_target_app.go
+++ b/backend/modules/evaluation/application/eval_target_app.go
@@ -707,14 +707,15 @@ func (e EvalTargetApplicationImpl) DebugEvalTarget(ctx context.Context, request 
 }
 
 func (e EvalTargetApplicationImpl) AsyncDebugEvalTarget(ctx context.Context, request *eval_target.AsyncDebugEvalTargetRequest) (r *eval_target.AsyncDebugEvalTargetResponse, err error) {
-	// err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
-	//	ObjectID:      strconv.FormatInt(request.GetWorkspaceID(), 10),
-	//	SpaceID:       request.GetWorkspaceID(),
-	//	ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionDebugEvalTarget), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
-	// })
-	// if err != nil {
-	//	return nil, err
-	// }
+	// 鉴权
+	err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
+		ObjectID:      strconv.FormatInt(request.GetWorkspaceID(), 10),
+		SpaceID:       request.GetWorkspaceID(),
+		ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionDebugEvalTarget), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	startTime := time.Now()
 	userID := session.UserIDInCtxOrEmpty(ctx)

--- a/backend/modules/evaluation/application/eval_target_app.go
+++ b/backend/modules/evaluation/application/eval_target_app.go
@@ -650,14 +650,15 @@ func (e EvalTargetApplicationImpl) MockEvalTargetOutput(ctx context.Context, req
 }
 
 func (e EvalTargetApplicationImpl) DebugEvalTarget(ctx context.Context, request *eval_target.DebugEvalTargetRequest) (r *eval_target.DebugEvalTargetResponse, err error) {
-	// err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
-	//	ObjectID:      strconv.FormatInt(request.GetWorkspaceID(), 10),
-	//	SpaceID:       request.GetWorkspaceID(),
-	//	ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionDebugEvalTarget), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
-	// })
-	// if err != nil {
-	//	return nil, err
-	// }
+	// 鉴权
+	err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
+		ObjectID:      strconv.FormatInt(request.GetWorkspaceID(), 10),
+		SpaceID:       request.GetWorkspaceID(),
+		ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionDebugEvalTarget), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	logID := logs.GetLogID(ctx)
 

--- a/backend/modules/evaluation/application/eval_target_app_test.go
+++ b/backend/modules/evaluation/application/eval_target_app_test.go
@@ -1809,9 +1809,11 @@ func TestEvalTargetApplicationImpl_DebugEvalTarget(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	mockAuth := rpcmocks.NewMockIAuthProvider(ctrl)
 	mockEvalTargetService := mocks.NewMockIEvalTargetService(ctrl)
 
 	app := &EvalTargetApplicationImpl{
+		auth:              mockAuth,
 		evalTargetService: mockEvalTargetService,
 	}
 
@@ -1854,8 +1856,27 @@ func TestEvalTargetApplicationImpl_DebugEvalTarget(t *testing.T) {
 				CustomRPCServer: customRPC,
 			},
 			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), &rpc.AuthorizationParam{
+					ObjectID:      strconv.FormatInt(workspaceID, 10),
+					SpaceID:       workspaceID,
+					ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionDebugEvalTarget), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
+				}).Return(nil)
 				mockEvalTargetService.EXPECT().DebugTarget(gomock.Any(), gomock.Any()).Return(record, nil)
 			},
+		},
+		{
+			name: "permission denied",
+			req: &evaltargetapi.DebugEvalTargetRequest{
+				WorkspaceID:     &workspaceID,
+				EvalTargetType:  &targetType,
+				Param:           gptr.Of(string(paramBytes)),
+				CustomRPCServer: customRPC,
+			},
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(errorx.NewByCode(errno.CommonNoPermissionCode))
+			},
+			wantErr:     true,
+			wantErrCode: errno.CommonNoPermissionCode,
 		},
 		{
 			name: "invalid json",
@@ -1864,7 +1885,9 @@ func TestEvalTargetApplicationImpl_DebugEvalTarget(t *testing.T) {
 				EvalTargetType: &targetType,
 				Param:          gptr.Of("{"),
 			},
-			mockSetup:   func() {},
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+			},
 			wantErr:     true,
 			wantErrCode: errno.CommonInvalidParamCode,
 		},
@@ -1878,6 +1901,7 @@ func TestEvalTargetApplicationImpl_DebugEvalTarget(t *testing.T) {
 				CustomRPCServer:    customRPC,
 			},
 			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
 				mockEvalTargetService.EXPECT().DebugTarget(gomock.Any(), gomock.Any()).
 					Return(nil, errorx.NewByCode(errno.CommonInternalErrorCode))
 			},
@@ -1891,8 +1915,10 @@ func TestEvalTargetApplicationImpl_DebugEvalTarget(t *testing.T) {
 				EvalTargetType: gptr.Of(domain_eval_target.EvalTargetType(0)),
 				Param:          gptr.Of(string(paramBytes)),
 			},
-			mockSetup: func() {},
-			wantErr:   true,
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantErr: true,
 		},
 	}
 

--- a/backend/modules/evaluation/application/eval_target_app_test.go
+++ b/backend/modules/evaluation/application/eval_target_app_test.go
@@ -1953,8 +1953,10 @@ func TestEvalTargetApplicationImpl_AsyncDebugEvalTarget(t *testing.T) {
 
 	mockEvalTargetService := mocks.NewMockIEvalTargetService(ctrl)
 	mockEvalAsyncRepo := repomocks.NewMockIEvalAsyncRepo(ctrl)
+	mockAuth := rpcmocks.NewMockIAuthProvider(ctrl)
 
 	app := &EvalTargetApplicationImpl{
+		auth:              mockAuth,
 		evalTargetService: mockEvalTargetService,
 		evalAsyncRepo:     mockEvalAsyncRepo,
 	}
@@ -1998,9 +2000,28 @@ func TestEvalTargetApplicationImpl_AsyncDebugEvalTarget(t *testing.T) {
 				CustomRPCServer: customRPC,
 			},
 			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), &rpc.AuthorizationParam{
+					ObjectID:      strconv.FormatInt(workspaceID, 10),
+					SpaceID:       workspaceID,
+					ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionDebugEvalTarget), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
+				}).Return(nil)
 				mockEvalTargetService.EXPECT().AsyncDebugTarget(gomock.Any(), gomock.Any()).Return(record, "callee", nil)
 				mockEvalAsyncRepo.EXPECT().SetEvalAsyncCtx(gomock.Any(), strconv.FormatInt(record.ID, 10), gomock.Any()).Return(nil)
 			},
+		},
+		{
+			name: "permission denied",
+			req: &evaltargetapi.AsyncDebugEvalTargetRequest{
+				WorkspaceID:     &workspaceID,
+				EvalTargetType:  &targetType,
+				Param:           gptr.Of(string(paramBytes)),
+				CustomRPCServer: customRPC,
+			},
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(errorx.NewByCode(errno.CommonNoPermissionCode))
+			},
+			wantErr:     true,
+			wantErrCode: errno.CommonNoPermissionCode,
 		},
 		{
 			name: "invalid json",
@@ -2009,7 +2030,9 @@ func TestEvalTargetApplicationImpl_AsyncDebugEvalTarget(t *testing.T) {
 				EvalTargetType: &targetType,
 				Param:          gptr.Of("{"),
 			},
-			mockSetup:   func() {},
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+			},
 			wantErr:     true,
 			wantErrCode: errno.CommonInvalidParamCode,
 		},
@@ -2023,6 +2046,7 @@ func TestEvalTargetApplicationImpl_AsyncDebugEvalTarget(t *testing.T) {
 				CustomRPCServer:    customRPC,
 			},
 			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
 				mockEvalTargetService.EXPECT().AsyncDebugTarget(gomock.Any(), gomock.Any()).
 					Return(nil, "", errorx.NewByCode(errno.CommonInternalErrorCode))
 			},
@@ -2039,6 +2063,7 @@ func TestEvalTargetApplicationImpl_AsyncDebugEvalTarget(t *testing.T) {
 				CustomRPCServer:    customRPC,
 			},
 			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
 				mockEvalTargetService.EXPECT().AsyncDebugTarget(gomock.Any(), gomock.Any()).Return(record, "callee", nil)
 				mockEvalAsyncRepo.EXPECT().SetEvalAsyncCtx(gomock.Any(), strconv.FormatInt(record.ID, 10), gomock.Any()).
 					Return(errorx.NewByCode(errno.CommonInternalErrorCode))
@@ -2053,8 +2078,10 @@ func TestEvalTargetApplicationImpl_AsyncDebugEvalTarget(t *testing.T) {
 				EvalTargetType: gptr.Of(domain_eval_target.EvalTargetType(0)),
 				Param:          gptr.Of(string(paramBytes)),
 			},
-			mockSetup: func() {},
-			wantErr:   true,
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantErr: true,
 		},
 	}
 

--- a/backend/modules/evaluation/application/evaluator_app.go
+++ b/backend/modules/evaluation/application/evaluator_app.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/bytedance/gg/gptr"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/coze-dev/coze-loop/backend/infra/external/audit"
 	"github.com/coze-dev/coze-loop/backend/infra/external/benefit"
@@ -510,13 +509,21 @@ func (e *EvaluatorHandlerImpl) UpdateEvaluatorDraft(ctx context.Context, request
 	if err != nil {
 		return nil, err
 	}
-	if request.GetEvaluatorType() == evaluatordto.EvaluatorType_CustomRPC {
+	// 落库按服务端真实类型进行（见下方 ConvertEvaluatorDTO2DO），故写门禁也必须基于服务端真实类型，
+	// 而非客户端传入的 request.GetEvaluatorType()，否则可声明 Prompt 绕过 CustomRPC/Agent 写门禁，
+	// 却仍按真实类型把请求体内容写入（类型混淆）。
+	serverEvaluatorType := evaluatordto.EvaluatorType(evaluatorDO.EvaluatorType)
+	// 类型一致性校验：请求显式声明了类型（非未设 0）却与服务端对象不一致时，直接拒绝。
+	if request.GetEvaluatorType() != 0 && request.GetEvaluatorType() != serverEvaluatorType {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("evaluator type mismatch"))
+	}
+	if serverEvaluatorType == evaluatordto.EvaluatorType_CustomRPC {
 		err = e.authCustomRPCEvaluatorContentWritable(ctx, evaluatorDO.SpaceID)
 		if err != nil {
 			return nil, err
 		}
 	}
-	if request.GetEvaluatorType() == evaluatordto.EvaluatorType_Agent {
+	if serverEvaluatorType == evaluatordto.EvaluatorType_Agent {
 		err = e.authAgentEvaluatorContentWritable(ctx)
 		if err != nil {
 			return nil, err
@@ -541,32 +548,21 @@ func (e *EvaluatorHandlerImpl) UpdateEvaluatorDraft(ctx context.Context, request
 
 // DeleteEvaluator 删除 evaluator_version
 func (e *EvaluatorHandlerImpl) DeleteEvaluator(ctx context.Context, request *evaluatorservice.DeleteEvaluatorRequest) (resp *evaluatorservice.DeleteEvaluatorResponse, err error) {
-	// 鉴权
-	evaluatorDOS, err := e.evaluatorService.BatchGetEvaluator(ctx, request.GetWorkspaceID(), []int64{request.GetEvaluatorID()}, false)
+	// 鉴权：用带空间校验的 GetEvaluator（跨空间 id 返回 nil），对齐 UpdateEvaluator/UpdateEvaluatorDraft。
+	// 不再用无空间过滤的 BatchGetEvaluator + errgroup：原实现在结果为空时会跳过鉴权直接删除。
+	evaluatorDO, err := e.evaluatorService.GetEvaluator(ctx, request.GetWorkspaceID(), request.GetEvaluatorID(), false)
 	if err != nil {
 		return nil, err
 	}
-	g, gCtx := errgroup.WithContext(ctx)
-	for _, evaluatorDO := range evaluatorDOS {
-		if evaluatorDO == nil {
-			continue
-		}
-		curEvaluator := evaluatorDO
-		g.Go(func() error {
-			defer func() {
-				if r := recover(); r != nil {
-					logs.CtxError(ctx, "goroutine panic: %v", r)
-				}
-			}()
-			return e.auth.Authorization(gCtx, &rpc.AuthorizationParam{
-				ObjectID:      strconv.FormatInt(curEvaluator.ID, 10),
-				SpaceID:       curEvaluator.SpaceID,
-				ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.Edit), EntityType: gptr.Of(rpc.AuthEntityType_Evaluator)}},
-			})
-		})
-
+	if evaluatorDO == nil {
+		return nil, errorx.NewByCode(errno.EvaluatorNotExistCode)
 	}
-	if err = g.Wait(); err != nil {
+	err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
+		ObjectID:      strconv.FormatInt(evaluatorDO.ID, 10),
+		SpaceID:       evaluatorDO.SpaceID,
+		ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.Edit), EntityType: gptr.Of(rpc.AuthEntityType_Evaluator)}},
+	})
+	if err != nil {
 		return nil, err
 	}
 	userIDInContext := session.UserIDInCtxOrEmpty(ctx)

--- a/backend/modules/evaluation/application/evaluator_app_test.go
+++ b/backend/modules/evaluation/application/evaluator_app_test.go
@@ -3090,8 +3090,8 @@ func TestEvaluatorHandlerImpl_ComplexBusinessScenarios(t *testing.T) {
 				}
 
 				mockEvaluatorService.EXPECT().
-					BatchGetEvaluator(gomock.Any(), spaceID, []int64{evaluatorID}, false).
-					Return([]*entity.Evaluator{evaluator}, nil).
+					GetEvaluator(gomock.Any(), spaceID, evaluatorID, false).
+					Return(evaluator, nil).
 					Times(1)
 
 				mockAuth.EXPECT().
@@ -5682,11 +5682,12 @@ func TestEvaluatorHandlerImpl_UpdateEvaluatorDraft_CustomRPC(t *testing.T) {
 				},
 			}
 
-			// Mock 获取评估器信息
+			// Mock 获取评估器信息（服务端真实类型 = CustomRPC，与请求类型一致，写门禁按服务端类型触发）
 			evaluatorDO := &entity.Evaluator{
-				ID:      evaluatorID,
-				SpaceID: tt.spaceID,
-				Name:    "测试评估器",
+				ID:            evaluatorID,
+				SpaceID:       tt.spaceID,
+				Name:          "测试评估器",
+				EvaluatorType: entity.EvaluatorTypeCustomRPC,
 			}
 
 			mockEvaluatorService.EXPECT().
@@ -5846,6 +5847,109 @@ func TestEvaluatorHandlerImpl_UpdateEvaluatorDraft_Agent(t *testing.T) {
 				assert.NotNil(t, resp)
 				assert.NotNil(t, resp.Evaluator)
 			}
+		})
+	}
+}
+
+// TestEvaluatorHandlerImpl_UpdateEvaluatorDraft_TypeConfusion 覆盖类型混淆修复：
+// 写门禁与落库均按服务端真实类型；请求声明类型与服务端不一致时被类型一致性校验拦截；
+// 请求未设类型(0)时门禁仍按服务端真实类型触发（不能被声明为其他类型绕过）。
+func TestEvaluatorHandlerImpl_UpdateEvaluatorDraft_TypeConfusion(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAuth := rpcmocks.NewMockIAuthProvider(ctrl)
+	mockEvaluatorService := mocks.NewMockEvaluatorService(ctrl)
+	mockConfiger := confmocks.NewMockIConfiger(ctrl)
+	mockUserInfoService := userinfomocks.NewMockUserInfoService(ctrl)
+
+	app := &EvaluatorHandlerImpl{
+		auth:             mockAuth,
+		evaluatorService: mockEvaluatorService,
+		configer:         mockConfiger,
+		userInfoService:  mockUserInfoService,
+	}
+
+	ctx := context.Background()
+	workspaceID := int64(123456)
+	evaluatorID := int64(789)
+
+	tests := []struct {
+		name        string
+		reqType     evaluatordto.EvaluatorType
+		serverType  entity.EvaluatorType
+		mockSetup   func()
+		wantErrCode int32
+	}{
+		{
+			// 攻击：声明 Prompt 想绕过 CustomRPC 门禁，但服务端真实为 CustomRPC。
+			// 类型一致性校验(①)在门禁前拦截，返回 CommonInvalidParamCode，不触达 configer/更新。
+			name:       "declared_prompt_but_server_customrpc_rejected",
+			reqType:    evaluatordto.EvaluatorType_Prompt,
+			serverType: entity.EvaluatorTypeCustomRPC,
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			wantErrCode: errno.CommonInvalidParamCode,
+		},
+		{
+			// 未设类型(0)：跳过一致性校验(①)，写门禁(②)按服务端真实 CustomRPC 触发，空间不在 allowlist → 拒绝。
+			name:       "unset_type_server_customrpc_gate_denies",
+			reqType:    0,
+			serverType: entity.EvaluatorTypeCustomRPC,
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+				mockConfiger.EXPECT().GetBuiltinEvaluatorSpaceConf(gomock.Any()).Return([]string{})
+				mockConfiger.EXPECT().
+					CheckCustomRPCEvaluatorWritable(gomock.Any(), strconv.FormatInt(workspaceID, 10), []string{}).
+					Return(false, nil)
+			},
+			wantErrCode: errno.CommonInvalidParamCode,
+		},
+		{
+			// 未设类型(0)：写门禁(②)按服务端真实 Agent 触发，Agent 恒拒 → 拒绝。
+			name:       "unset_type_server_agent_gate_denies",
+			reqType:    0,
+			serverType: entity.EvaluatorTypeAgent,
+			mockSetup: func() {
+				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+				mockConfiger.EXPECT().CheckAgentEvaluatorWritable(gomock.Any()).Return(false, nil)
+			},
+			wantErrCode: errno.CommonInvalidParamCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluatorDO := &entity.Evaluator{
+				ID:            evaluatorID,
+				SpaceID:       workspaceID,
+				Name:          "测试评估器",
+				EvaluatorType: tt.serverType,
+			}
+			mockEvaluatorService.EXPECT().
+				GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
+				Return(evaluatorDO, nil)
+			tt.mockSetup()
+
+			request := &evaluatorservice.UpdateEvaluatorDraftRequest{
+				WorkspaceID:   workspaceID,
+				EvaluatorID:   evaluatorID,
+				EvaluatorType: tt.reqType,
+				EvaluatorContent: &evaluatordto.EvaluatorContent{
+					CustomRPCEvaluator: &evaluatordto.CustomRPCEvaluator{
+						ServiceName:    gptr.Of("test.psm.service"),
+						AccessProtocol: evaluatordto.EvaluatorAccessProtocolRPC,
+					},
+				},
+			}
+
+			resp, err := app.UpdateEvaluatorDraft(ctx, request)
+			assert.Error(t, err)
+			if statusErr, ok := errorx.FromStatusError(err); ok {
+				assert.Equal(t, tt.wantErrCode, statusErr.Code())
+			}
+			assert.Nil(t, resp)
 		})
 	}
 }
@@ -7135,8 +7239,8 @@ func TestEvaluatorHandlerImpl_DeleteEvaluator_Comprehensive(t *testing.T) {
 				EvaluatorID: &evaluatorID,
 			},
 			mockSetup: func() {
-				mockEvaluatorService.EXPECT().BatchGetEvaluator(gomock.Any(), workspaceID, []int64{evaluatorID}, false).
-					Return([]*entity.Evaluator{evaluatorDO}, nil)
+				mockEvaluatorService.EXPECT().GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
+					Return(evaluatorDO, nil)
 				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
 				mockEvaluatorService.EXPECT().DeleteEvaluator(gomock.Any(), []int64{evaluatorID}, gomock.Any()).Return(nil)
 			},
@@ -7149,7 +7253,7 @@ func TestEvaluatorHandlerImpl_DeleteEvaluator_Comprehensive(t *testing.T) {
 				EvaluatorID: &evaluatorID,
 			},
 			mockSetup: func() {
-				mockEvaluatorService.EXPECT().BatchGetEvaluator(gomock.Any(), workspaceID, []int64{evaluatorID}, false).
+				mockEvaluatorService.EXPECT().GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
 					Return(nil, errors.New("db error"))
 			},
 			wantErr: true,
@@ -7161,8 +7265,8 @@ func TestEvaluatorHandlerImpl_DeleteEvaluator_Comprehensive(t *testing.T) {
 				EvaluatorID: &evaluatorID,
 			},
 			mockSetup: func() {
-				mockEvaluatorService.EXPECT().BatchGetEvaluator(gomock.Any(), workspaceID, []int64{evaluatorID}, false).
-					Return([]*entity.Evaluator{evaluatorDO}, nil)
+				mockEvaluatorService.EXPECT().GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
+					Return(evaluatorDO, nil)
 				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(errors.New("auth failed"))
 			},
 			wantErr: true,
@@ -7174,8 +7278,8 @@ func TestEvaluatorHandlerImpl_DeleteEvaluator_Comprehensive(t *testing.T) {
 				EvaluatorID: &evaluatorID,
 			},
 			mockSetup: func() {
-				mockEvaluatorService.EXPECT().BatchGetEvaluator(gomock.Any(), workspaceID, []int64{evaluatorID}, false).
-					Return([]*entity.Evaluator{evaluatorDO}, nil)
+				mockEvaluatorService.EXPECT().GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
+					Return(evaluatorDO, nil)
 				mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
 				mockEvaluatorService.EXPECT().DeleteEvaluator(gomock.Any(), []int64{evaluatorID}, gomock.Any()).
 					Return(errors.New("delete error"))
@@ -7183,17 +7287,31 @@ func TestEvaluatorHandlerImpl_DeleteEvaluator_Comprehensive(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "evaluator_not_found_skip_delete",
+			// 修复后：查不到（GetEvaluator 返回 nil）必须返回 NotExist 并拒绝删除，
+			// 不再跳过鉴权直接删（不设 Authorization / DeleteEvaluator 期望，gomock 严格模式会拦住误调用）。
+			name: "evaluator_not_found_reject",
 			req: &evaluatorservice.DeleteEvaluatorRequest{
 				WorkspaceID: workspaceID,
 				EvaluatorID: &evaluatorID,
 			},
 			mockSetup: func() {
-				mockEvaluatorService.EXPECT().BatchGetEvaluator(gomock.Any(), workspaceID, []int64{evaluatorID}, false).
-					Return([]*entity.Evaluator{nil}, nil)
-				mockEvaluatorService.EXPECT().DeleteEvaluator(gomock.Any(), []int64{evaluatorID}, gomock.Any()).Return(nil)
+				mockEvaluatorService.EXPECT().GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
+					Return(nil, nil)
 			},
-			wantErr: false,
+			wantErr: true,
+		},
+		{
+			// 跨空间 id：GetEvaluator 因 SpaceID 不匹配返回 nil，同样拒绝、不删（不越权删他人资源）。
+			name: "cross_space_rejected",
+			req: &evaluatorservice.DeleteEvaluatorRequest{
+				WorkspaceID: workspaceID,
+				EvaluatorID: &evaluatorID,
+			},
+			mockSetup: func() {
+				mockEvaluatorService.EXPECT().GetEvaluator(gomock.Any(), workspaceID, evaluatorID, false).
+					Return(nil, nil)
+			},
+			wantErr: true,
 		},
 	}
 

--- a/backend/modules/evaluation/application/experiment_app.go
+++ b/backend/modules/evaluation/application/experiment_app.go
@@ -285,22 +285,24 @@ func (e *experimentApplication) UpdateExperimentTemplate(ctx context.Context, re
 
 	logs.CtxInfo(ctx, "UpdateExperimentTemplate template_id: %d, workspace_id: %d", templateID, workspaceID)
 
-	// 权限校验，与 ListExperimentTemplates 一致：空间级 listLoopExptTemplate
-	if err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
-		ObjectID:      strconv.FormatInt(workspaceID, 10),
-		SpaceID:       workspaceID,
-		ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.ActionReadExptTemplate), EntityType: gptr.Of(rpc.AuthEntityType_Space)}},
-	}); err != nil {
-		return nil, err
-	}
-
-	// 获取现有模板用于业务逻辑
+	// 先获取现有模板：拿 owner + 存在性（Get 已按 workspaceID 过滤，跨空间返回 not-found）
 	got, err := e.templateManager.Get(ctx, templateID, workspaceID, session)
 	if err != nil {
 		return nil, err
 	}
 	if got == nil {
 		return nil, errorx.NewByCode(errno.ResourceNotFoundCode, errorx.WithExtraMsg("template not found"))
+	}
+
+	// 对象级 edit 权限校验：仅模板 owner / 具备 edit 权限者可修改，防止同空间低权限用户越权改他人模板
+	if err = e.auth.AuthorizationWithoutSPI(ctx, &rpc.AuthorizationWithoutSPIParam{
+		ObjectID:        strconv.FormatInt(templateID, 10),
+		SpaceID:         workspaceID,
+		ActionObjects:   []*rpc.ActionObject{{Action: gptr.Of(consts.Edit), EntityType: gptr.Of(rpc.AuthEntityType_EvaluationExptTemplate)}},
+		OwnerID:         gptr.Of(got.GetCreatedBy()),
+		ResourceSpaceID: workspaceID,
+	}); err != nil {
+		return nil, err
 	}
 
 	// 转换请求参数

--- a/backend/modules/evaluation/application/experiment_app_test.go
+++ b/backend/modules/evaluation/application/experiment_app_test.go
@@ -3408,15 +3408,24 @@ func TestExperimentApplication_UpdateExperimentTemplate(t *testing.T) {
 			BaseInfo: existing.BaseInfo,
 		}
 
-		// 先 Get 做权限用
+		// 先 Get 拿 owner + 存在性
 		mockTemplateManager.EXPECT().
 			Get(gomock.Any(), templateID, workspaceID, gomock.Any()).
 			Return(existing, nil)
 
-		// 使用 Authorization 做空间级模板读权限校验
+		// 对象级 edit 权限校验
 		mockAuth.EXPECT().
-			Authorization(gomock.Any(), gomock.Any()).
-			Return(nil)
+			AuthorizationWithoutSPI(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, param *rpc.AuthorizationWithoutSPIParam) error {
+				assert.Equal(t, strconv.FormatInt(templateID, 10), param.ObjectID)
+				assert.Equal(t, workspaceID, param.SpaceID)
+				assert.Equal(t, workspaceID, param.ResourceSpaceID)
+				assert.Equal(t, "u1", *param.OwnerID)
+				assert.Equal(t, 1, len(param.ActionObjects))
+				assert.Equal(t, "edit", *param.ActionObjects[0].Action)
+				assert.Equal(t, rpc.AuthEntityType_EvaluationExptTemplate, *param.ActionObjects[0].EntityType)
+				return nil
+			})
 
 		mockTemplateManager.EXPECT().
 			Update(gomock.Any(), gomock.Any(), gomock.Any()).
@@ -3448,6 +3457,64 @@ func TestExperimentApplication_UpdateExperimentTemplate(t *testing.T) {
 		resp, err := app.UpdateExperimentTemplate(context.Background(), req)
 		assert.NoError(t, err)
 		assert.Equal(t, "new_name", resp.GetExperimentTemplate().GetMeta().GetName())
+	})
+
+	t.Run("no edit permission rejected", func(t *testing.T) {
+		req := &exptpb.UpdateExperimentTemplateRequest{
+			WorkspaceID: workspaceID,
+			TemplateID:  templateID,
+			Meta: &expt.ExptTemplateMeta{
+				Name: gptr.Of("new_name"),
+			},
+		}
+
+		existing := &entity.ExptTemplate{
+			Meta: &entity.ExptTemplateMeta{
+				ID:          templateID,
+				WorkspaceID: workspaceID,
+				Name:        "old_name",
+			},
+			BaseInfo: &entity.BaseInfo{
+				CreatedBy: &entity.UserInfo{UserID: gptr.Of("u1")},
+			},
+		}
+
+		// Get 正常返回他人模板
+		mockTemplateManager.EXPECT().
+			Get(gomock.Any(), templateID, workspaceID, gomock.Any()).
+			Return(existing, nil)
+
+		// 对象级 edit 校验失败：仅有 list/read 权限的用户被拒绝
+		mockAuth.EXPECT().
+			AuthorizationWithoutSPI(gomock.Any(), gomock.Any()).
+			Return(errorx.NewByCode(errno.CommonNoPermissionCode))
+
+		// Update 绝不应被调用（gomock 未声明即禁止调用）
+
+		app := NewExperimentApplication(
+			nil,                 // aggResultSvc
+			nil,                 // resultSvc
+			nil,                 // manager
+			nil,                 // scheduler
+			nil,                 // recordEval
+			nil,                 // idgen
+			nil,                 // configer
+			mockAuth,            // auth
+			mockUserInfo,        // userInfoService
+			nil,                 // evalTargetService
+			nil,                 // evaluationSetItemService
+			nil,                 // annotateService
+			nil,                 // tagRPCAdapter
+			nil,                 // exptResultExportService
+			nil,                 // exptInsightAnalysisService
+			nil,                 // evaluatorService
+			mockTemplateManager, // templateManager
+			nil,                 // fileProvider
+			nil,                 // lifecycleEventHandler
+			nil,                 // sandboxSchedulerAdapter
+		)
+		_, err := app.UpdateExperimentTemplate(context.Background(), req)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
 ## What

  Fix authorization gaps in the evaluation module's application layer:

  1. **`DebugEvalTarget` / `AsyncDebugEvalTarget`** — the authorization call was
     commented out in both the sync and async eval-target debug handlers, so any
     authenticated caller could trigger a debug run against an arbitrary
     `workspace_id`. Restored the space-level `Authorization` check
     (`ActionDebugEvalTarget` / `AuthEntityType_Space`) on both. (The frontend
     "debug target" feature calls both endpoints depending on sync/async mode, so
     both must be fixed.)

  2. **`UpdateExperimentTemplate`** — the write path only checked space-level
     *read/list* permission, allowing a low-privilege member to modify templates
     owned by others. Switched to an object-level *edit* check
     (`AuthorizationWithoutSPI` with the template's owner), consistent with
     `UpdateExperiment`.

  3. **`DeleteEvaluator`** — authorization relied on the result of an unfiltered
     batch lookup; an empty result silently skipped the auth check and fell
     through to a global-id soft delete. Reworked to use the space-scoped
     `GetEvaluator`, return `EvaluatorNotExistCode` when not found, and authorize
     against the resolved object — aligned with `UpdateEvaluator`.

  4. **`UpdateEvaluatorDraft`** — the CustomRPC/Agent write gate keyed off the
     client-supplied `evaluator_type`, while persistence used the server object's
     real type (type confusion): a caller could declare a non-CustomRPC type to
     skip the gate yet still write CustomRPC content. The gate now keys off the
     server-side type, plus a consistency check that rejects a request whose
     declared type does not match the stored object.

  ## Why

  Each is an authorization boundary defect: missing (1), downgraded to a weaker
  permission (2), auth object vs. write object mismatch (3), or auth decision
  driven by client-controllable input (4).

  ## Tests

  Added/updated unit tests covering the unauthorized/mismatched paths for all
  handlers (permission-denied, not-found rejection, cross-space rejection,
  type-mismatch rejection). All evaluation application tests pass:
  `cd backend && go test -gcflags="all=-N -l" ./modules/evaluation/application/...`