### PR TITLE
[feat][evaluation] add KillExperimentOApi open-api endpoint

### DIFF
--- a/backend/api/handler/coze/loop/apis/eval_open_apiservice.go
+++ b/backend/api/handler/coze/loop/apis/eval_open_apiservice.go
@@ -320,3 +320,9 @@ func GetEvalTargetRecordOApi(ctx context.Context, c *app.RequestContext) {
 func UpdateExptRunConfOApi(ctx context.Context, c *app.RequestContext) {
 	invokeAndRender(ctx, c, localEvalOpenAPIClient.UpdateExptRunConfOApi)
 }
+
+// KillExperimentOApi .
+// @router /v1/loop/evaluation/experiments/:experiment_id/kill [POST]
+func KillExperimentOApi(ctx context.Context, c *app.RequestContext) {
+	invokeAndRender(ctx, c, localEvalOpenAPIClient.KillExperimentOApi)
+}

--- a/backend/api/router/coze/loop/apis/coze.loop.apis.go
+++ b/backend/api/router/coze/loop/apis/coze.loop.apis.go
@@ -569,6 +569,7 @@ func Register(r *server.Hertz, handler *apis.APIHandler) {
 				_experiments0.GET("/:experiment_id", append(_experiment_idMw(handler), apis.GetExperimentsOApi)...)
 				_experiment_id := _experiments0.Group("/:experiment_id", _experiment_idMw(handler)...)
 				_experiment_id.POST("/aggr_results", append(_getexperimentaggrresultoapiMw(handler), apis.GetExperimentAggrResultOApi)...)
+				_experiment_id.POST("/kill", append(_killexperimentoapiMw(handler), apis.KillExperimentOApi)...)
 				_experiment_id.POST("/results", append(_results1Mw(handler), apis.ListExperimentResultOApi)...)
 				_results1 := _experiment_id.Group("/results", _results1Mw(handler)...)
 				_results1.POST("/export", append(_exportexperimentresultoapiMw(handler), apis.ExportExperimentResultOApi)...)

--- a/backend/api/router/coze/loop/apis/middleware.go
+++ b/backend/api/router/coze/loop/apis/middleware.go
@@ -2434,3 +2434,8 @@ func _updateexptrunconfoapiMw(handler *apis.APIHandler) []app.HandlerFunc {
 	// your code...
 	return nil
 }
+
+func _killexperimentoapiMw(handler *apis.APIHandler) []app.HandlerFunc {
+	// your code...
+	return nil
+}

--- a/backend/kitex_gen/coze/loop/apis/evalopenapiservice/client.go
+++ b/backend/kitex_gen/coze/loop/apis/evalopenapiservice/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	ListExperimentResultOApi(ctx context.Context, req *openapi.ListExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ListExperimentResultOApiResponse, err error)
 	GetExperimentAggrResultOApi(ctx context.Context, req *openapi.GetExperimentAggrResultOApiRequest, callOptions ...callopt.Option) (r *openapi.GetExperimentAggrResultOApiResponse, err error)
 	RetryExperimentOApi(ctx context.Context, req *openapi.RetryExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.RetryExperimentOApiResponse, err error)
+	KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.KillExperimentOApiResponse, err error)
 	ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ExportExperimentResultOApiResponse, err error)
 	GetExperimentResultExportRecordOApi(ctx context.Context, req *openapi.GetExperimentResultExportRecordOApiRequest, callOptions ...callopt.Option) (r *openapi.GetExperimentResultExportRecordOApiResponse, err error)
 	ListEvaluatorsOApi(ctx context.Context, req *openapi.ListEvaluatorsOApiRequest, callOptions ...callopt.Option) (r *openapi.ListEvaluatorsOApiResponse, err error)
@@ -231,6 +232,11 @@ func (p *kEvalOpenAPIServiceClient) GetExperimentAggrResultOApi(ctx context.Cont
 func (p *kEvalOpenAPIServiceClient) RetryExperimentOApi(ctx context.Context, req *openapi.RetryExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.RetryExperimentOApiResponse, err error) {
 	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
 	return p.kClient.RetryExperimentOApi(ctx, req)
+}
+
+func (p *kEvalOpenAPIServiceClient) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.KillExperimentOApiResponse, err error) {
+	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
+	return p.kClient.KillExperimentOApi(ctx, req)
 }
 
 func (p *kEvalOpenAPIServiceClient) ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ExportExperimentResultOApiResponse, err error) {

--- a/backend/kitex_gen/coze/loop/apis/evalopenapiservice/evalopenapiservice.go
+++ b/backend/kitex_gen/coze/loop/apis/evalopenapiservice/evalopenapiservice.go
@@ -210,6 +210,13 @@ var serviceMethods = map[string]kitex.MethodInfo{
 		false,
 		kitex.WithStreamingMode(kitex.StreamingNone),
 	),
+	"KillExperimentOApi": kitex.NewMethodInfo(
+		killExperimentOApiHandler,
+		newEvaluationOpenAPIServiceKillExperimentOApiArgs,
+		newEvaluationOpenAPIServiceKillExperimentOApiResult,
+		false,
+		kitex.WithStreamingMode(kitex.StreamingNone),
+	),
 	"ExportExperimentResultOApi": kitex.NewMethodInfo(
 		exportExperimentResultOApiHandler,
 		newEvaluationOpenAPIServiceExportExperimentResultOApiArgs,
@@ -936,6 +943,25 @@ func newEvaluationOpenAPIServiceRetryExperimentOApiResult() interface{} {
 	return openapi.NewEvaluationOpenAPIServiceRetryExperimentOApiResult()
 }
 
+func killExperimentOApiHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
+	realArg := arg.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs)
+	realResult := result.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiResult)
+	success, err := handler.(openapi.EvaluationOpenAPIService).KillExperimentOApi(ctx, realArg.Req)
+	if err != nil {
+		return err
+	}
+	realResult.Success = success
+	return nil
+}
+
+func newEvaluationOpenAPIServiceKillExperimentOApiArgs() interface{} {
+	return openapi.NewEvaluationOpenAPIServiceKillExperimentOApiArgs()
+}
+
+func newEvaluationOpenAPIServiceKillExperimentOApiResult() interface{} {
+	return openapi.NewEvaluationOpenAPIServiceKillExperimentOApiResult()
+}
+
 func exportExperimentResultOApiHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
 	realArg := arg.(*openapi.EvaluationOpenAPIServiceExportExperimentResultOApiArgs)
 	realResult := result.(*openapi.EvaluationOpenAPIServiceExportExperimentResultOApiResult)
@@ -1660,6 +1686,16 @@ func (p *kClient) RetryExperimentOApi(ctx context.Context, req *openapi.RetryExp
 	_args.Req = req
 	var _result openapi.EvaluationOpenAPIServiceRetryExperimentOApiResult
 	if err = p.c.Call(ctx, "RetryExperimentOApi", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
+
+func (p *kClient) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest) (r *openapi.KillExperimentOApiResponse, err error) {
+	var _args openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs
+	_args.Req = req
+	var _result openapi.EvaluationOpenAPIServiceKillExperimentOApiResult
+	if err = p.c.Call(ctx, "KillExperimentOApi", &_args, &_result); err != nil {
 		return
 	}
 	return _result.GetSuccess(), nil

--- a/backend/kitex_gen/coze/loop/evaluation/evalopenapiservice/client.go
+++ b/backend/kitex_gen/coze/loop/evaluation/evalopenapiservice/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	ListExperimentResultOApi(ctx context.Context, req *openapi.ListExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ListExperimentResultOApiResponse, err error)
 	GetExperimentAggrResultOApi(ctx context.Context, req *openapi.GetExperimentAggrResultOApiRequest, callOptions ...callopt.Option) (r *openapi.GetExperimentAggrResultOApiResponse, err error)
 	RetryExperimentOApi(ctx context.Context, req *openapi.RetryExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.RetryExperimentOApiResponse, err error)
+	KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.KillExperimentOApiResponse, err error)
 	ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ExportExperimentResultOApiResponse, err error)
 	GetExperimentResultExportRecordOApi(ctx context.Context, req *openapi.GetExperimentResultExportRecordOApiRequest, callOptions ...callopt.Option) (r *openapi.GetExperimentResultExportRecordOApiResponse, err error)
 	ListEvaluatorsOApi(ctx context.Context, req *openapi.ListEvaluatorsOApiRequest, callOptions ...callopt.Option) (r *openapi.ListEvaluatorsOApiResponse, err error)
