### PR TITLE
[fix][evaluation] Guard against false experiment termination after zombie kill

### DIFF
--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_mode_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_mode_impl.go
@@ -719,8 +719,16 @@ func (e *ExptSubmitExec) ScanEvalItems(ctx context.Context, event *entity.ExptSc
 
 func (e *ExptSubmitExec) ExptEnd(ctx context.Context, event *entity.ExptScheduleEvent, expt *entity.Experiment, toSubmit, incomplete int) (nextTick bool, err error) {
 	if toSubmit == 0 && incomplete == 0 {
+		base := newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService)
+		pending, err := base.hasPendingAfterRescan(ctx, event)
+		if err != nil {
+			return false, err
+		}
+		if pending {
+			return true, nil
+		}
 		logs.CtxInfo(ctx, "[ExptEval] expt daemon finished, expt_id: %v, expt_run_id: %v", event.ExptID, event.ExptRunID)
-		return false, newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService).exptEnd(ctx, event, expt)
+		return false, base.exptEnd(ctx, event, expt)
 	}
 	return true, nil
 }
@@ -936,8 +944,16 @@ func (e *ExptFailRetryExec) ScanEvalItems(ctx context.Context, event *entity.Exp
 
 func (e *ExptFailRetryExec) ExptEnd(ctx context.Context, event *entity.ExptScheduleEvent, expt *entity.Experiment, toSubmit, incomplete int) (nextTick bool, err error) {
 	if toSubmit == 0 && incomplete == 0 {
+		base := newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService)
+		pending, err := base.hasPendingAfterRescan(ctx, event)
+		if err != nil {
+			return false, err
+		}
+		if pending {
+			return true, nil
+		}
 		logs.CtxInfo(ctx, "[ExptEval] expt daemon finished, expt_id: %v, expt_run_id: %v", event.ExptID, event.ExptRunID)
-		return false, newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService).exptEnd(ctx, event, expt)
+		return false, base.exptEnd(ctx, event, expt)
 	}
 	return true, nil
 }
@@ -1276,6 +1292,28 @@ func (e *exptBaseExec) exptEnd(ctx context.Context, event *entity.ExptScheduleEv
 		logs.CtxError(ctx, "ExptSchedulerImpl set end idem key fail, err: %v", err)
 	}
 	return nil
+}
+
+// hasPendingAfterRescan 终止前以 DB 真实状态为准重扫一次，判断是否还有待处理的 item。
+// 背景：本 tick 传入的 toSubmit/incomplete 计数是在 handleZombies 清理僵尸之前算出来的。
+// 当并发度被 Processing 僵尸占满时，scanToSubmit 会因空闲名额为 0 而跳过、不去捞 Queueing item;
+// 随后僵尸被置 Fail 移出 incomplete，导致离线模式 ExptEnd 看到 toSubmit==0 && incomplete==0 而误判完成，
+// 把仍在 Queueing 的 item 永久遗漏。此处对齐在线(Append)模式"终止前重扫、不信旧计数"的做法。
+// 直接查 DB 是否仍有 Queueing/Processing 的 item(不受并发名额门控影响)，limit 1 即可，
+// 仅在准备收工这条冷路径触发，成本可控。
+func (e *exptBaseExec) hasPendingAfterRescan(ctx context.Context, event *entity.ExptScheduleEvent) (bool, error) {
+	rls, _, err := e.exptItemResultRepo.ScanItemRunLogs(ctx, event.ExptID, event.ExptRunID, &entity.ExptItemRunLogFilter{
+		Status: []entity.ItemRunState{entity.ItemRunState_Queueing, entity.ItemRunState_Processing},
+	}, 0, 1, event.SpaceID)
+	if err != nil {
+		return false, err
+	}
+	if len(rls) > 0 {
+		logs.CtxInfo(ctx, "[ExptEval] rescan before end found pending item, keep ticking, expt_id: %v, expt_run_id: %v, item_id: %v, status: %v",
+			event.ExptID, event.ExptRunID, rls[0].ItemID, rls[0].Status)
+		return true, nil
+	}
+	return false, nil
 }
 
 func (e *exptBaseExec) publishResult(ctx context.Context, turnEvaluatorRefs []*entity.ExptTurnEvaluatorResultRef, event *entity.ExptScheduleEvent) error {
@@ -1702,8 +1740,16 @@ func (e *ExptRetryAllExec) ScanEvalItems(ctx context.Context, event *entity.Expt
 
 func (e *ExptRetryAllExec) ExptEnd(ctx context.Context, event *entity.ExptScheduleEvent, expt *entity.Experiment, toSubmit, incomplete int) (nextTick bool, err error) {
 	if toSubmit == 0 && incomplete == 0 {
+		base := newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService)
+		pending, err := base.hasPendingAfterRescan(ctx, event)
+		if err != nil {
+			return false, err
+		}
+		if pending {
+			return true, nil
+		}
 		logs.CtxInfo(ctx, "[ExptEval] expt daemon finished, expt_id: %v, expt_run_id: %v", event.ExptID, event.ExptRunID)
-		return false, newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService).exptEnd(ctx, event, expt)
+		return false, base.exptEnd(ctx, event, expt)
 	}
 	return true, nil
 }
