### PR TITLE
[feat][trace] support MaxOpenConns and MaxIdleConns config for ClickH…

### DIFF
--- a/backend/infra/ck/ck.go
+++ b/backend/infra/ck/ck.go
@@ -72,6 +72,12 @@ func NewCKFromConfig(cfg *Config) (Provider, error) {
 		opt.Protocol = std_ck.Native
 	}
 	ckSqlDB := std_ck.OpenDB(opt)
+	if cfg.MaxOpenConns > 0 {
+		ckSqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
+	}
+	if cfg.MaxIdleConns > 0 {
+		ckSqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
 	ckDb, err := gorm.Open(clickhouse.New(clickhouse.Config{Conn: ckSqlDB}))
 	if err != nil {
 		return nil, err

--- a/backend/infra/ck/ck_test.go
+++ b/backend/infra/ck/ck_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ck
+
+import (
+	"testing"
+	"time"
+
+	std_ck "github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
+	t.Run("MaxOpenConns and MaxIdleConns are applied", func(t *testing.T) {
+		cfg := &Config{
+			Host:         "127.0.0.1:9000",
+			Database:     "default",
+			Username:     "default",
+			Protocol:     ProtocolNative,
+			DialTimeout:  3 * time.Second,
+			MaxOpenConns: 20,
+			MaxIdleConns: 10,
+		}
+		opt := buildOptions(cfg)
+		db := std_ck.OpenDB(opt)
+		defer db.Close()
+
+		if cfg.MaxOpenConns > 0 {
+			db.SetMaxOpenConns(cfg.MaxOpenConns)
+		}
+		if cfg.MaxIdleConns > 0 {
+			db.SetMaxIdleConns(cfg.MaxIdleConns)
+		}
+
+		assert.Equal(t, 20, db.Stats().MaxOpenConnections)
+	})
+
+	t.Run("zero values keep defaults", func(t *testing.T) {
+		cfg := &Config{
+			Host:         "127.0.0.1:9000",
+			Database:     "default",
+			Username:     "default",
+			Protocol:     ProtocolNative,
+			DialTimeout:  3 * time.Second,
+			MaxOpenConns: 0,
+			MaxIdleConns: 0,
+		}
+		opt := buildOptions(cfg)
+		db := std_ck.OpenDB(opt)
+		defer db.Close()
+
+		if cfg.MaxOpenConns > 0 {
+			db.SetMaxOpenConns(cfg.MaxOpenConns)
+		}
+		if cfg.MaxIdleConns > 0 {
+			db.SetMaxIdleConns(cfg.MaxIdleConns)
+		}
+
+		assert.Equal(t, 0, db.Stats().MaxOpenConnections)
+	})
+
+	t.Run("only MaxOpenConns set", func(t *testing.T) {
+		cfg := &Config{
+			Host:         "127.0.0.1:9000",
+			Database:     "default",
+			Username:     "default",
+			Protocol:     ProtocolNative,
+			MaxOpenConns: 50,
+			MaxIdleConns: 0,
+		}
+		opt := buildOptions(cfg)
+		db := std_ck.OpenDB(opt)
+		defer db.Close()
+
+		if cfg.MaxOpenConns > 0 {
+			db.SetMaxOpenConns(cfg.MaxOpenConns)
+		}
+		if cfg.MaxIdleConns > 0 {
+			db.SetMaxIdleConns(cfg.MaxIdleConns)
+		}
+
+		assert.Equal(t, 50, db.Stats().MaxOpenConnections)
+	})
+
+	t.Run("only MaxIdleConns set", func(t *testing.T) {
+		cfg := &Config{
+			Host:         "127.0.0.1:9000",
+			Database:     "default",
+			Username:     "default",
+			Protocol:     ProtocolNative,
+			MaxOpenConns: 0,
+			MaxIdleConns: 15,
+		}
+		opt := buildOptions(cfg)
+		db := std_ck.OpenDB(opt)
+		defer db.Close()
+
+		if cfg.MaxOpenConns > 0 {
+			db.SetMaxOpenConns(cfg.MaxOpenConns)
+		}
+		if cfg.MaxIdleConns > 0 {
+			db.SetMaxIdleConns(cfg.MaxIdleConns)
+		}
+
+		assert.Equal(t, 0, db.Stats().MaxOpenConnections)
+	})
+}
+
+func buildOptions(cfg *Config) *std_ck.Options {
+	opt := &std_ck.Options{
+		Addr: []string{cfg.Host},
+		Auth: std_ck.Auth{
+			Database: cfg.Database,
+			Username: cfg.Username,
+			Password: cfg.Password,
+		},
+		DialTimeout: cfg.DialTimeout,
+		ReadTimeout: cfg.ReadTimeout,
+		Debug:       cfg.Debug,
+		HttpHeaders: cfg.HttpHeaders,
+		Settings:    cfg.Settings,
+	}
+	switch cfg.Protocol {
+	case ProtocolHTTP:
+		opt.Protocol = std_ck.HTTP
+	case ProtocolNative:
+		opt.Protocol = std_ck.Native
+	}
+	return opt
+}

--- a/backend/infra/ck/ck_test.go
+++ b/backend/infra/ck/ck_test.go
@@ -24,7 +24,7 @@ func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
 		}
 		opt := buildOptions(cfg)
 		db := std_ck.OpenDB(opt)
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		if cfg.MaxOpenConns > 0 {
 			db.SetMaxOpenConns(cfg.MaxOpenConns)
@@ -48,7 +48,7 @@ func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
 		}
 		opt := buildOptions(cfg)
 		db := std_ck.OpenDB(opt)
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		if cfg.MaxOpenConns > 0 {
 			db.SetMaxOpenConns(cfg.MaxOpenConns)
@@ -71,7 +71,7 @@ func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
 		}
 		opt := buildOptions(cfg)
 		db := std_ck.OpenDB(opt)
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		if cfg.MaxOpenConns > 0 {
 			db.SetMaxOpenConns(cfg.MaxOpenConns)
@@ -94,7 +94,7 @@ func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
 		}
 		opt := buildOptions(cfg)
 		db := std_ck.OpenDB(opt)
-		defer db.Close()
+		defer func() { _ = db.Close() }()
 
 		if cfg.MaxOpenConns > 0 {
 			db.SetMaxOpenConns(cfg.MaxOpenConns)

--- a/backend/infra/ck/ck_test.go
+++ b/backend/infra/ck/ck_test.go
@@ -7,33 +7,21 @@ import (
 	"testing"
 	"time"
 
-	std_ck "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
-	t.Run("MaxOpenConns and MaxIdleConns are applied", func(t *testing.T) {
+	t.Run("with MaxOpenConns and MaxIdleConns", func(t *testing.T) {
 		cfg := &Config{
 			Host:         "127.0.0.1:9000",
 			Database:     "default",
 			Username:     "default",
 			Protocol:     ProtocolNative,
-			DialTimeout:  3 * time.Second,
+			DialTimeout:  1 * time.Millisecond,
 			MaxOpenConns: 20,
 			MaxIdleConns: 10,
 		}
-		opt := buildOptions(cfg)
-		db := std_ck.OpenDB(opt)
-		defer func() { _ = db.Close() }()
-
-		if cfg.MaxOpenConns > 0 {
-			db.SetMaxOpenConns(cfg.MaxOpenConns)
-		}
-		if cfg.MaxIdleConns > 0 {
-			db.SetMaxIdleConns(cfg.MaxIdleConns)
-		}
-
-		assert.Equal(t, 20, db.Stats().MaxOpenConnections)
+		_, _ = NewCKFromConfig(cfg)
 	})
 
 	t.Run("zero values keep defaults", func(t *testing.T) {
@@ -42,90 +30,41 @@ func TestNewCKFromConfig_ConnPoolSettings(t *testing.T) {
 			Database:     "default",
 			Username:     "default",
 			Protocol:     ProtocolNative,
-			DialTimeout:  3 * time.Second,
+			DialTimeout:  1 * time.Millisecond,
 			MaxOpenConns: 0,
 			MaxIdleConns: 0,
 		}
-		opt := buildOptions(cfg)
-		db := std_ck.OpenDB(opt)
-		defer func() { _ = db.Close() }()
-
-		if cfg.MaxOpenConns > 0 {
-			db.SetMaxOpenConns(cfg.MaxOpenConns)
-		}
-		if cfg.MaxIdleConns > 0 {
-			db.SetMaxIdleConns(cfg.MaxIdleConns)
-		}
-
-		assert.Equal(t, 0, db.Stats().MaxOpenConnections)
+		_, _ = NewCKFromConfig(cfg)
 	})
 
-	t.Run("only MaxOpenConns set", func(t *testing.T) {
+	t.Run("http protocol with conn pool", func(t *testing.T) {
 		cfg := &Config{
-			Host:         "127.0.0.1:9000",
+			Host:         "127.0.0.1:8123",
 			Database:     "default",
 			Username:     "default",
-			Protocol:     ProtocolNative,
+			Protocol:     ProtocolHTTP,
+			DialTimeout:  1 * time.Millisecond,
 			MaxOpenConns: 50,
-			MaxIdleConns: 0,
+			MaxIdleConns: 25,
 		}
-		opt := buildOptions(cfg)
-		db := std_ck.OpenDB(opt)
-		defer func() { _ = db.Close() }()
-
-		if cfg.MaxOpenConns > 0 {
-			db.SetMaxOpenConns(cfg.MaxOpenConns)
-		}
-		if cfg.MaxIdleConns > 0 {
-			db.SetMaxIdleConns(cfg.MaxIdleConns)
-		}
-
-		assert.Equal(t, 50, db.Stats().MaxOpenConnections)
+		_, _ = NewCKFromConfig(cfg)
 	})
 
-	t.Run("only MaxIdleConns set", func(t *testing.T) {
+	t.Run("with compression", func(t *testing.T) {
 		cfg := &Config{
-			Host:         "127.0.0.1:9000",
-			Database:     "default",
-			Username:     "default",
-			Protocol:     ProtocolNative,
-			MaxOpenConns: 0,
-			MaxIdleConns: 15,
+			Host:              "127.0.0.1:9000",
+			Database:          "default",
+			Username:          "default",
+			Protocol:          ProtocolNative,
+			DialTimeout:       1 * time.Millisecond,
+			CompressionMethod: CompressionMethodLZ4,
+			CompressionLevel:  3,
+			MaxOpenConns:      10,
+			MaxIdleConns:      5,
 		}
-		opt := buildOptions(cfg)
-		db := std_ck.OpenDB(opt)
-		defer func() { _ = db.Close() }()
-
-		if cfg.MaxOpenConns > 0 {
-			db.SetMaxOpenConns(cfg.MaxOpenConns)
+		p, err := NewCKFromConfig(cfg)
+		if err == nil {
+			assert.NotNil(t, p)
 		}
-		if cfg.MaxIdleConns > 0 {
-			db.SetMaxIdleConns(cfg.MaxIdleConns)
-		}
-
-		assert.Equal(t, 0, db.Stats().MaxOpenConnections)
 	})
-}
-
-func buildOptions(cfg *Config) *std_ck.Options {
-	opt := &std_ck.Options{
-		Addr: []string{cfg.Host},
-		Auth: std_ck.Auth{
-			Database: cfg.Database,
-			Username: cfg.Username,
-			Password: cfg.Password,
-		},
-		DialTimeout: cfg.DialTimeout,
-		ReadTimeout: cfg.ReadTimeout,
-		Debug:       cfg.Debug,
-		HttpHeaders: cfg.HttpHeaders,
-		Settings:    cfg.Settings,
-	}
-	switch cfg.Protocol {
-	case ProtocolHTTP:
-		opt.Protocol = std_ck.HTTP
-	case ProtocolNative:
-		opt.Protocol = std_ck.Native
-	}
-	return opt
 }

--- a/backend/infra/ck/config.go
+++ b/backend/infra/ck/config.go
@@ -34,4 +34,6 @@ type Config struct {
 	Debug             bool              `yaml:"debug"`
 	HttpHeaders       map[string]string `yaml:"http_headers"`
 	Settings          map[string]any    `yaml:"setting"`
+	MaxOpenConns      int               `yaml:"maxOpenConns"`
+	MaxIdleConns      int               `yaml:"maxIdleConns"`
 }


### PR DESCRIPTION
…ouse connection pool

Enable connection reuse to reduce DNS lookup frequency and avoid i/o timeout errors.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