@@ -231,6 +232,11 @@ func (p *kEvalOpenAPIServiceClient) GetExperimentAggrResultOApi(ctx context.Cont
 func (p *kEvalOpenAPIServiceClient) RetryExperimentOApi(ctx context.Context, req *openapi.RetryExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.RetryExperimentOApiResponse, err error) {
 	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
 	return p.kClient.RetryExperimentOApi(ctx, req)
+}
+
+func (p *kEvalOpenAPIServiceClient) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.KillExperimentOApiResponse, err error) {
+	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
+	return p.kClient.KillExperimentOApi(ctx, req)
 }
 
 func (p *kEvalOpenAPIServiceClient) ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ExportExperimentResultOApiResponse, err error) {

--- a/backend/kitex_gen/coze/loop/evaluation/evalopenapiservice/evalopenapiservice.go
+++ b/backend/kitex_gen/coze/loop/evaluation/evalopenapiservice/evalopenapiservice.go
@@ -210,6 +210,13 @@ var serviceMethods = map[string]kitex.MethodInfo{
 		false,
 		kitex.WithStreamingMode(kitex.StreamingNone),
 	),
+	"KillExperimentOApi": kitex.NewMethodInfo(
+		killExperimentOApiHandler,
+		newEvaluationOpenAPIServiceKillExperimentOApiArgs,
+		newEvaluationOpenAPIServiceKillExperimentOApiResult,
+		false,
+		kitex.WithStreamingMode(kitex.StreamingNone),
+	),
 	"ExportExperimentResultOApi": kitex.NewMethodInfo(
 		exportExperimentResultOApiHandler,
 		newEvaluationOpenAPIServiceExportExperimentResultOApiArgs,
@@ -936,6 +943,25 @@ func newEvaluationOpenAPIServiceRetryExperimentOApiResult() interface{} {
 	return openapi.NewEvaluationOpenAPIServiceRetryExperimentOApiResult()
 }
 
+func killExperimentOApiHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
+	realArg := arg.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs)
+	realResult := result.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiResult)
+	success, err := handler.(openapi.EvaluationOpenAPIService).KillExperimentOApi(ctx, realArg.Req)
+	if err != nil {
+		return err
+	}
+	realResult.Success = success
+	return nil
+}
+
+func newEvaluationOpenAPIServiceKillExperimentOApiArgs() interface{} {
+	return openapi.NewEvaluationOpenAPIServiceKillExperimentOApiArgs()
+}
+
+func newEvaluationOpenAPIServiceKillExperimentOApiResult() interface{} {
+	return openapi.NewEvaluationOpenAPIServiceKillExperimentOApiResult()
+}
+
 func exportExperimentResultOApiHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
 	realArg := arg.(*openapi.EvaluationOpenAPIServiceExportExperimentResultOApiArgs)
 	realResult := result.(*openapi.EvaluationOpenAPIServiceExportExperimentResultOApiResult)