@@ -2117,7 +2163,16 @@ func (e *ExptRetryItemsExec) ExptEnd(ctx context.Context, event *entity.ExptSche
 		}
 	}
 
-	if err := newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService).exptEnd(ctx, event, expt); err != nil {
+	base := newExptBaseExec(e.manager, e.idem, e.configer, e.exptItemResultRepo, e.publisher, e.evaluatorRecordService)
+	pending, err := base.hasPendingAfterRescan(ctx, event)
+	if err != nil {
+		return false, err
+	}
+	if pending {
+		return true, nil
+	}
+
+	if err := base.exptEnd(ctx, event, expt); err != nil {
 		return false, err
 	}
 	return false, nil

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_mode_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_mode_impl_test.go
@@ -164,6 +164,8 @@ func TestExptSubmitExec_ExptEnd(t *testing.T) {
 			if tc.mockSetup != nil {
 				tc.mockSetup(f)
 			}
+			// 终止前重扫默认无残留 item(除非用例自行覆盖)，使既有"正常结束"用例继续通过。
+			f.itemRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, int64(0), nil).AnyTimes()
 			exec := &ExptSubmitExec{
 				manager:            f.manager,
 				idem:               f.idem,
@@ -179,6 +181,36 @@ func TestExptSubmitExec_ExptEnd(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExptSubmitExec_ExptEnd_RescanGuard 覆盖终止前重扫护栏：
+// 即便本 tick 传入的 toSubmit/incomplete 均为 0(僵尸被清后的误判场景)，
+// 只要 DB 里仍有 Queueing/Processing 的 item，ExptEnd 必须返回 nextTick=true 且不结束实验。
+func TestExptSubmitExec_ExptEnd_RescanGuard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := &exptSubmitExecFields{
+		manager:   svcmocks.NewMockIExptManager(ctrl),
+		idem:      idemmocks.NewMockIdempotentService(ctrl),
+		configer:  configmocks.NewMockIConfiger(ctrl),
+		itemRepo:  mock_repo.NewMockIExptItemResultRepo(ctrl),
+		publisher: eventmocks.NewMockExptEventPublisher(ctrl),
+	}
+	// 重扫命中一个仍在排队的 item：护栏应保持 tick，不得走 exptEnd(不允许调用 idem.Exist/CompleteRun/CompleteExpt)。
+	f.itemRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*entity.ExptItemResultRunLog{{ItemID: 1001, Status: int32(entity.ItemRunState_Queueing)}}, int64(1), nil)
+
+	exec := &ExptSubmitExec{
+		manager:            f.manager,
+		idem:               f.idem,
+		configer:           f.configer,
+		exptItemResultRepo: f.itemRepo,
+	}
+	event := &entity.ExptScheduleEvent{ExptID: 1, ExptRunID: 2, SpaceID: 3, ExptRunMode: 1, Session: &entity.Session{UserID: "u1"}}
+	nextTick, err := exec.ExptEnd(context.Background(), event, &entity.Experiment{}, 0, 0)
+	assert.NoError(t, err)
+	assert.True(t, nextTick, "still has queueing item -> must keep ticking, not terminate")
 }
 
 func TestExptSubmitExec_NextTick(t *testing.T) {
@@ -1316,6 +1348,8 @@ func TestExptFailRetryExec_ExptEnd(t *testing.T) {
 			if tt.prepareMock != nil {
 				tt.prepareMock(f, ctrl, tt.args)
 			}
+			// 终止前重扫默认无残留 item(除非用例自行覆盖)，使既有"正常结束"用例继续通过。
+			f.exptItemResultRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, int64(0), nil).AnyTimes()
 
 			e := &ExptFailRetryExec{
 				manager:            f.manager,
@@ -3981,6 +4015,8 @@ func TestExptRetryAllExec_ExptEnd(t *testing.T) {
 			if tt.prepareMock != nil {
 				tt.prepareMock(f, tt.args)
 			}
+			// 终止前重扫默认无残留 item(除非用例自行覆盖)，使既有"正常结束"用例继续通过。
+			f.exptItemResultRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, int64(0), nil).AnyTimes()
 
 			e := &ExptRetryAllExec{
 				manager:                  f.manager,
@@ -4829,6 +4865,8 @@ func TestExptRetryItemsExec_ExptEnd(t *testing.T) {
 			if tt.prepareMock != nil {
 				tt.prepareMock(f, tt.args)
 			}
+			// 终止前重扫默认无残留 item(除非用例自行覆盖)，使既有"正常结束"用例继续通过。
+			f.exptItemResultRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, int64(0), nil).AnyTimes()
 
 			e := &ExptRetryItemsExec{
 				manager:                  f.manager,

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_mode_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_mode_impl_test.go
@@ -1372,6 +1372,37 @@ func TestExptFailRetryExec_ExptEnd(t *testing.T) {
 	}
 }
 
+// TestExptFailRetryExec_ExptEnd_RescanGuard 覆盖终止前重扫护栏：
+// 即便本 tick 传入的 toSubmit/incomplete 均为 0(僵尸被清后的误判场景)，
+// 只要 DB 里仍有 Queueing/Processing 的 item，ExptEnd 必须返回 nextTick=true 且不结束实验。
+func TestExptFailRetryExec_ExptEnd_RescanGuard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := &exptFailRetryExecFields{
+		manager:            svcmocks.NewMockIExptManager(ctrl),
+		exptItemResultRepo: mock_repo.NewMockIExptItemResultRepo(ctrl),
+		idem:               idemmocks.NewMockIdempotentService(ctrl),
+		configer:           configmocks.NewMockIConfiger(ctrl),
+		publisher:          eventmocks.NewMockExptEventPublisher(ctrl),
+	}
+	// 重扫命中一个仍在处理的 item：护栏应保持 tick，不得走 exptEnd(不允许调用 idem.Exist/CompleteRun/CompleteExpt)。
+	f.exptItemResultRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*entity.ExptItemResultRunLog{{ItemID: 1001, Status: int32(entity.ItemRunState_Processing)}}, int64(1), nil)
+
+	e := &ExptFailRetryExec{
+		manager:            f.manager,
+		exptItemResultRepo: f.exptItemResultRepo,
+		idem:               f.idem,
+		configer:           f.configer,
+		publisher:          f.publisher,
+	}
+	event := &entity.ExptScheduleEvent{ExptID: 1, ExptRunID: 2, SpaceID: 3, ExptRunMode: 1, Session: &entity.Session{UserID: "u1"}}
+	nextTick, err := e.ExptEnd(context.Background(), event, &entity.Experiment{}, 0, 0)
+	assert.NoError(t, err)
+	assert.True(t, nextTick, "still has processing item -> must keep ticking, not terminate")
+}
+
 func TestExptAppendExec_Mode(t *testing.T) {
 	type fields struct {
 		manager            *svcmocks.MockIExptManager
@@ -4042,6 +4073,38 @@ func TestExptRetryAllExec_ExptEnd(t *testing.T) {
 	}
 }
 
+// TestExptRetryAllExec_ExptEnd_RescanGuard 覆盖终止前重扫护栏：
+// 即便本 tick 传入的 toSubmit/incomplete 均为 0(僵尸被清后的误判场景)，
+// 只要 DB 里仍有 Queueing/Processing 的 item，ExptEnd 必须返回 nextTick=true 且不结束实验。
+func TestExptRetryAllExec_ExptEnd_RescanGuard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	f := buildRetryAllExecFields(ctrl)
+	// 重扫命中一个仍在排队的 item：护栏应保持 tick，不得走 exptEnd(不允许调用 idem.Exist/CompleteRun/CompleteExpt)。
+	f.exptItemResultRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*entity.ExptItemResultRunLog{{ItemID: 1001, Status: int32(entity.ItemRunState_Queueing)}}, int64(1), nil)
+
+	e := &ExptRetryAllExec{
+		manager:                  f.manager,
+		exptItemResultRepo:       f.exptItemResultRepo,
+		exptStatsRepo:            f.exptStatsRepo,
+		exptTurnResultRepo:       f.exptTurnResultRepo,
+		idgenerator:              f.idgenerator,
+		evaluationSetItemService: f.evaluationSetItemService,
+		exptRepo:                 f.exptRepo,
+		idem:                     f.idem,
+		configer:                 f.configer,
+		publisher:                f.publisher,
+		evaluatorRecordService:   f.evaluatorRecordService,
+		templateManager:          f.templateManager,
+	}
+	event := &entity.ExptScheduleEvent{ExptID: 1, ExptRunID: 2, SpaceID: 3, ExptRunMode: 1, Session: &entity.Session{UserID: "u1"}}
+	nextTick, err := e.ExptEnd(context.Background(), event, &entity.Experiment{}, 0, 0)
+	assert.NoError(t, err)
+	assert.True(t, nextTick, "still has queueing item -> must keep ticking, not terminate")
+}
+
 func TestExptRetryAllExec_NextTick(t *testing.T) {
 	testUserID := "test_user_id_123"
 
@@ -4891,6 +4954,54 @@ func TestExptRetryItemsExec_ExptEnd(t *testing.T) {
 			assert.Equal(t, tt.wantNextTick, nextTick)
 		})
 	}