@@ -1660,6 +1686,16 @@ func (p *kClient) RetryExperimentOApi(ctx context.Context, req *openapi.RetryExp
 	_args.Req = req
 	var _result openapi.EvaluationOpenAPIServiceRetryExperimentOApiResult
 	if err = p.c.Call(ctx, "RetryExperimentOApi", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
+
+func (p *kClient) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest) (r *openapi.KillExperimentOApiResponse, err error) {
+	var _args openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs
+	_args.Req = req
+	var _result openapi.EvaluationOpenAPIServiceKillExperimentOApiResult
+	if err = p.c.Call(ctx, "KillExperimentOApi", &_args, &_result); err != nil {
 		return
 	}
 	return _result.GetSuccess(), nil

--- a/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
@@ -3274,7 +3274,7 @@ type SubmitExperimentRequest struct {
 	// 试运行行数
 	TrialRunItemCount       *int64 `thrift:"trial_run_item_count,46,optional" frugal:"46,optional,i64" form:"trial_run_item_count" json:"trial_run_item_count,omitempty"`
 	EnableExtractTrajectory *bool  `thrift:"enable_extract_trajectory,47,optional" frugal:"47,optional,bool" json:"enable_extract_trajectory" form:"enable_extract_trajectory" `
-	// 提交实验时前端透传的发起人 user JWT，用于预下载 agent_buddy skill 入 TOS
+	// 提交实验时前端透传的发起人 user JWT，用于预下载 skill 入 TOS
 	XJwtToken   *string               `thrift:"x_jwt_token,48,optional" frugal:"48,optional,string" header:"X-Jwt-Token" json:"x_jwt_token,omitempty"`
 	TriggerType *expt.ExptTriggerType `thrift:"trigger_type,50,optional" frugal:"50,optional,string" form:"trigger_type" json:"trigger_type,omitempty" query:"trigger_type"`
 	TimeRange   *expt.TaskTimeRange   `thrift:"time_range,51,optional" frugal:"51,optional,expt.TaskTimeRange" form:"time_range" json:"time_range,omitempty"`

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/coze.loop.evaluation.openapi.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/coze.loop.evaluation.openapi.go
@@ -35707,6 +35707,660 @@ func (p *RetryExperimentOpenAPIData) Field3DeepEqual(src *int64) bool {
 	return true
 }
 
+// KillExperimentOApiRequest 通过 OpenAPI 终止一个进行中的实验。
+// 仅对处于 Processing 状态的实验生效，成功后实验会被置为 Terminated。
+type KillExperimentOApiRequest struct {
+	WorkspaceID  *int64     `thrift:"workspace_id,1,optional" frugal:"1,optional,i64" json:"workspace_id" form:"workspace_id" `
+	ExperimentID *int64     `thrift:"experiment_id,2,optional" frugal:"2,optional,i64" json:"experiment_id" path:"experiment_id" `
+	Base         *base.Base `thrift:"Base,255,optional" frugal:"255,optional,base.Base" form:"Base" json:"Base,omitempty" query:"Base"`
+}
+
+func NewKillExperimentOApiRequest() *KillExperimentOApiRequest {
+	return &KillExperimentOApiRequest{}
+}
+
+func (p *KillExperimentOApiRequest) InitDefault() {
+}
+
+var KillExperimentOApiRequest_WorkspaceID_DEFAULT int64
+
+func (p *KillExperimentOApiRequest) GetWorkspaceID() (v int64) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetWorkspaceID() {
+		return KillExperimentOApiRequest_WorkspaceID_DEFAULT
+	}
+	return *p.WorkspaceID
+}
+
+var KillExperimentOApiRequest_ExperimentID_DEFAULT int64
+
+func (p *KillExperimentOApiRequest) GetExperimentID() (v int64) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetExperimentID() {
+		return KillExperimentOApiRequest_ExperimentID_DEFAULT
+	}
+	return *p.ExperimentID
+}
+
+var KillExperimentOApiRequest_Base_DEFAULT *base.Base
+
+func (p *KillExperimentOApiRequest) GetBase() (v *base.Base) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetBase() {
+		return KillExperimentOApiRequest_Base_DEFAULT
+	}
+	return p.Base
+}
+func (p *KillExperimentOApiRequest) SetWorkspaceID(val *int64) {
+	p.WorkspaceID = val
+}
+func (p *KillExperimentOApiRequest) SetExperimentID(val *int64) {
+	p.ExperimentID = val
+}
+func (p *KillExperimentOApiRequest) SetBase(val *base.Base) {
+	p.Base = val
+}
+
+var fieldIDToName_KillExperimentOApiRequest = map[int16]string{
+	1:   "workspace_id",
+	2:   "experiment_id",
+	255: "Base",
+}
+
+func (p *KillExperimentOApiRequest) IsSetWorkspaceID() bool {
+	return p.WorkspaceID != nil
+}
+
+func (p *KillExperimentOApiRequest) IsSetExperimentID() bool {
+	return p.ExperimentID != nil
+}
+
+func (p *KillExperimentOApiRequest) IsSetBase() bool {
+	return p.Base != nil
+}
+
+func (p *KillExperimentOApiRequest) Read(iprot thrift.TProtocol) (err error) {
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 2:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 255:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField255(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_KillExperimentOApiRequest[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *KillExperimentOApiRequest) ReadField1(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.WorkspaceID = _field
+	return nil
+}
+func (p *KillExperimentOApiRequest) ReadField2(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.ExperimentID = _field
+	return nil
+}
+func (p *KillExperimentOApiRequest) ReadField255(iprot thrift.TProtocol) error {
+	_field := base.NewBase()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.Base = _field
+	return nil
+}
+
+func (p *KillExperimentOApiRequest) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("KillExperimentOApiRequest"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+		if err = p.writeField2(oprot); err != nil {
+			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField255(oprot); err != nil {
+			fieldId = 255
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *KillExperimentOApiRequest) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetWorkspaceID() {
+		if err = oprot.WriteFieldBegin("workspace_id", thrift.I64, 1); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.WorkspaceID); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+func (p *KillExperimentOApiRequest) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetExperimentID() {
+		if err = oprot.WriteFieldBegin("experiment_id", thrift.I64, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.ExperimentID); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+func (p *KillExperimentOApiRequest) writeField255(oprot thrift.TProtocol) (err error) {
+	if p.IsSetBase() {
+		if err = oprot.WriteFieldBegin("Base", thrift.STRUCT, 255); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.Base.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 255 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 255 end error: ", p), err)
+}
+
+func (p *KillExperimentOApiRequest) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("KillExperimentOApiRequest(%+v)", *p)
+
+}
+
+func (p *KillExperimentOApiRequest) DeepEqual(ano *KillExperimentOApiRequest) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.WorkspaceID) {
+		return false
+	}
+	if !p.Field2DeepEqual(ano.ExperimentID) {
+		return false
+	}
+	if !p.Field255DeepEqual(ano.Base) {
+		return false
+	}
+	return true
+}
+
+func (p *KillExperimentOApiRequest) Field1DeepEqual(src *int64) bool {
+
+	if p.WorkspaceID == src {
+		return true
+	} else if p.WorkspaceID == nil || src == nil {
+		return false
+	}
+	if *p.WorkspaceID != *src {
+		return false
+	}
+	return true
+}
+func (p *KillExperimentOApiRequest) Field2DeepEqual(src *int64) bool {
+
+	if p.ExperimentID == src {
+		return true
+	} else if p.ExperimentID == nil || src == nil {
+		return false
+	}
+	if *p.ExperimentID != *src {
+		return false
+	}
+	return true
+}
+func (p *KillExperimentOApiRequest) Field255DeepEqual(src *base.Base) bool {
+
+	if !p.Base.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+
+type KillExperimentOApiResponse struct {
+	Code     *int32         `thrift:"code,1,optional" frugal:"1,optional,i32" form:"code" json:"code,omitempty" query:"code"`
+	Msg      *string        `thrift:"msg,2,optional" frugal:"2,optional,string" form:"msg" json:"msg,omitempty" query:"msg"`
+	BaseResp *base.BaseResp `thrift:"BaseResp,255" frugal:"255,default,base.BaseResp" form:"BaseResp" json:"BaseResp" query:"BaseResp"`
+}
+
+func NewKillExperimentOApiResponse() *KillExperimentOApiResponse {
+	return &KillExperimentOApiResponse{}
+}
+
+func (p *KillExperimentOApiResponse) InitDefault() {
+}
+
+var KillExperimentOApiResponse_Code_DEFAULT int32
+
+func (p *KillExperimentOApiResponse) GetCode() (v int32) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetCode() {
+		return KillExperimentOApiResponse_Code_DEFAULT
+	}
+	return *p.Code
+}
+
+var KillExperimentOApiResponse_Msg_DEFAULT string
+
+func (p *KillExperimentOApiResponse) GetMsg() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetMsg() {
+		return KillExperimentOApiResponse_Msg_DEFAULT
+	}
+	return *p.Msg
+}
+
+var KillExperimentOApiResponse_BaseResp_DEFAULT *base.BaseResp
+
+func (p *KillExperimentOApiResponse) GetBaseResp() (v *base.BaseResp) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetBaseResp() {
+		return KillExperimentOApiResponse_BaseResp_DEFAULT
+	}
+	return p.BaseResp
+}
+func (p *KillExperimentOApiResponse) SetCode(val *int32) {
+	p.Code = val
+}
+func (p *KillExperimentOApiResponse) SetMsg(val *string) {
+	p.Msg = val
+}
+func (p *KillExperimentOApiResponse) SetBaseResp(val *base.BaseResp) {
+	p.BaseResp = val
+}
+
+var fieldIDToName_KillExperimentOApiResponse = map[int16]string{
+	1:   "code",
+	2:   "msg",
+	255: "BaseResp",
+}
+
+func (p *KillExperimentOApiResponse) IsSetCode() bool {
+	return p.Code != nil
+}
+
+func (p *KillExperimentOApiResponse) IsSetMsg() bool {
+	return p.Msg != nil
+}
+
+func (p *KillExperimentOApiResponse) IsSetBaseResp() bool {
+	return p.BaseResp != nil
+}
+
+func (p *KillExperimentOApiResponse) Read(iprot thrift.TProtocol) (err error) {
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.I32 {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField2(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 255:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField255(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_KillExperimentOApiResponse[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *KillExperimentOApiResponse) ReadField1(iprot thrift.TProtocol) error {
+
+	var _field *int32
+	if v, err := iprot.ReadI32(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Code = _field
+	return nil
+}
+func (p *KillExperimentOApiResponse) ReadField2(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.Msg = _field
+	return nil
+}
+func (p *KillExperimentOApiResponse) ReadField255(iprot thrift.TProtocol) error {
+	_field := base.NewBaseResp()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.BaseResp = _field
+	return nil
+}
+
+func (p *KillExperimentOApiResponse) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("KillExperimentOApiResponse"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+		if err = p.writeField2(oprot); err != nil {
+			fieldId = 2
+			goto WriteFieldError
+		}
+		if err = p.writeField255(oprot); err != nil {
+			fieldId = 255
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *KillExperimentOApiResponse) writeField1(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCode() {
+		if err = oprot.WriteFieldBegin("code", thrift.I32, 1); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI32(*p.Code); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+func (p *KillExperimentOApiResponse) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetMsg() {
+		if err = oprot.WriteFieldBegin("msg", thrift.STRING, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.Msg); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
+func (p *KillExperimentOApiResponse) writeField255(oprot thrift.TProtocol) (err error) {
+	if err = oprot.WriteFieldBegin("BaseResp", thrift.STRUCT, 255); err != nil {
+		goto WriteFieldBeginError
+	}
+	if err := p.BaseResp.Write(oprot); err != nil {
+		return err
+	}
+	if err = oprot.WriteFieldEnd(); err != nil {
+		goto WriteFieldEndError
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 255 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 255 end error: ", p), err)
+}
+
+func (p *KillExperimentOApiResponse) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("KillExperimentOApiResponse(%+v)", *p)
+
+}
+
+func (p *KillExperimentOApiResponse) DeepEqual(ano *KillExperimentOApiResponse) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.Code) {
+		return false
+	}
+	if !p.Field2DeepEqual(ano.Msg) {
+		return false
+	}
+	if !p.Field255DeepEqual(ano.BaseResp) {
+		return false
+	}
+	return true
+}
+
+func (p *KillExperimentOApiResponse) Field1DeepEqual(src *int32) bool {
+
+	if p.Code == src {
+		return true
+	} else if p.Code == nil || src == nil {
+		return false
+	}
+	if *p.Code != *src {
+		return false
+	}
+	return true
+}
+func (p *KillExperimentOApiResponse) Field2DeepEqual(src *string) bool {
+
+	if p.Msg == src {
+		return true
+	} else if p.Msg == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.Msg, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *KillExperimentOApiResponse) Field255DeepEqual(src *base.BaseResp) bool {
+
+	if !p.BaseResp.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+
 // 3.6 导出实验报告
 type ExportExperimentResultOApiRequest struct {
 	WorkspaceID   *int64                                 `thrift:"workspace_id,1,optional" frugal:"1,optional,i64" json:"workspace_id" form:"workspace_id" `
@@ -62151,6 +62805,8 @@ type EvaluationOpenAPIService interface {
 	GetExperimentAggrResultOApi(ctx context.Context, req *GetExperimentAggrResultOApiRequest) (r *GetExperimentAggrResultOApiResponse, err error)
 	// 重试实验
 	RetryExperimentOApi(ctx context.Context, req *RetryExperimentOApiRequest) (r *RetryExperimentOApiResponse, err error)
+	// 终止实验
+	KillExperimentOApi(ctx context.Context, req *KillExperimentOApiRequest) (r *KillExperimentOApiResponse, err error)
 	// 导出实验报告
 	ExportExperimentResultOApi(ctx context.Context, req *ExportExperimentResultOApiRequest) (r *ExportExperimentResultOApiResponse, err error)
 	// 查询实验报告导出记录（含下载链接）
@@ -62480,6 +63136,15 @@ func (p *EvaluationOpenAPIServiceClient) RetryExperimentOApi(ctx context.Context
 	}
 	return _result.GetSuccess(), nil
 }
+func (p *EvaluationOpenAPIServiceClient) KillExperimentOApi(ctx context.Context, req *KillExperimentOApiRequest) (r *KillExperimentOApiResponse, err error) {
+	var _args EvaluationOpenAPIServiceKillExperimentOApiArgs
+	_args.Req = req
+	var _result EvaluationOpenAPIServiceKillExperimentOApiResult
+	if err = p.Client_().Call(ctx, "KillExperimentOApi", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
 func (p *EvaluationOpenAPIServiceClient) ExportExperimentResultOApi(ctx context.Context, req *ExportExperimentResultOApiRequest) (r *ExportExperimentResultOApiResponse, err error) {
 	var _args EvaluationOpenAPIServiceExportExperimentResultOApiArgs
 	_args.Req = req
@@ -62736,6 +63401,7 @@ func NewEvaluationOpenAPIServiceProcessor(handler EvaluationOpenAPIService) *Eva
 	self.AddToProcessorMap("ListExperimentResultOApi", &evaluationOpenAPIServiceProcessorListExperimentResultOApi{handler: handler})
 	self.AddToProcessorMap("GetExperimentAggrResultOApi", &evaluationOpenAPIServiceProcessorGetExperimentAggrResultOApi{handler: handler})
 	self.AddToProcessorMap("RetryExperimentOApi", &evaluationOpenAPIServiceProcessorRetryExperimentOApi{handler: handler})
+	self.AddToProcessorMap("KillExperimentOApi", &evaluationOpenAPIServiceProcessorKillExperimentOApi{handler: handler})
 	self.AddToProcessorMap("ExportExperimentResultOApi", &evaluationOpenAPIServiceProcessorExportExperimentResultOApi{handler: handler})
 	self.AddToProcessorMap("GetExperimentResultExportRecordOApi", &evaluationOpenAPIServiceProcessorGetExperimentResultExportRecordOApi{handler: handler})
 	self.AddToProcessorMap("ListEvaluatorsOApi", &evaluationOpenAPIServiceProcessorListEvaluatorsOApi{handler: handler})
@@ -64106,6 +64772,54 @@ func (p *evaluationOpenAPIServiceProcessorRetryExperimentOApi) Process(ctx conte
 		result.Success = retval
 	}
 	if err2 = oprot.WriteMessageBegin("RetryExperimentOApi", thrift.REPLY, seqId); err2 != nil {
+		err = err2
+	}
+	if err2 = result.Write(oprot); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.WriteMessageEnd(); err == nil && err2 != nil {
+		err = err2
+	}
+	if err2 = oprot.Flush(ctx); err == nil && err2 != nil {
+		err = err2
+	}
+	if err != nil {
+		return
+	}
+	return true, err
+}
+
+type evaluationOpenAPIServiceProcessorKillExperimentOApi struct {
+	handler EvaluationOpenAPIService
+}
+
+func (p *evaluationOpenAPIServiceProcessorKillExperimentOApi) Process(ctx context.Context, seqId int32, iprot, oprot thrift.TProtocol) (success bool, err thrift.TException) {
+	args := EvaluationOpenAPIServiceKillExperimentOApiArgs{}
+	if err = args.Read(iprot); err != nil {
+		iprot.ReadMessageEnd()
+		x := thrift.NewTApplicationException(thrift.PROTOCOL_ERROR, err.Error())
+		oprot.WriteMessageBegin("KillExperimentOApi", thrift.EXCEPTION, seqId)
+		x.Write(oprot)
+		oprot.WriteMessageEnd()
+		oprot.Flush(ctx)
+		return false, err
+	}
+
+	iprot.ReadMessageEnd()
+	var err2 error
+	result := EvaluationOpenAPIServiceKillExperimentOApiResult{}
+	var retval *KillExperimentOApiResponse
+	if retval, err2 = p.handler.KillExperimentOApi(ctx, args.Req); err2 != nil {
+		x := thrift.NewTApplicationException(thrift.INTERNAL_ERROR, "Internal error processing KillExperimentOApi: "+err2.Error())
+		oprot.WriteMessageBegin("KillExperimentOApi", thrift.EXCEPTION, seqId)
+		x.Write(oprot)
+		oprot.WriteMessageEnd()
+		oprot.Flush(ctx)
+		return true, err2
+	} else {
+		result.Success = retval
+	}
+	if err2 = oprot.WriteMessageBegin("KillExperimentOApi", thrift.REPLY, seqId); err2 != nil {
 		err = err2
 	}
 	if err2 = result.Write(oprot); err == nil && err2 != nil {
@@ -74852,6 +75566,350 @@ func (p *EvaluationOpenAPIServiceRetryExperimentOApiResult) DeepEqual(ano *Evalu
 }
 
 func (p *EvaluationOpenAPIServiceRetryExperimentOApiResult) Field0DeepEqual(src *RetryExperimentOApiResponse) bool {
+
+	if !p.Success.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+
+type EvaluationOpenAPIServiceKillExperimentOApiArgs struct {
+	Req *KillExperimentOApiRequest `thrift:"req,1" frugal:"1,default,KillExperimentOApiRequest"`
+}
+
+func NewEvaluationOpenAPIServiceKillExperimentOApiArgs() *EvaluationOpenAPIServiceKillExperimentOApiArgs {
+	return &EvaluationOpenAPIServiceKillExperimentOApiArgs{}
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) InitDefault() {
+}
+
+var EvaluationOpenAPIServiceKillExperimentOApiArgs_Req_DEFAULT *KillExperimentOApiRequest
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) GetReq() (v *KillExperimentOApiRequest) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetReq() {
+		return EvaluationOpenAPIServiceKillExperimentOApiArgs_Req_DEFAULT
+	}
+	return p.Req
+}
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) SetReq(val *KillExperimentOApiRequest) {
+	p.Req = val
+}
+
+var fieldIDToName_EvaluationOpenAPIServiceKillExperimentOApiArgs = map[int16]string{
+	1: "req",
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) IsSetReq() bool {
+	return p.Req != nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) Read(iprot thrift.TProtocol) (err error) {
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_EvaluationOpenAPIServiceKillExperimentOApiArgs[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) ReadField1(iprot thrift.TProtocol) error {
+	_field := NewKillExperimentOApiRequest()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.Req = _field
+	return nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("KillExperimentOApi_args"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField1(oprot); err != nil {
+			fieldId = 1
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) writeField1(oprot thrift.TProtocol) (err error) {
+	if err = oprot.WriteFieldBegin("req", thrift.STRUCT, 1); err != nil {
+		goto WriteFieldBeginError
+	}
+	if err := p.Req.Write(oprot); err != nil {
+		return err
+	}
+	if err = oprot.WriteFieldEnd(); err != nil {
+		goto WriteFieldEndError
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("EvaluationOpenAPIServiceKillExperimentOApiArgs(%+v)", *p)
+
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) DeepEqual(ano *EvaluationOpenAPIServiceKillExperimentOApiArgs) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field1DeepEqual(ano.Req) {
+		return false
+	}
+	return true
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) Field1DeepEqual(src *KillExperimentOApiRequest) bool {
+
+	if !p.Req.DeepEqual(src) {
+		return false
+	}
+	return true
+}
+
+type EvaluationOpenAPIServiceKillExperimentOApiResult struct {
+	Success *KillExperimentOApiResponse `thrift:"success,0,optional" frugal:"0,optional,KillExperimentOApiResponse"`
+}
+
+func NewEvaluationOpenAPIServiceKillExperimentOApiResult() *EvaluationOpenAPIServiceKillExperimentOApiResult {
+	return &EvaluationOpenAPIServiceKillExperimentOApiResult{}
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) InitDefault() {
+}
+
+var EvaluationOpenAPIServiceKillExperimentOApiResult_Success_DEFAULT *KillExperimentOApiResponse
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) GetSuccess() (v *KillExperimentOApiResponse) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetSuccess() {
+		return EvaluationOpenAPIServiceKillExperimentOApiResult_Success_DEFAULT
+	}
+	return p.Success
+}
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) SetSuccess(x interface{}) {
+	p.Success = x.(*KillExperimentOApiResponse)
+}
+
+var fieldIDToName_EvaluationOpenAPIServiceKillExperimentOApiResult = map[int16]string{
+	0: "success",
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) IsSetSuccess() bool {
+	return p.Success != nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) Read(iprot thrift.TProtocol) (err error) {
+	var fieldTypeId thrift.TType
+	var fieldId int16
+
+	if _, err = iprot.ReadStructBegin(); err != nil {
+		goto ReadStructBeginError
+	}
+
+	for {
+		_, fieldTypeId, fieldId, err = iprot.ReadFieldBegin()
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRUCT {
+				if err = p.ReadField0(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		default:
+			if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		}
+		if err = iprot.ReadFieldEnd(); err != nil {
+			goto ReadFieldEndError
+		}
+	}
+	if err = iprot.ReadStructEnd(); err != nil {
+		goto ReadStructEndError
+	}
+
+	return nil
+ReadStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct begin error: ", p), err)
+ReadFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_EvaluationOpenAPIServiceKillExperimentOApiResult[fieldId]), err)
+SkipFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+
+ReadFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read field end error", p), err)
+ReadStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) ReadField0(iprot thrift.TProtocol) error {
+	_field := NewKillExperimentOApiResponse()
+	if err := _field.Read(iprot); err != nil {
+		return err
+	}
+	p.Success = _field
+	return nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) Write(oprot thrift.TProtocol) (err error) {
+	var fieldId int16
+	if err = oprot.WriteStructBegin("KillExperimentOApi_result"); err != nil {
+		goto WriteStructBeginError
+	}
+	if p != nil {
+		if err = p.writeField0(oprot); err != nil {
+			fieldId = 0
+			goto WriteFieldError
+		}
+	}
+	if err = oprot.WriteFieldStop(); err != nil {
+		goto WriteFieldStopError
+	}
+	if err = oprot.WriteStructEnd(); err != nil {
+		goto WriteStructEndError
+	}
+	return nil
+WriteStructBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct begin error: ", p), err)
+WriteFieldError:
+	return thrift.PrependError(fmt.Sprintf("%T write field %d error: ", p, fieldId), err)
+WriteFieldStopError:
+	return thrift.PrependError(fmt.Sprintf("%T write field stop error: ", p), err)
+WriteStructEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write struct end error: ", p), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) writeField0(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSuccess() {
+		if err = oprot.WriteFieldBegin("success", thrift.STRUCT, 0); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := p.Success.Write(oprot); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 0 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 0 end error: ", p), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) String() string {
+	if p == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("EvaluationOpenAPIServiceKillExperimentOApiResult(%+v)", *p)
+
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) DeepEqual(ano *EvaluationOpenAPIServiceKillExperimentOApiResult) bool {
+	if p == ano {
+		return true
+	} else if p == nil || ano == nil {
+		return false
+	}
+	if !p.Field0DeepEqual(ano.Success) {
+		return false
+	}
+	return true
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) Field0DeepEqual(src *KillExperimentOApiResponse) bool {
 
 	if !p.Success.DeepEqual(src) {
 		return false

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/coze.loop.evaluation.openapi_validator.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/coze.loop.evaluation.openapi_validator.go
@@ -1076,6 +1076,22 @@ func (p *RetryExperimentOApiResponse) IsValid() error {
 func (p *RetryExperimentOpenAPIData) IsValid() error {
 	return nil
 }
+func (p *KillExperimentOApiRequest) IsValid() error {
+	if p.Base != nil {
+		if err := p.Base.IsValid(); err != nil {
+			return fmt.Errorf("field Base not valid, %w", err)
+		}
+	}
+	return nil
+}
+func (p *KillExperimentOApiResponse) IsValid() error {
+	if p.BaseResp != nil {
+		if err := p.BaseResp.IsValid(); err != nil {
+			return fmt.Errorf("field BaseResp not valid, %w", err)
+		}
+	}
+	return nil
+}
 func (p *ExportExperimentResultOApiRequest) IsValid() error {
 	if p.ExportColumns != nil {
 		if err := p.ExportColumns.IsValid(); err != nil {

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/evaluationopenapiservice/client.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/evaluationopenapiservice/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	ListExperimentResultOApi(ctx context.Context, req *openapi.ListExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ListExperimentResultOApiResponse, err error)
 	GetExperimentAggrResultOApi(ctx context.Context, req *openapi.GetExperimentAggrResultOApiRequest, callOptions ...callopt.Option) (r *openapi.GetExperimentAggrResultOApiResponse, err error)
 	RetryExperimentOApi(ctx context.Context, req *openapi.RetryExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.RetryExperimentOApiResponse, err error)
+	KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.KillExperimentOApiResponse, err error)
 	ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ExportExperimentResultOApiResponse, err error)
 	GetExperimentResultExportRecordOApi(ctx context.Context, req *openapi.GetExperimentResultExportRecordOApiRequest, callOptions ...callopt.Option) (r *openapi.GetExperimentResultExportRecordOApiResponse, err error)
 	ListEvaluatorsOApi(ctx context.Context, req *openapi.ListEvaluatorsOApiRequest, callOptions ...callopt.Option) (r *openapi.ListEvaluatorsOApiResponse, err error)
@@ -231,6 +232,11 @@ func (p *kEvaluationOpenAPIServiceClient) GetExperimentAggrResultOApi(ctx contex
 func (p *kEvaluationOpenAPIServiceClient) RetryExperimentOApi(ctx context.Context, req *openapi.RetryExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.RetryExperimentOApiResponse, err error) {
 	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
 	return p.kClient.RetryExperimentOApi(ctx, req)
+}
+
+func (p *kEvaluationOpenAPIServiceClient) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (r *openapi.KillExperimentOApiResponse, err error) {
+	ctx = client.NewCtxWithCallOptions(ctx, callOptions)
+	return p.kClient.KillExperimentOApi(ctx, req)
 }
 
 func (p *kEvaluationOpenAPIServiceClient) ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (r *openapi.ExportExperimentResultOApiResponse, err error) {

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/evaluationopenapiservice/evaluationopenapiservice.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/evaluationopenapiservice/evaluationopenapiservice.go
@@ -209,6 +209,13 @@ var serviceMethods = map[string]kitex.MethodInfo{
 		false,
 		kitex.WithStreamingMode(kitex.StreamingNone),
 	),
+	"KillExperimentOApi": kitex.NewMethodInfo(
+		killExperimentOApiHandler,
+		newEvaluationOpenAPIServiceKillExperimentOApiArgs,
+		newEvaluationOpenAPIServiceKillExperimentOApiResult,
+		false,
+		kitex.WithStreamingMode(kitex.StreamingNone),
+	),
 	"ExportExperimentResultOApi": kitex.NewMethodInfo(
 		exportExperimentResultOApiHandler,
 		newEvaluationOpenAPIServiceExportExperimentResultOApiArgs,
@@ -935,6 +942,25 @@ func newEvaluationOpenAPIServiceRetryExperimentOApiResult() interface{} {
 	return openapi.NewEvaluationOpenAPIServiceRetryExperimentOApiResult()
 }
 
+func killExperimentOApiHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
+	realArg := arg.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs)
+	realResult := result.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiResult)
+	success, err := handler.(openapi.EvaluationOpenAPIService).KillExperimentOApi(ctx, realArg.Req)
+	if err != nil {
+		return err
+	}
+	realResult.Success = success
+	return nil
+}
+
+func newEvaluationOpenAPIServiceKillExperimentOApiArgs() interface{} {
+	return openapi.NewEvaluationOpenAPIServiceKillExperimentOApiArgs()
+}
+
+func newEvaluationOpenAPIServiceKillExperimentOApiResult() interface{} {
+	return openapi.NewEvaluationOpenAPIServiceKillExperimentOApiResult()
+}
+
 func exportExperimentResultOApiHandler(ctx context.Context, handler interface{}, arg, result interface{}) error {
 	realArg := arg.(*openapi.EvaluationOpenAPIServiceExportExperimentResultOApiArgs)
 	realResult := result.(*openapi.EvaluationOpenAPIServiceExportExperimentResultOApiResult)
@@ -1659,6 +1685,16 @@ func (p *kClient) RetryExperimentOApi(ctx context.Context, req *openapi.RetryExp
 	_args.Req = req
 	var _result openapi.EvaluationOpenAPIServiceRetryExperimentOApiResult
 	if err = p.c.Call(ctx, "RetryExperimentOApi", &_args, &_result); err != nil {
+		return
+	}
+	return _result.GetSuccess(), nil
+}
+
+func (p *kClient) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest) (r *openapi.KillExperimentOApiResponse, err error) {
+	var _args openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs
+	_args.Req = req
+	var _result openapi.EvaluationOpenAPIServiceKillExperimentOApiResult
+	if err = p.c.Call(ctx, "KillExperimentOApi", &_args, &_result); err != nil {
 		return
 	}
 	return _result.GetSuccess(), nil

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/k-coze.loop.evaluation.openapi.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/k-coze.loop.evaluation.openapi.go
@@ -25704,6 +25704,455 @@ func (p *RetryExperimentOpenAPIData) DeepCopy(s interface{}) error {
 	return nil
 }
 
+func (p *KillExperimentOApiRequest) FastRead(buf []byte) (int, error) {
+
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	for {
+		fieldTypeId, fieldId, l, err = thrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField2(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 255:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField255(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+	}
+
+	return offset, nil
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_KillExperimentOApiRequest[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+}
+
+func (p *KillExperimentOApiRequest) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.WorkspaceID = _field
+	return offset, nil
+}
+
+func (p *KillExperimentOApiRequest) FastReadField2(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.ExperimentID = _field
+	return offset, nil
+}
+
+func (p *KillExperimentOApiRequest) FastReadField255(buf []byte) (int, error) {
+	offset := 0
+	_field := base.NewBase()
+	if l, err := _field.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.Base = _field
+	return offset, nil
+}
+
+func (p *KillExperimentOApiRequest) FastWrite(buf []byte) int {
+	return p.FastWriteNocopy(buf, nil)
+}
+
+func (p *KillExperimentOApiRequest) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p != nil {
+		offset += p.fastWriteField1(buf[offset:], w)
+		offset += p.fastWriteField2(buf[offset:], w)
+		offset += p.fastWriteField255(buf[offset:], w)
+	}
+	offset += thrift.Binary.WriteFieldStop(buf[offset:])
+	return offset
+}
+
+func (p *KillExperimentOApiRequest) BLength() int {
+	l := 0
+	if p != nil {
+		l += p.field1Length()
+		l += p.field2Length()
+		l += p.field255Length()
+	}
+	l += thrift.Binary.FieldStopLength()
+	return l
+}
+
+func (p *KillExperimentOApiRequest) fastWriteField1(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetWorkspaceID() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 1)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.WorkspaceID)
+	}
+	return offset
+}
+
+func (p *KillExperimentOApiRequest) fastWriteField2(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetExperimentID() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 2)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.ExperimentID)
+	}
+	return offset
+}
+
+func (p *KillExperimentOApiRequest) fastWriteField255(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetBase() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRUCT, 255)
+		offset += p.Base.FastWriteNocopy(buf[offset:], w)
+	}
+	return offset
+}
+
+func (p *KillExperimentOApiRequest) field1Length() int {
+	l := 0
+	if p.IsSetWorkspaceID() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
+func (p *KillExperimentOApiRequest) field2Length() int {
+	l := 0
+	if p.IsSetExperimentID() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
+func (p *KillExperimentOApiRequest) field255Length() int {
+	l := 0
+	if p.IsSetBase() {
+		l += thrift.Binary.FieldBeginLength()
+		l += p.Base.BLength()
+	}
+	return l
+}
+
+func (p *KillExperimentOApiRequest) DeepCopy(s interface{}) error {
+	src, ok := s.(*KillExperimentOApiRequest)
+	if !ok {
+		return fmt.Errorf("%T's type not matched %T", s, p)
+	}
+
+	if src.WorkspaceID != nil {
+		tmp := *src.WorkspaceID
+		p.WorkspaceID = &tmp
+	}
+
+	if src.ExperimentID != nil {
+		tmp := *src.ExperimentID
+		p.ExperimentID = &tmp
+	}
+
+	var _base *base.Base
+	if src.Base != nil {
+		_base = &base.Base{}
+		if err := _base.DeepCopy(src.Base); err != nil {
+			return err
+		}
+	}
+	p.Base = _base
+
+	return nil
+}
+
+func (p *KillExperimentOApiResponse) FastRead(buf []byte) (int, error) {
+
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	for {
+		fieldTypeId, fieldId, l, err = thrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.I32 {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 2:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField2(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 255:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField255(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+	}
+
+	return offset, nil
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_KillExperimentOApiResponse[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+}
+
+func (p *KillExperimentOApiResponse) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int32
+	if v, l, err := thrift.Binary.ReadI32(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.Code = _field
+	return offset, nil
+}
+
+func (p *KillExperimentOApiResponse) FastReadField2(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.Msg = _field
+	return offset, nil
+}
+
+func (p *KillExperimentOApiResponse) FastReadField255(buf []byte) (int, error) {
+	offset := 0
+	_field := base.NewBaseResp()
+	if l, err := _field.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.BaseResp = _field
+	return offset, nil
+}
+
+func (p *KillExperimentOApiResponse) FastWrite(buf []byte) int {
+	return p.FastWriteNocopy(buf, nil)
+}
+
+func (p *KillExperimentOApiResponse) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p != nil {
+		offset += p.fastWriteField1(buf[offset:], w)
+		offset += p.fastWriteField2(buf[offset:], w)
+		offset += p.fastWriteField255(buf[offset:], w)
+	}
+	offset += thrift.Binary.WriteFieldStop(buf[offset:])
+	return offset
+}
+
+func (p *KillExperimentOApiResponse) BLength() int {
+	l := 0
+	if p != nil {
+		l += p.field1Length()
+		l += p.field2Length()
+		l += p.field255Length()
+	}
+	l += thrift.Binary.FieldStopLength()
+	return l
+}
+
+func (p *KillExperimentOApiResponse) fastWriteField1(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetCode() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I32, 1)
+		offset += thrift.Binary.WriteI32(buf[offset:], *p.Code)
+	}
+	return offset
+}
+
+func (p *KillExperimentOApiResponse) fastWriteField2(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetMsg() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 2)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.Msg)
+	}
+	return offset
+}
+
+func (p *KillExperimentOApiResponse) fastWriteField255(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRUCT, 255)
+	offset += p.BaseResp.FastWriteNocopy(buf[offset:], w)
+	return offset
+}
+
+func (p *KillExperimentOApiResponse) field1Length() int {
+	l := 0
+	if p.IsSetCode() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I32Length()
+	}
+	return l
+}
+
+func (p *KillExperimentOApiResponse) field2Length() int {
+	l := 0
+	if p.IsSetMsg() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.Msg)
+	}
+	return l
+}
+
+func (p *KillExperimentOApiResponse) field255Length() int {
+	l := 0
+	l += thrift.Binary.FieldBeginLength()
+	l += p.BaseResp.BLength()
+	return l
+}
+
+func (p *KillExperimentOApiResponse) DeepCopy(s interface{}) error {
+	src, ok := s.(*KillExperimentOApiResponse)
+	if !ok {
+		return fmt.Errorf("%T's type not matched %T", s, p)
+	}
+
+	if src.Code != nil {
+		tmp := *src.Code
+		p.Code = &tmp
+	}
+
+	if src.Msg != nil {
+		var tmp string
+		if *src.Msg != "" {
+			tmp = kutils.StringDeepCopy(*src.Msg)
+		}
+		p.Msg = &tmp
+	}
+
+	var _baseResp *base.BaseResp
+	if src.BaseResp != nil {
+		_baseResp = &base.BaseResp{}
+		if err := _baseResp.DeepCopy(src.BaseResp); err != nil {
+			return err
+		}
+	}
+	p.BaseResp = _baseResp
+
+	return nil
+}
+
 func (p *ExportExperimentResultOApiRequest) FastRead(buf []byte) (int, error) {
 
 	var err error
@@ -51133,6 +51582,240 @@ func (p *EvaluationOpenAPIServiceRetryExperimentOApiResult) DeepCopy(s interface
 	return nil
 }
 
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) FastRead(buf []byte) (int, error) {
+
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	for {
+		fieldTypeId, fieldId, l, err = thrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 1:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField1(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+	}
+
+	return offset, nil
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_EvaluationOpenAPIServiceKillExperimentOApiArgs[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) FastReadField1(buf []byte) (int, error) {
+	offset := 0
+	_field := NewKillExperimentOApiRequest()
+	if l, err := _field.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.Req = _field
+	return offset, nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) FastWrite(buf []byte) int {
+	return p.FastWriteNocopy(buf, nil)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p != nil {
+		offset += p.fastWriteField1(buf[offset:], w)
+	}
+	offset += thrift.Binary.WriteFieldStop(buf[offset:])
+	return offset
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) BLength() int {
+	l := 0
+	if p != nil {
+		l += p.field1Length()
+	}
+	l += thrift.Binary.FieldStopLength()
+	return l
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) fastWriteField1(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRUCT, 1)
+	offset += p.Req.FastWriteNocopy(buf[offset:], w)
+	return offset
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) field1Length() int {
+	l := 0
+	l += thrift.Binary.FieldBeginLength()
+	l += p.Req.BLength()
+	return l
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) DeepCopy(s interface{}) error {
+	src, ok := s.(*EvaluationOpenAPIServiceKillExperimentOApiArgs)
+	if !ok {
+		return fmt.Errorf("%T's type not matched %T", s, p)
+	}
+
+	var _req *KillExperimentOApiRequest
+	if src.Req != nil {
+		_req = &KillExperimentOApiRequest{}
+		if err := _req.DeepCopy(src.Req); err != nil {
+			return err
+		}
+	}
+	p.Req = _req
+
+	return nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) FastRead(buf []byte) (int, error) {
+
+	var err error
+	var offset int
+	var l int
+	var fieldTypeId thrift.TType
+	var fieldId int16
+	for {
+		fieldTypeId, fieldId, l, err = thrift.Binary.ReadFieldBegin(buf[offset:])
+		offset += l
+		if err != nil {
+			goto ReadFieldBeginError
+		}
+		if fieldTypeId == thrift.STOP {
+			break
+		}
+		switch fieldId {
+		case 0:
+			if fieldTypeId == thrift.STRUCT {
+				l, err = p.FastReadField0(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		default:
+			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+			offset += l
+			if err != nil {
+				goto SkipFieldError
+			}
+		}
+	}
+
+	return offset, nil
+ReadFieldBeginError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d begin error: ", p, fieldId), err)
+ReadFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T read field %d '%s' error: ", p, fieldId, fieldIDToName_EvaluationOpenAPIServiceKillExperimentOApiResult[fieldId]), err)
+SkipFieldError:
+	return offset, thrift.PrependError(fmt.Sprintf("%T field %d skip type %d error: ", p, fieldId, fieldTypeId), err)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) FastReadField0(buf []byte) (int, error) {
+	offset := 0
+	_field := NewKillExperimentOApiResponse()
+	if l, err := _field.FastRead(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+	}
+	p.Success = _field
+	return offset, nil
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) FastWrite(buf []byte) int {
+	return p.FastWriteNocopy(buf, nil)
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p != nil {
+		offset += p.fastWriteField0(buf[offset:], w)
+	}
+	offset += thrift.Binary.WriteFieldStop(buf[offset:])
+	return offset
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) BLength() int {
+	l := 0
+	if p != nil {
+		l += p.field0Length()
+	}
+	l += thrift.Binary.FieldStopLength()
+	return l
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) fastWriteField0(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetSuccess() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRUCT, 0)
+		offset += p.Success.FastWriteNocopy(buf[offset:], w)
+	}
+	return offset
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) field0Length() int {
+	l := 0
+	if p.IsSetSuccess() {
+		l += thrift.Binary.FieldBeginLength()
+		l += p.Success.BLength()
+	}
+	return l
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) DeepCopy(s interface{}) error {
+	src, ok := s.(*EvaluationOpenAPIServiceKillExperimentOApiResult)
+	if !ok {
+		return fmt.Errorf("%T's type not matched %T", s, p)
+	}
+
+	var _success *KillExperimentOApiResponse
+	if src.Success != nil {
+		_success = &KillExperimentOApiResponse{}
+		if err := _success.DeepCopy(src.Success); err != nil {
+			return err
+		}
+	}
+	p.Success = _success
+
+	return nil
+}
+
 func (p *EvaluationOpenAPIServiceExportExperimentResultOApiArgs) FastRead(buf []byte) (int, error) {
 
 	var err error
@@ -56736,6 +57419,14 @@ func (p *EvaluationOpenAPIServiceRetryExperimentOApiArgs) GetFirstArgument() int
 }
 
 func (p *EvaluationOpenAPIServiceRetryExperimentOApiResult) GetResult() interface{} {
+	return p.Success
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiArgs) GetFirstArgument() interface{} {
+	return p.Req
+}
+
+func (p *EvaluationOpenAPIServiceKillExperimentOApiResult) GetResult() interface{} {
 	return p.Success
 }
 

--- a/backend/loop_gen/coze/loop/evaluation/loopenapi/local_evaluationopenapiservice.go
+++ b/backend/loop_gen/coze/loop/evaluation/loopenapi/local_evaluationopenapiservice.go
@@ -668,6 +668,29 @@ func (l *LocalEvaluationOpenAPIService) RetryExperimentOApi(ctx context.Context,
 	return result.GetSuccess(), nil
 }
 
+// KillExperimentOApi
+// 终止实验
+func (l *LocalEvaluationOpenAPIService) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest, callOptions ...callopt.Option) (*openapi.KillExperimentOApiResponse, error) {
+	chain := l.mds(func(ctx context.Context, in, out interface{}) error {
+		arg := in.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs)
+		result := out.(*openapi.EvaluationOpenAPIServiceKillExperimentOApiResult)
+		resp, err := l.impl.KillExperimentOApi(ctx, arg.Req)
+		if err != nil {
+			return err
+		}
+		result.SetSuccess(resp)
+		return nil
+	})
+
+	arg := &openapi.EvaluationOpenAPIServiceKillExperimentOApiArgs{Req: req}
+	result := &openapi.EvaluationOpenAPIServiceKillExperimentOApiResult{}
+	ctx = l.injectRPCInfo(ctx, "KillExperimentOApi")
+	if err := chain(ctx, arg, result); err != nil {
+		return nil, err
+	}
+	return result.GetSuccess(), nil
+}
+
 // ExportExperimentResultOApi
 // 导出实验报告
 func (l *LocalEvaluationOpenAPIService) ExportExperimentResultOApi(ctx context.Context, req *openapi.ExportExperimentResultOApiRequest, callOptions ...callopt.Option) (*openapi.ExportExperimentResultOApiResponse, error) {

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -1549,6 +1549,47 @@ func (e *EvalOpenAPIApplication) RetryExperimentOApi(ctx context.Context, req *o
 	}, nil
 }
 
+func (e *EvalOpenAPIApplication) KillExperimentOApi(ctx context.Context, req *openapi.KillExperimentOApiRequest) (r *openapi.KillExperimentOApiResponse, err error) {
+	startTime := time.Now().UnixNano() / int64(time.Millisecond)
+	defer func() {
+		e.metric.EmitOpenAPIMetric(ctx, req.GetWorkspaceID(), 0, kitexutil.GetTOMethod(ctx), startTime, err)
+	}()
+
+	if req == nil {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("req is nil"))
+	}
+
+	if req.GetExperimentID() <= 0 {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("experiment_id is required"))
+	}
+
+	if req.GetWorkspaceID() <= 0 {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("workspace_id is required"))
+	}
+
+	// OpenAPI 入口显式鉴权，对齐 RetryExperimentOApi。内部 KillExperiment 对
+	// maintainer 用户会跳过鉴权（运维快捷路径），对外 OpenAPI 面不应享受该豁免，
+	// 故在 wrapper 层强制校验实验的 Run 权限。
+	err = e.auth.Authorization(ctx, &rpc.AuthorizationParam{
+		ObjectID:      strconv.FormatInt(req.GetExperimentID(), 10),
+		SpaceID:       req.GetWorkspaceID(),
+		ActionObjects: []*rpc.ActionObject{{Action: gptr.Of(consts.Run), EntityType: gptr.Of(rpc.AuthEntityType_EvaluationExperiment)}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// KillExperiment 内部再做状态校验（仅 Processing 可终止）。
+	if _, err = e.experimentApp.KillExperiment(ctx, &exptpb.KillExperimentRequest{
+		WorkspaceID: req.WorkspaceID,
+		ExptID:      req.ExperimentID,
+	}); err != nil {
+		return nil, err
+	}
+
+	return &openapi.KillExperimentOApiResponse{}, nil
+}
+
 func mapOpenAPIExptRetryMode(mode experiment.ExptRetryMode) (domain_expt.ExptRetryMode, error) {
 	switch mode {
 	case experiment.ExptRetryModeRetryAll:

--- a/backend/modules/evaluation/application/eval_openapi_app_test.go
+++ b/backend/modules/evaluation/application/eval_openapi_app_test.go
@@ -2682,6 +2682,10 @@ type fakeExperimentApp struct {
 	retryErr     error
 	lastRetryReq *exptpb.RetryExperimentRequest
 
+	killResp    *exptpb.KillExperimentResponse
+	killErr     error
+	lastKillReq *exptpb.KillExperimentRequest
+
 	exportResp    *exptpb.ExportExptResultResponse
 	exportErr     error
 	lastExportReq *exptpb.ExportExptResultRequest
@@ -2715,6 +2719,14 @@ func (f *fakeExperimentApp) RetryExperiment(_ context.Context, req *exptpb.Retry
 		return f.retryResp, f.retryErr
 	}
 	return &exptpb.RetryExperimentResponse{}, nil
+}
+
+func (f *fakeExperimentApp) KillExperiment(_ context.Context, req *exptpb.KillExperimentRequest) (*exptpb.KillExperimentResponse, error) {
+	f.lastKillReq = req
+	if f.killResp != nil || f.killErr != nil {
+		return f.killResp, f.killErr
+	}
+	return &exptpb.KillExperimentResponse{}, nil
 }
 
 func (f *fakeExperimentApp) ExportExptResult_(_ context.Context, req *exptpb.ExportExptResultRequest) (*exptpb.ExportExptResultResponse, error) {
@@ -7139,6 +7151,134 @@ func TestEvalOpenAPIApplication_RetryExperimentOApi(t *testing.T) {
 				if assert.NotNil(t, fakeApp.lastRetryReq) {
 					assert.Equal(t, workspaceID, fakeApp.lastRetryReq.GetWorkspaceID())
 					assert.Equal(t, experimentID, fakeApp.lastRetryReq.GetExptID())
+				}
+			}
+
+			if req != nil {
+				assert.True(t, metric.called)
+				assert.Equal(t, req.GetWorkspaceID(), metric.spaceID)
+			}
+		})
+	}
+}
+
+func TestEvalOpenAPIApplication_KillExperimentOApi(t *testing.T) {
+	t.Parallel()
+
+	workspaceID := int64(91001)
+	experimentID := int64(91002)
+
+	buildBaseReq := func() *openapi.KillExperimentOApiRequest {
+		return &openapi.KillExperimentOApiRequest{
+			WorkspaceID:  gptr.Of(workspaceID),
+			ExperimentID: gptr.Of(experimentID),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		buildReq func() *openapi.KillExperimentOApiRequest
+		setup    func(auth *rpcmocks.MockIAuthProvider, fakeApp *fakeExperimentApp)
+		wantErr  int32
+	}{
+		{
+			name:     "nil request",
+			buildReq: func() *openapi.KillExperimentOApiRequest { return nil },
+			setup: func(auth *rpcmocks.MockIAuthProvider, _ *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr: errno.CommonInvalidParamCode,
+		},
+		{
+			name: "invalid experiment_id",
+			buildReq: func() *openapi.KillExperimentOApiRequest {
+				req := buildBaseReq()
+				req.ExperimentID = gptr.Of(int64(0))
+				return req
+			},
+			setup: func(auth *rpcmocks.MockIAuthProvider, _ *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr: errno.CommonInvalidParamCode,
+		},
+		{
+			name: "invalid workspace_id",
+			buildReq: func() *openapi.KillExperimentOApiRequest {
+				req := buildBaseReq()
+				req.WorkspaceID = gptr.Of(int64(0))
+				return req
+			},
+			setup: func(auth *rpcmocks.MockIAuthProvider, _ *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr: errno.CommonInvalidParamCode,
+		},
+		{
+			name:     "auth failed",
+			buildReq: buildBaseReq,
+			setup: func(auth *rpcmocks.MockIAuthProvider, _ *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.AssignableToTypeOf(&rpc.AuthorizationParam{})).Return(errorx.NewByCode(errno.CommonNoPermissionCode))
+			},
+			wantErr: errno.CommonNoPermissionCode,
+		},
+		{
+			name:     "kill experiment error",
+			buildReq: buildBaseReq,
+			setup: func(auth *rpcmocks.MockIAuthProvider, fakeApp *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.AssignableToTypeOf(&rpc.AuthorizationParam{})).Return(nil)
+				fakeApp.killErr = errors.New("kill failed")
+			},
+			wantErr: -1,
+		},
+		{
+			name:     "success",
+			buildReq: buildBaseReq,
+			setup: func(auth *rpcmocks.MockIAuthProvider, fakeApp *fakeExperimentApp) {
+				auth.EXPECT().Authorization(gomock.Any(), gomock.AssignableToTypeOf(&rpc.AuthorizationParam{})).Return(nil)
+				fakeApp.killResp = &exptpb.KillExperimentResponse{}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tc := tt
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			auth := rpcmocks.NewMockIAuthProvider(ctrl)
+			metric := &fakeOpenAPIMetric{}
+			fakeApp := &fakeExperimentApp{}
+
+			app := &EvalOpenAPIApplication{
+				auth:          auth,
+				experimentApp: fakeApp,
+				metric:        metric,
+			}
+
+			req := tc.buildReq()
+			if tc.setup != nil {
+				tc.setup(auth, fakeApp)
+			}
+
+			resp, err := app.KillExperimentOApi(context.Background(), req)
+
+			if tc.wantErr != 0 {
+				assert.Error(t, err)
+				if tc.wantErr > 0 {
+					statusErr, ok := errorx.FromStatusError(err)
+					assert.True(t, ok)
+					assert.Equal(t, tc.wantErr, statusErr.Code())
+				}
+				assert.Nil(t, resp)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, resp)
+				if assert.NotNil(t, fakeApp.lastKillReq) {
+					assert.Equal(t, workspaceID, fakeApp.lastKillReq.GetWorkspaceID())
+					assert.Equal(t, experimentID, fakeApp.lastKillReq.GetExptID())
 				}
 			}
 

--- a/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.openapi.thrift
+++ b/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.openapi.thrift
@@ -748,6 +748,22 @@ struct RetryExperimentOpenAPIData {
     3: optional i64 run_id
 }
 
+// KillExperimentOApiRequest 通过 OpenAPI 终止一个进行中的实验。
+// 仅对处于 Processing 状态的实验生效，成功后实验会被置为 Terminated。
+struct KillExperimentOApiRequest {
+    1: optional i64 workspace_id (api.body = 'workspace_id', api.js_conv = "true", go.tag = 'json:"workspace_id"')
+    2: optional i64 experiment_id (api.path = "experiment_id", api.js_conv = "true", go.tag = 'json:"experiment_id"')
+
+    255: optional base.Base Base
+}
+
+struct KillExperimentOApiResponse {
+    1: optional i32 code
+    2: optional string msg
+
+    255: base.BaseResp BaseResp
+}
+
 // 3.6 导出实验报告
 struct ExportExperimentResultOApiRequest {
     1: optional i64 workspace_id (api.body = 'workspace_id', api.js_conv = "true", go.tag = 'json:"workspace_id"')
@@ -1365,6 +1381,8 @@ service EvaluationOpenAPIService {
     GetExperimentAggrResultOApiResponse GetExperimentAggrResultOApi(1: GetExperimentAggrResultOApiRequest req) (api.category = "openapi", api.post = "/v1/loop/evaluation/experiments/:experiment_id/aggr_results")
     // 重试实验
     RetryExperimentOApiResponse RetryExperimentOApi(1: RetryExperimentOApiRequest req) (api.category = "openapi", api.post = "/v1/loop/evaluation/experiments/:experiment_id/retry")
+    // 终止实验
+    KillExperimentOApiResponse KillExperimentOApi(1: KillExperimentOApiRequest req) (api.category = "openapi", api.post = "/v1/loop/evaluation/experiments/:experiment_id/kill")
     // 导出实验报告
     ExportExperimentResultOApiResponse ExportExperimentResultOApi(1: ExportExperimentResultOApiRequest req) (api.category = "openapi", api.post = "/v1/loop/evaluation/experiments/:experiment_id/results/export")
     // 查询实验报告导出记录（含下载链接）


### PR DESCRIPTION
Expose the existing internal KillExperiment via open-api: POST /v1/loop/evaluation/experiments/:experiment_id/kill (mirrors RetryExperimentOApi). The application wrapper reuses experimentApp. KillExperiment, which already enforces processing-only + auth and moves the experiment to terminated asynchronously.

Includes regenerated kitex_gen / loop_gen / router / handler and a unit test for the wrapper.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