+}
+
+// TestExptRetryItemsExec_ExptEnd_RescanGuard 覆盖终止前重扫护栏：
+// RetryItems 模式在过完 Lock + run log item 归属校验后，仍需以 DB 真实状态重扫一次。
+// 即便本 tick 传入的 toSubmit/incomplete 均为 0，只要 DB 里仍有 Queueing/Processing 的 item，
+// ExptEnd 必须返回 nextTick=true 且不结束实验(不允许调用 exptEnd 内的 idem.Exist/CompleteRun/CompleteExpt)。
+func TestExptRetryItemsExec_ExptEnd_RescanGuard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	testUserID := "test_user_id_123"
+	f := buildRetryItemsExecFields(ctrl)
+	event := &entity.ExptScheduleEvent{
+		ExptID:             1,
+		ExptRunID:          2,
+		SpaceID:            3,
+		ExptRunMode:        entity.EvaluationModeRetryItems,
+		Session:            &entity.Session{UserID: testUserID},
+		ExecEvalSetItemIDs: []int64{1},
+	}
+	// 走完前置：抢锁成功 → run log 全部 item 均在本轮重试范围内 → 进入重扫 → 解锁。
+	f.manager.EXPECT().LockCompletingRun(gomock.Any(), event.ExptID, event.ExptRunID, event.SpaceID, event.Session).Return(nil).Times(1)
+	f.exptRunLogRepo.EXPECT().Get(gomock.Any(), event.ExptID, event.ExptRunID).Return(&entity.ExptRunLog{
+		ItemIds: []entity.ExptRunLogItems{{ItemIDs: []int64{1}}},
+	}, nil).Times(1)
+	f.manager.EXPECT().UnlockCompletingRun(gomock.Any(), event.ExptID, event.ExptRunID, event.SpaceID, event.Session).Return(nil).Times(1)
+	// 重扫命中一个仍在排队的 item：护栏应保持 tick，不得走 exptEnd。
+	f.exptItemResultRepo.EXPECT().ScanItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]*entity.ExptItemResultRunLog{{ItemID: 1001, Status: int32(entity.ItemRunState_Queueing)}}, int64(1), nil)
+
+	e := &ExptRetryItemsExec{
+		manager:                  f.manager,
+		exptItemResultRepo:       f.exptItemResultRepo,
+		exptStatsRepo:            f.exptStatsRepo,
+		exptTurnResultRepo:       f.exptTurnResultRepo,
+		idgenerator:              f.idgenerator,
+		evaluationSetItemService: f.evaluationSetItemService,
+		exptRepo:                 f.exptRepo,
+		idem:                     f.idem,
+		configer:                 f.configer,
+		publisher:                f.publisher,
+		evaluatorRecordService:   f.evaluatorRecordService,
+		templateManager:          f.templateManager,
+		exptRunLogRepo:           f.exptRunLogRepo,
+	}
+	nextTick, err := e.ExptEnd(session.WithCtxUser(context.Background(), &session.User{ID: testUserID}), event, buildMockExpt(), 0, 0)
+	assert.NoError(t, err)
+	assert.True(t, nextTick, "still has queueing item -> must keep ticking, not terminate")
 }
 
 func TestExptRetryItemsExec_ScheduleStart(t *testing.T) {


### PR DESCRIPTION
Problem

With concurrency=1, if the only Processing item becomes a zombie, ScanEvalItems skips scanToSubmit (no free concurrency slot) and never picks up Queueing items. handleZombies then marks the zombie as Failed and removes it from incomplete. In offline mode, ExptEnd sees toSubmit == 0 && incomplete == 0, wrongly concludes the experiment is done, and terminates it — leaving still-Queueing items behind.

Fix

Align offline mode with the online (Append) pattern of "rescan before ending, don't trust stale counts". Added hasPendingAfterRescan on exptBaseExec, which queries the DB directly for any Queueing/Processing items (not gated by concurrency slots), triggered only on the cold path right before finalizing. The four offline executors (Submit / FailRetry / RetryAll / RetryItems) now pass this guard before terminating; if anything remains, they continue with nextTick. Append mode already rescans and is unaffected.

Tests

Added unit tests covering both the positive and negative paths of the guard across all retry executors. In the misjudgment scenario (toSubmit == incomplete == 0), the tests assert that as long as the DB rescan still finds Queueing/Processing items, ExptEnd returns nextTick=true and does not finalize. The RetryItems case additionally covers the Lock + run-log item-ownership pre-checks.