### PR TITLE
[feat][evaluation] item-complete analysis gate + created_by propagation + group reverse-lookup / standard-output enhancements

### DIFF
--- a/backend/kitex_gen/coze/loop/evaluation/domain/eval_target/eval_target.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/eval_target/eval_target.go
@@ -10704,6 +10704,9 @@ type SandboxAgent struct {
 	Envs []*SandboxEnvVar `thrift:"envs,7,optional" frugal:"7,optional,list<SandboxEnvVar>" form:"envs" json:"envs,omitempty" query:"envs"`
 	// 沙箱镜像
 	Image *string `thrift:"image,8,optional" frugal:"8,optional,string" form:"image" json:"image,omitempty" query:"image"`
+	// 是否开启分析：由创建评测对象时从 application.usages 反查（含 "analysis"）固化，
+	// 控制 item-complete MQ 是否发送（与 TCC 空间白名单 AND）
+	EnableAnalysis *bool `thrift:"enable_analysis,9,optional" frugal:"9,optional,bool" form:"enable_analysis" json:"enable_analysis,omitempty" query:"enable_analysis"`
 }
 
 func NewSandboxAgent() *SandboxAgent {
@@ -10796,6 +10799,18 @@ func (p *SandboxAgent) GetImage() (v string) {
 	}
 	return *p.Image
 }
+
+var SandboxAgent_EnableAnalysis_DEFAULT bool
+
+func (p *SandboxAgent) GetEnableAnalysis() (v bool) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetEnableAnalysis() {
+		return SandboxAgent_EnableAnalysis_DEFAULT
+	}
+	return *p.EnableAnalysis
+}
 func (p *SandboxAgent) SetName(val *string) {
 	p.Name = val
 }
@@ -10817,6 +10832,9 @@ func (p *SandboxAgent) SetEnvs(val []*SandboxEnvVar) {
 func (p *SandboxAgent) SetImage(val *string) {
 	p.Image = val
 }
+func (p *SandboxAgent) SetEnableAnalysis(val *bool) {
+	p.EnableAnalysis = val
+}
 
 var fieldIDToName_SandboxAgent = map[int16]string{
 	1: "name",
@@ -10826,6 +10844,7 @@ var fieldIDToName_SandboxAgent = map[int16]string{
 	6: "agent_run_cmd",
 	7: "envs",
 	8: "image",
+	9: "enable_analysis",
 }
 
 func (p *SandboxAgent) IsSetName() bool {
@@ -10854,6 +10873,10 @@ func (p *SandboxAgent) IsSetEnvs() bool {
 
 func (p *SandboxAgent) IsSetImage() bool {
 	return p.Image != nil
+}
+
+func (p *SandboxAgent) IsSetEnableAnalysis() bool {
+	return p.EnableAnalysis != nil
 }
 
 func (p *SandboxAgent) Read(iprot thrift.TProtocol) (err error) {
@@ -10925,6 +10948,14 @@ func (p *SandboxAgent) Read(iprot thrift.TProtocol) (err error) {
 		case 8:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField8(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 9:
+			if fieldTypeId == thrift.BOOL {
+				if err = p.ReadField9(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -11048,6 +11079,17 @@ func (p *SandboxAgent) ReadField8(iprot thrift.TProtocol) error {
 	p.Image = _field
 	return nil
 }
+func (p *SandboxAgent) ReadField9(iprot thrift.TProtocol) error {
+
+	var _field *bool
+	if v, err := iprot.ReadBool(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.EnableAnalysis = _field
+	return nil
+}
 
 func (p *SandboxAgent) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -11081,6 +11123,10 @@ func (p *SandboxAgent) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField8(oprot); err != nil {
 			fieldId = 8
+			goto WriteFieldError
+		}
+		if err = p.writeField9(oprot); err != nil {
+			fieldId = 9
 			goto WriteFieldError
 		}
 	}
@@ -11235,6 +11281,24 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 8 end error: ", p), err)
 }
+func (p *SandboxAgent) writeField9(oprot thrift.TProtocol) (err error) {
+	if p.IsSetEnableAnalysis() {
+		if err = oprot.WriteFieldBegin("enable_analysis", thrift.BOOL, 9); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteBool(*p.EnableAnalysis); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 9 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 9 end error: ", p), err)
+}
 
 func (p *SandboxAgent) String() string {
 	if p == nil {
@@ -11269,6 +11333,9 @@ func (p *SandboxAgent) DeepEqual(ano *SandboxAgent) bool {
 		return false
 	}
 	if !p.Field8DeepEqual(ano.Image) {
+		return false
+	}
+	if !p.Field9DeepEqual(ano.EnableAnalysis) {
 		return false
 	}
 	return true
@@ -11355,6 +11422,18 @@ func (p *SandboxAgent) Field8DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.Image, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *SandboxAgent) Field9DeepEqual(src *bool) bool {
+
+	if p.EnableAnalysis == src {
+		return true
+	} else if p.EnableAnalysis == nil || src == nil {
+		return false
+	}
+	if *p.EnableAnalysis != *src {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/domain/eval_target/k-eval_target.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/eval_target/k-eval_target.go
@@ -7526,6 +7526,20 @@ func (p *SandboxAgent) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 9:
+			if fieldTypeId == thrift.BOOL {
+				l, err = p.FastReadField9(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -7653,6 +7667,20 @@ func (p *SandboxAgent) FastReadField8(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *SandboxAgent) FastReadField9(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *bool
+	if v, l, err := thrift.Binary.ReadBool(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.EnableAnalysis = _field
+	return offset, nil
+}
+
 func (p *SandboxAgent) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -7660,6 +7688,7 @@ func (p *SandboxAgent) FastWrite(buf []byte) int {
 func (p *SandboxAgent) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 	offset := 0
 	if p != nil {
+		offset += p.fastWriteField9(buf[offset:], w)
 		offset += p.fastWriteField1(buf[offset:], w)
 		offset += p.fastWriteField2(buf[offset:], w)
 		offset += p.fastWriteField3(buf[offset:], w)
@@ -7682,6 +7711,7 @@ func (p *SandboxAgent) BLength() int {
 		l += p.field6Length()
 		l += p.field7Length()
 		l += p.field8Length()
+		l += p.field9Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -7757,6 +7787,15 @@ func (p *SandboxAgent) fastWriteField8(buf []byte, w thrift.NocopyWriter) int {
 	return offset
 }
 
+func (p *SandboxAgent) fastWriteField9(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetEnableAnalysis() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.BOOL, 9)
+		offset += thrift.Binary.WriteBool(buf[offset:], *p.EnableAnalysis)
+	}
+	return offset
+}
+
 func (p *SandboxAgent) field1Length() int {
 	l := 0
 	if p.IsSetName() {
@@ -7820,6 +7859,15 @@ func (p *SandboxAgent) field8Length() int {
 	if p.IsSetImage() {
 		l += thrift.Binary.FieldBeginLength()
 		l += thrift.Binary.StringLengthNocopy(*p.Image)
+	}
+	return l
+}
+
+func (p *SandboxAgent) field9Length() int {
+	l := 0
+	if p.IsSetEnableAnalysis() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.BoolLength()
 	}
 	return l
 }
@@ -7888,6 +7936,11 @@ func (p *SandboxAgent) DeepCopy(s interface{}) error {
 			tmp = kutils.StringDeepCopy(*src.Image)
 		}
 		p.Image = &tmp
+	}
+
+	if src.EnableAnalysis != nil {
+		tmp := *src.EnableAnalysis
+		p.EnableAnalysis = &tmp
 	}
 
 	return nil

--- a/backend/kitex_gen/coze/loop/evaluation/domain/expt/expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/expt/expt.go
@@ -1189,7 +1189,9 @@ type Experiment struct {
 	EndTime       *int64      `thrift:"end_time,8,optional" frugal:"8,optional,i64" json:"end_time" form:"end_time" query:"end_time"`
 	ItemConcurNum *int32      `thrift:"item_concur_num,9,optional" frugal:"9,optional,i32" form:"item_concur_num" json:"item_concur_num,omitempty" query:"item_concur_num"`
 	// 实验可见性，默认为空，可见
-	Visibility            *Visibility              `thrift:"visibility,10,optional" frugal:"10,optional,string" form:"visibility" json:"visibility,omitempty" query:"visibility"`
+	Visibility *Visibility `thrift:"visibility,10,optional" frugal:"10,optional,string" form:"visibility" json:"visibility,omitempty" query:"visibility"`
+	// 实验创建时间（秒），来源 experiment.created_at
+	CreateTime            *int64                   `thrift:"create_time,11,optional" frugal:"11,optional,i64" json:"create_time" form:"create_time" query:"create_time"`
 	EvalSetVersionID      *int64                   `thrift:"eval_set_version_id,21,optional" frugal:"21,optional,i64" json:"eval_set_version_id" form:"eval_set_version_id" query:"eval_set_version_id"`
 	TargetVersionID       *int64                   `thrift:"target_version_id,22,optional" frugal:"22,optional,i64" json:"target_version_id" form:"target_version_id" query:"target_version_id"`
 	EvaluatorVersionIds   []int64                  `thrift:"evaluator_version_ids,23,optional" frugal:"23,optional,list<i64>" json:"evaluator_version_ids" form:"evaluator_version_ids" query:"evaluator_version_ids"`
@@ -1365,6 +1367,18 @@ func (p *Experiment) GetVisibility() (v Visibility) {
 		return Experiment_Visibility_DEFAULT
 	}
 	return *p.Visibility
+}
+
+var Experiment_CreateTime_DEFAULT int64
+
+func (p *Experiment) GetCreateTime() (v int64) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetCreateTime() {
+		return Experiment_CreateTime_DEFAULT
+	}
+	return *p.CreateTime
 }
 
 var Experiment_EvalSetVersionID_DEFAULT int64
@@ -1816,6 +1830,9 @@ func (p *Experiment) SetItemConcurNum(val *int32) {
 func (p *Experiment) SetVisibility(val *Visibility) {
 	p.Visibility = val
 }
+func (p *Experiment) SetCreateTime(val *int64) {
+	p.CreateTime = val
+}
 func (p *Experiment) SetEvalSetVersionID(val *int64) {
 	p.EvalSetVersionID = val
 }
@@ -1933,6 +1950,7 @@ var fieldIDToName_Experiment = map[int16]string{
 	8:   "end_time",
 	9:   "item_concur_num",
 	10:  "visibility",
+	11:  "create_time",
 	21:  "eval_set_version_id",
 	22:  "target_version_id",
 	23:  "evaluator_version_ids",
@@ -2008,6 +2026,10 @@ func (p *Experiment) IsSetItemConcurNum() bool {
 
 func (p *Experiment) IsSetVisibility() bool {
 	return p.Visibility != nil
+}
+
+func (p *Experiment) IsSetCreateTime() bool {
+	return p.CreateTime != nil
 }
 
 func (p *Experiment) IsSetEvalSetVersionID() bool {
@@ -2243,6 +2265,14 @@ func (p *Experiment) Read(iprot thrift.TProtocol) (err error) {
 		case 10:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField10(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 11:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField11(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -2666,6 +2696,17 @@ func (p *Experiment) ReadField10(iprot thrift.TProtocol) error {
 		_field = &v
 	}
 	p.Visibility = _field
+	return nil
+}
+func (p *Experiment) ReadField11(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.CreateTime = _field
 	return nil
 }
 func (p *Experiment) ReadField21(iprot thrift.TProtocol) error {
@@ -3164,6 +3205,10 @@ func (p *Experiment) Write(oprot thrift.TProtocol) (err error) {
 			fieldId = 10
 			goto WriteFieldError
 		}
+		if err = p.writeField11(oprot); err != nil {
+			fieldId = 11
+			goto WriteFieldError
+		}
 		if err = p.writeField21(oprot); err != nil {
 			fieldId = 21
 			goto WriteFieldError
@@ -3501,6 +3546,24 @@ WriteFieldBeginError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 10 begin error: ", p), err)
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 10 end error: ", p), err)
+}
+func (p *Experiment) writeField11(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCreateTime() {
+		if err = oprot.WriteFieldBegin("create_time", thrift.I64, 11); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.CreateTime); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 end error: ", p), err)
 }
 func (p *Experiment) writeField21(oprot thrift.TProtocol) (err error) {
 	if p.IsSetEvalSetVersionID() {
@@ -4236,6 +4299,9 @@ func (p *Experiment) DeepEqual(ano *Experiment) bool {
 	if !p.Field10DeepEqual(ano.Visibility) {
 		return false
 	}
+	if !p.Field11DeepEqual(ano.CreateTime) {
+		return false
+	}
 	if !p.Field21DeepEqual(ano.EvalSetVersionID) {
 		return false
 	}
@@ -4460,6 +4526,18 @@ func (p *Experiment) Field10DeepEqual(src *Visibility) bool {
 		return false
 	}
 	if strings.Compare(*p.Visibility, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *Experiment) Field11DeepEqual(src *int64) bool {
+
+	if p.CreateTime == src {
+		return true
+	} else if p.CreateTime == nil || src == nil {
+		return false
+	}
+	if *p.CreateTime != *src {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/domain/expt/k-expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/expt/k-expt.go
@@ -200,6 +200,20 @@ func (p *Experiment) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 11:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField11(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 21:
 			if fieldTypeId == thrift.I64 {
 				l, err = p.FastReadField21(buf[offset:])
@@ -850,6 +864,20 @@ func (p *Experiment) FastReadField10(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *Experiment) FastReadField11(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.CreateTime = _field
+	return offset, nil
+}
+
 func (p *Experiment) FastReadField21(buf []byte) (int, error) {
 	offset := 0
 
@@ -1422,6 +1450,7 @@ func (p *Experiment) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
 		offset += p.fastWriteField9(buf[offset:], w)
+		offset += p.fastWriteField11(buf[offset:], w)
 		offset += p.fastWriteField21(buf[offset:], w)
 		offset += p.fastWriteField22(buf[offset:], w)
 		offset += p.fastWriteField27(buf[offset:], w)
@@ -1481,6 +1510,7 @@ func (p *Experiment) BLength() int {
 		l += p.field8Length()
 		l += p.field9Length()
 		l += p.field10Length()
+		l += p.field11Length()
 		l += p.field21Length()
 		l += p.field22Length()
 		l += p.field23Length()
@@ -1607,6 +1637,15 @@ func (p *Experiment) fastWriteField10(buf []byte, w thrift.NocopyWriter) int {
 	if p.IsSetVisibility() {
 		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 10)
 		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.Visibility)
+	}
+	return offset
+}
+
+func (p *Experiment) fastWriteField11(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetCreateTime() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 11)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.CreateTime)
 	}
 	return offset
 }
@@ -2066,6 +2105,15 @@ func (p *Experiment) field10Length() int {
 	return l
 }
 
+func (p *Experiment) field11Length() int {
+	l := 0
+	if p.IsSetCreateTime() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
 func (p *Experiment) field21Length() int {
 	l := 0
 	if p.IsSetEvalSetVersionID() {
@@ -2475,6 +2523,11 @@ func (p *Experiment) DeepCopy(s interface{}) error {
 	if src.Visibility != nil {
 		tmp := *src.Visibility
 		p.Visibility = &tmp
+	}
+
+	if src.CreateTime != nil {
+		tmp := *src.CreateTime
+		p.CreateTime = &tmp
 	}
 
 	if src.EvalSetVersionID != nil {

--- a/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
@@ -17574,6 +17574,8 @@ type ItemStandardEvalOutput struct {
 	ExperimentCreateTime *int64 `thrift:"experiment_create_time,16,optional" frugal:"16,optional,i64" json:"experiment_create_time" form:"experiment_create_time" query:"experiment_create_time"`
 	// item 执行结束时间（秒），来源 expt_item_result.updated_at
 	ItemEndTime *int64 `thrift:"item_end_time,17,optional" frugal:"17,optional,i64" json:"item_end_time" form:"item_end_time" query:"item_end_time"`
+	// 实验创建人 userID，来源 experiment.created_by（实验级恒定）
+	CreatedBy *string `thrift:"created_by,18,optional" frugal:"18,optional,string" json:"created_by" form:"created_by" query:"created_by"`
 	// 标准化评测输出内容块：小内容 inline，大内容通过各 section 的 full_content 引用。
 	Detail *StandardEvalOutputContent `thrift:"detail,30,optional" frugal:"30,optional,StandardEvalOutputContent" json:"detail" form:"detail" query:"detail"`
 	Rounds *StandardEvalOutputContent `thrift:"rounds,31,optional" frugal:"31,optional,StandardEvalOutputContent" json:"rounds" form:"rounds" query:"rounds"`
@@ -17794,6 +17796,18 @@ func (p *ItemStandardEvalOutput) GetItemEndTime() (v int64) {
 	return *p.ItemEndTime
 }
 
+var ItemStandardEvalOutput_CreatedBy_DEFAULT string
+
+func (p *ItemStandardEvalOutput) GetCreatedBy() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetCreatedBy() {
+		return ItemStandardEvalOutput_CreatedBy_DEFAULT
+	}
+	return *p.CreatedBy
+}
+
 var ItemStandardEvalOutput_Detail_DEFAULT *StandardEvalOutputContent
 
 func (p *ItemStandardEvalOutput) GetDetail() (v *StandardEvalOutputContent) {
@@ -17916,6 +17930,9 @@ func (p *ItemStandardEvalOutput) SetExperimentCreateTime(val *int64) {
 func (p *ItemStandardEvalOutput) SetItemEndTime(val *int64) {
 	p.ItemEndTime = val
 }
+func (p *ItemStandardEvalOutput) SetCreatedBy(val *string) {
+	p.CreatedBy = val
+}
 func (p *ItemStandardEvalOutput) SetDetail(val *StandardEvalOutputContent) {
 	p.Detail = val
 }
@@ -17953,6 +17970,7 @@ var fieldIDToName_ItemStandardEvalOutput = map[int16]string{
 	15: "experiment_group_key",
 	16: "experiment_create_time",
 	17: "item_end_time",
+	18: "created_by",
 	30: "detail",
 	31: "rounds",
 	32: "agent",
@@ -18027,6 +18045,10 @@ func (p *ItemStandardEvalOutput) IsSetExperimentCreateTime() bool {
 
 func (p *ItemStandardEvalOutput) IsSetItemEndTime() bool {
 	return p.ItemEndTime != nil
+}
+
+func (p *ItemStandardEvalOutput) IsSetCreatedBy() bool {
+	return p.CreatedBy != nil
 }
 
 func (p *ItemStandardEvalOutput) IsSetDetail() bool {
@@ -18202,6 +18224,14 @@ func (p *ItemStandardEvalOutput) Read(iprot thrift.TProtocol) (err error) {
 		case 17:
 			if fieldTypeId == thrift.I64 {
 				if err = p.ReadField17(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 18:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField18(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -18472,6 +18502,17 @@ func (p *ItemStandardEvalOutput) ReadField17(iprot thrift.TProtocol) error {
 	p.ItemEndTime = _field
 	return nil
 }
+func (p *ItemStandardEvalOutput) ReadField18(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.CreatedBy = _field
+	return nil
+}
 func (p *ItemStandardEvalOutput) ReadField30(iprot thrift.TProtocol) error {
 	_field := NewStandardEvalOutputContent()
 	if err := _field.Read(iprot); err != nil {
@@ -18593,6 +18634,10 @@ func (p *ItemStandardEvalOutput) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField17(oprot); err != nil {
 			fieldId = 17
+			goto WriteFieldError
+		}
+		if err = p.writeField18(oprot); err != nil {
+			fieldId = 18
 			goto WriteFieldError
 		}
 		if err = p.writeField30(oprot); err != nil {
@@ -18943,6 +18988,24 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 17 end error: ", p), err)
 }
+func (p *ItemStandardEvalOutput) writeField18(oprot thrift.TProtocol) (err error) {
+	if p.IsSetCreatedBy() {
+		if err = oprot.WriteFieldBegin("created_by", thrift.STRING, 18); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.CreatedBy); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 18 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 18 end error: ", p), err)
+}
 func (p *ItemStandardEvalOutput) writeField30(oprot thrift.TProtocol) (err error) {
 	if p.IsSetDetail() {
 		if err = oprot.WriteFieldBegin("detail", thrift.STRUCT, 30); err != nil {
@@ -19115,6 +19178,9 @@ func (p *ItemStandardEvalOutput) DeepEqual(ano *ItemStandardEvalOutput) bool {
 		return false
 	}
 	if !p.Field17DeepEqual(ano.ItemEndTime) {
+		return false
+	}
+	if !p.Field18DeepEqual(ano.CreatedBy) {
 		return false
 	}
 	if !p.Field30DeepEqual(ano.Detail) {
@@ -19338,6 +19404,18 @@ func (p *ItemStandardEvalOutput) Field17DeepEqual(src *int64) bool {
 		return false
 	}
 	if *p.ItemEndTime != *src {
+		return false
+	}
+	return true
+}
+func (p *ItemStandardEvalOutput) Field18DeepEqual(src *string) bool {
+
+	if p.CreatedBy == src {
+		return true
+	} else if p.CreatedBy == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.CreatedBy, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/coze.loop.evaluation.expt.go
@@ -65,9 +65,8 @@ type CreateExperimentRequest struct {
 	// ★ 新路径分流依据 (唯一开关): 仅 == MultiSetConfig(2) 走 item-centric 多评测集路径; 缺省/SingleSet(1) 走老路径。
 	// 与 eval_set_configs 须一致: ==2 要求 configs 非空; !=2 要求 configs 为空, 否则硬校验报错。
 	EvalSetSourceType *expt.ExptEvalSetSourceType `thrift:"eval_set_source_type,71,optional" frugal:"71,optional,ExptEvalSetSourceType" form:"eval_set_source_type" json:"eval_set_source_type,omitempty"`
-	// 实验分组 key；不填时后端默认为实验 id
-	ExperimentGroupKey *string `thrift:"experiment_group_key,90,optional" frugal:"90,optional,string" json:"experiment_group_key" form:"experiment_group_key" `
-	// 引用分组实验 id：填写时校验其为当前空间内的实验 id，通过后本实验的 group key 复用该引用实验的 group key（归入同一分组）；优先级高于 experiment_group_key
+	// 实验分组 key 默认为实验 id；填写 ref_group_experiment_id 时复用该引用实验的 group key（归入同一分组）
+	// 引用分组实验 id：填写时校验其为当前空间内的实验 id
 	RefGroupExperimentID *int64 `thrift:"ref_group_experiment_id,91,optional" frugal:"91,optional,i64" json:"ref_group_experiment_id" form:"ref_group_experiment_id" `
 	// 通知配置
 	NotificationConf *expt.ExptNotificationConf `thrift:"notification_conf,110,optional" frugal:"110,optional,expt.ExptNotificationConf" form:"notification_conf" json:"notification_conf,omitempty"`
@@ -438,18 +437,6 @@ func (p *CreateExperimentRequest) GetEvalSetSourceType() (v expt.ExptEvalSetSour
 	return *p.EvalSetSourceType
 }
 
-var CreateExperimentRequest_ExperimentGroupKey_DEFAULT string
-
-func (p *CreateExperimentRequest) GetExperimentGroupKey() (v string) {
-	if p == nil {
-		return
-	}
-	if !p.IsSetExperimentGroupKey() {
-		return CreateExperimentRequest_ExperimentGroupKey_DEFAULT
-	}
-	return *p.ExperimentGroupKey
-}
-
 var CreateExperimentRequest_RefGroupExperimentID_DEFAULT int64
 
 func (p *CreateExperimentRequest) GetRefGroupExperimentID() (v int64) {
@@ -599,9 +586,6 @@ func (p *CreateExperimentRequest) SetEvalSetConfigs(val []*expt.EvalSetConfig) {
 func (p *CreateExperimentRequest) SetEvalSetSourceType(val *expt.ExptEvalSetSourceType) {
 	p.EvalSetSourceType = val
 }
-func (p *CreateExperimentRequest) SetExperimentGroupKey(val *string) {
-	p.ExperimentGroupKey = val
-}
 func (p *CreateExperimentRequest) SetRefGroupExperimentID(val *int64) {
 	p.RefGroupExperimentID = val
 }
@@ -649,7 +633,6 @@ var fieldIDToName_CreateExperimentRequest = map[int16]string{
 	50:  "trigger_type",
 	70:  "eval_set_configs",
 	71:  "eval_set_source_type",
-	90:  "experiment_group_key",
 	91:  "ref_group_experiment_id",
 	110: "notification_conf",
 	100: "ext",
@@ -771,10 +754,6 @@ func (p *CreateExperimentRequest) IsSetEvalSetConfigs() bool {
 
 func (p *CreateExperimentRequest) IsSetEvalSetSourceType() bool {
 	return p.EvalSetSourceType != nil
-}
-
-func (p *CreateExperimentRequest) IsSetExperimentGroupKey() bool {
-	return p.ExperimentGroupKey != nil
 }
 
 func (p *CreateExperimentRequest) IsSetRefGroupExperimentID() bool {
@@ -1052,14 +1031,6 @@ func (p *CreateExperimentRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 71:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField71(iprot); err != nil {
-					goto ReadFieldError
-				}
-			} else if err = iprot.Skip(fieldTypeId); err != nil {
-				goto SkipFieldError
-			}
-		case 90:
-			if fieldTypeId == thrift.STRING {
-				if err = p.ReadField90(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -1530,17 +1501,6 @@ func (p *CreateExperimentRequest) ReadField71(iprot thrift.TProtocol) error {
 	p.EvalSetSourceType = _field
 	return nil
 }
-func (p *CreateExperimentRequest) ReadField90(iprot thrift.TProtocol) error {
-
-	var _field *string
-	if v, err := iprot.ReadString(); err != nil {
-		return err
-	} else {
-		_field = &v
-	}
-	p.ExperimentGroupKey = _field
-	return nil
-}
 func (p *CreateExperimentRequest) ReadField91(iprot thrift.TProtocol) error {
 
 	var _field *int64
@@ -1730,10 +1690,6 @@ func (p *CreateExperimentRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField71(oprot); err != nil {
 			fieldId = 71
-			goto WriteFieldError
-		}
-		if err = p.writeField90(oprot); err != nil {
-			fieldId = 90
 			goto WriteFieldError
 		}
 		if err = p.writeField91(oprot); err != nil {
@@ -2355,24 +2311,6 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 71 end error: ", p), err)
 }
-func (p *CreateExperimentRequest) writeField90(oprot thrift.TProtocol) (err error) {
-	if p.IsSetExperimentGroupKey() {
-		if err = oprot.WriteFieldBegin("experiment_group_key", thrift.STRING, 90); err != nil {
-			goto WriteFieldBeginError
-		}
-		if err := oprot.WriteString(*p.ExperimentGroupKey); err != nil {
-			return err
-		}
-		if err = oprot.WriteFieldEnd(); err != nil {
-			goto WriteFieldEndError
-		}
-	}
-	return nil
-WriteFieldBeginError:
-	return thrift.PrependError(fmt.Sprintf("%T write field 90 begin error: ", p), err)
-WriteFieldEndError:
-	return thrift.PrependError(fmt.Sprintf("%T write field 90 end error: ", p), err)
-}
 func (p *CreateExperimentRequest) writeField91(oprot thrift.TProtocol) (err error) {
 	if p.IsSetRefGroupExperimentID() {
 		if err = oprot.WriteFieldBegin("ref_group_experiment_id", thrift.I64, 91); err != nil {
@@ -2577,9 +2515,6 @@ func (p *CreateExperimentRequest) DeepEqual(ano *CreateExperimentRequest) bool {
 		return false
 	}
 	if !p.Field71DeepEqual(ano.EvalSetSourceType) {
-		return false
-	}
-	if !p.Field90DeepEqual(ano.ExperimentGroupKey) {
 		return false
 	}
 	if !p.Field91DeepEqual(ano.RefGroupExperimentID) {
@@ -2945,18 +2880,6 @@ func (p *CreateExperimentRequest) Field71DeepEqual(src *expt.ExptEvalSetSourceTy
 	}
 	return true
 }
-func (p *CreateExperimentRequest) Field90DeepEqual(src *string) bool {
-
-	if p.ExperimentGroupKey == src {
-		return true
-	} else if p.ExperimentGroupKey == nil || src == nil {
-		return false
-	}
-	if strings.Compare(*p.ExperimentGroupKey, *src) != 0 {
-		return false
-	}
-	return true
-}
 func (p *CreateExperimentRequest) Field91DeepEqual(src *int64) bool {
 
 	if p.RefGroupExperimentID == src {
@@ -3289,9 +3212,8 @@ type SubmitExperimentRequest struct {
 	// 与 eval_set_configs 须一致: ==2 要求 configs 非空; !=2 要求 configs 为空, 否则硬校验报错。
 	EvalSetSourceType *expt.ExptEvalSetSourceType `thrift:"eval_set_source_type,76,optional" frugal:"76,optional,ExptEvalSetSourceType" form:"eval_set_source_type" json:"eval_set_source_type,omitempty"`
 	Ext               map[string]string           `thrift:"ext,100,optional" frugal:"100,optional,map<string:string>" form:"ext" json:"ext,omitempty"`
-	// 实验分组 key；不填时后端默认为实验 id
-	ExperimentGroupKey *string `thrift:"experiment_group_key,90,optional" frugal:"90,optional,string" json:"experiment_group_key" form:"experiment_group_key" `
-	// 引用分组实验 id：填写时校验其为当前空间内的实验 id，通过后本实验的 group key 复用该引用实验的 group key（归入同一分组）；优先级高于 experiment_group_key
+	// 实验分组 key 默认为实验 id；填写 ref_group_experiment_id 时复用该引用实验的 group key（归入同一分组）
+	// 引用分组实验 id：填写时校验其为当前空间内的实验 id
 	RefGroupExperimentID *int64 `thrift:"ref_group_experiment_id,91,optional" frugal:"91,optional,i64" json:"ref_group_experiment_id" form:"ref_group_experiment_id" `
 	// 通知配置
 	NotificationConf *expt.ExptNotificationConf `thrift:"notification_conf,110,optional" frugal:"110,optional,expt.ExptNotificationConf" form:"notification_conf" json:"notification_conf,omitempty"`
@@ -3697,18 +3619,6 @@ func (p *SubmitExperimentRequest) GetExt() (v map[string]string) {
 	return p.Ext
 }
 
-var SubmitExperimentRequest_ExperimentGroupKey_DEFAULT string
-
-func (p *SubmitExperimentRequest) GetExperimentGroupKey() (v string) {
-	if p == nil {
-		return
-	}
-	if !p.IsSetExperimentGroupKey() {
-		return SubmitExperimentRequest_ExperimentGroupKey_DEFAULT
-	}
-	return *p.ExperimentGroupKey
-}
-
 var SubmitExperimentRequest_RefGroupExperimentID_DEFAULT int64
 
 func (p *SubmitExperimentRequest) GetRefGroupExperimentID() (v int64) {
@@ -3855,9 +3765,6 @@ func (p *SubmitExperimentRequest) SetEvalSetSourceType(val *expt.ExptEvalSetSour
 func (p *SubmitExperimentRequest) SetExt(val map[string]string) {
 	p.Ext = val
 }
-func (p *SubmitExperimentRequest) SetExperimentGroupKey(val *string) {
-	p.ExperimentGroupKey = val
-}
 func (p *SubmitExperimentRequest) SetRefGroupExperimentID(val *int64) {
 	p.RefGroupExperimentID = val
 }
@@ -3905,7 +3812,6 @@ var fieldIDToName_SubmitExperimentRequest = map[int16]string{
 	75:  "eval_set_configs",
 	76:  "eval_set_source_type",
 	100: "ext",
-	90:  "experiment_group_key",
 	91:  "ref_group_experiment_id",
 	110: "notification_conf",
 	200: "session",
@@ -4038,10 +3944,6 @@ func (p *SubmitExperimentRequest) IsSetEvalSetSourceType() bool {
 
 func (p *SubmitExperimentRequest) IsSetExt() bool {
 	return p.Ext != nil
-}
-
-func (p *SubmitExperimentRequest) IsSetExperimentGroupKey() bool {
-	return p.ExperimentGroupKey != nil
 }
 
 func (p *SubmitExperimentRequest) IsSetRefGroupExperimentID() bool {
@@ -4339,14 +4241,6 @@ func (p *SubmitExperimentRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 100:
 			if fieldTypeId == thrift.MAP {
 				if err = p.ReadField100(iprot); err != nil {
-					goto ReadFieldError
-				}
-			} else if err = iprot.Skip(fieldTypeId); err != nil {
-				goto SkipFieldError
-			}
-		case 90:
-			if fieldTypeId == thrift.STRING {
-				if err = p.ReadField90(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -4851,17 +4745,6 @@ func (p *SubmitExperimentRequest) ReadField100(iprot thrift.TProtocol) error {
 	p.Ext = _field
 	return nil
 }
-func (p *SubmitExperimentRequest) ReadField90(iprot thrift.TProtocol) error {
-
-	var _field *string
-	if v, err := iprot.ReadString(); err != nil {
-		return err
-	} else {
-		_field = &v
-	}
-	p.ExperimentGroupKey = _field
-	return nil
-}
 func (p *SubmitExperimentRequest) ReadField91(iprot thrift.TProtocol) error {
 
 	var _field *int64
@@ -5034,10 +4917,6 @@ func (p *SubmitExperimentRequest) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField100(oprot); err != nil {
 			fieldId = 100
-			goto WriteFieldError
-		}
-		if err = p.writeField90(oprot); err != nil {
-			fieldId = 90
 			goto WriteFieldError
 		}
 		if err = p.writeField91(oprot); err != nil {
@@ -5717,24 +5596,6 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 100 end error: ", p), err)
 }
-func (p *SubmitExperimentRequest) writeField90(oprot thrift.TProtocol) (err error) {
-	if p.IsSetExperimentGroupKey() {
-		if err = oprot.WriteFieldBegin("experiment_group_key", thrift.STRING, 90); err != nil {
-			goto WriteFieldBeginError
-		}
-		if err := oprot.WriteString(*p.ExperimentGroupKey); err != nil {
-			return err
-		}
-		if err = oprot.WriteFieldEnd(); err != nil {
-			goto WriteFieldEndError
-		}
-	}
-	return nil
-WriteFieldBeginError:
-	return thrift.PrependError(fmt.Sprintf("%T write field 90 begin error: ", p), err)
-WriteFieldEndError:
-	return thrift.PrependError(fmt.Sprintf("%T write field 90 end error: ", p), err)
-}
 func (p *SubmitExperimentRequest) writeField91(oprot thrift.TProtocol) (err error) {
 	if p.IsSetRefGroupExperimentID() {
 		if err = oprot.WriteFieldBegin("ref_group_experiment_id", thrift.I64, 91); err != nil {
@@ -5919,9 +5780,6 @@ func (p *SubmitExperimentRequest) DeepEqual(ano *SubmitExperimentRequest) bool {
 		return false
 	}
 	if !p.Field100DeepEqual(ano.Ext) {
-		return false
-	}
-	if !p.Field90DeepEqual(ano.ExperimentGroupKey) {
 		return false
 	}
 	if !p.Field91DeepEqual(ano.RefGroupExperimentID) {
@@ -6313,18 +6171,6 @@ func (p *SubmitExperimentRequest) Field100DeepEqual(src map[string]string) bool 
 		if strings.Compare(v, _src) != 0 {
 			return false
 		}
-	}
-	return true
-}
-func (p *SubmitExperimentRequest) Field90DeepEqual(src *string) bool {
-
-	if p.ExperimentGroupKey == src {
-		return true
-	} else if p.ExperimentGroupKey == nil || src == nil {
-		return false
-	}
-	if strings.Compare(*p.ExperimentGroupKey, *src) != 0 {
-		return false
 	}
 	return true
 }
@@ -8504,8 +8350,9 @@ func (p *GetExperimentIDsByGroupRequest) Field255DeepEqual(src *base.Base) bool 
 }
 
 type GetExperimentIDsByGroupResponse struct {
-	ExptIds  []int64        `thrift:"expt_ids,1,optional" frugal:"1,optional,list<i64>" json:"expt_ids" form:"expt_ids" `
-	BaseResp *base.BaseResp `thrift:"BaseResp,255" frugal:"255,default,base.BaseResp" form:"BaseResp" json:"BaseResp" query:"BaseResp"`
+	ExptIds     []int64            `thrift:"expt_ids,1,optional" frugal:"1,optional,list<i64>" json:"expt_ids" form:"expt_ids" `
+	Experiments []*expt.Experiment `thrift:"experiments,2,optional" frugal:"2,optional,list<expt.Experiment>" json:"experiments" form:"experiments" `
+	BaseResp    *base.BaseResp     `thrift:"BaseResp,255" frugal:"255,default,base.BaseResp" form:"BaseResp" json:"BaseResp" query:"BaseResp"`
 }
 
 func NewGetExperimentIDsByGroupResponse() *GetExperimentIDsByGroupResponse {
@@ -8527,6 +8374,18 @@ func (p *GetExperimentIDsByGroupResponse) GetExptIds() (v []int64) {
 	return p.ExptIds
 }
 
+var GetExperimentIDsByGroupResponse_Experiments_DEFAULT []*expt.Experiment
+
+func (p *GetExperimentIDsByGroupResponse) GetExperiments() (v []*expt.Experiment) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetExperiments() {
+		return GetExperimentIDsByGroupResponse_Experiments_DEFAULT
+	}
+	return p.Experiments
+}
+
 var GetExperimentIDsByGroupResponse_BaseResp_DEFAULT *base.BaseResp
 
 func (p *GetExperimentIDsByGroupResponse) GetBaseResp() (v *base.BaseResp) {
@@ -8541,17 +8400,25 @@ func (p *GetExperimentIDsByGroupResponse) GetBaseResp() (v *base.BaseResp) {
 func (p *GetExperimentIDsByGroupResponse) SetExptIds(val []int64) {
 	p.ExptIds = val
 }
+func (p *GetExperimentIDsByGroupResponse) SetExperiments(val []*expt.Experiment) {
+	p.Experiments = val
+}
 func (p *GetExperimentIDsByGroupResponse) SetBaseResp(val *base.BaseResp) {
 	p.BaseResp = val
 }
 
 var fieldIDToName_GetExperimentIDsByGroupResponse = map[int16]string{
 	1:   "expt_ids",
+	2:   "experiments",
 	255: "BaseResp",
 }
 
 func (p *GetExperimentIDsByGroupResponse) IsSetExptIds() bool {
 	return p.ExptIds != nil
+}
+
+func (p *GetExperimentIDsByGroupResponse) IsSetExperiments() bool {
+	return p.Experiments != nil
 }
 
 func (p *GetExperimentIDsByGroupResponse) IsSetBaseResp() bool {
@@ -8579,6 +8446,14 @@ func (p *GetExperimentIDsByGroupResponse) Read(iprot thrift.TProtocol) (err erro
 		case 1:
 			if fieldTypeId == thrift.LIST {
 				if err = p.ReadField1(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 2:
+			if fieldTypeId == thrift.LIST {
+				if err = p.ReadField2(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -8644,6 +8519,29 @@ func (p *GetExperimentIDsByGroupResponse) ReadField1(iprot thrift.TProtocol) err
 	p.ExptIds = _field
 	return nil
 }
+func (p *GetExperimentIDsByGroupResponse) ReadField2(iprot thrift.TProtocol) error {
+	_, size, err := iprot.ReadListBegin()
+	if err != nil {
+		return err
+	}
+	_field := make([]*expt.Experiment, 0, size)
+	values := make([]expt.Experiment, size)
+	for i := 0; i < size; i++ {
+		_elem := &values[i]
+		_elem.InitDefault()
+
+		if err := _elem.Read(iprot); err != nil {
+			return err
+		}
+
+		_field = append(_field, _elem)
+	}
+	if err := iprot.ReadListEnd(); err != nil {
+		return err
+	}
+	p.Experiments = _field
+	return nil
+}
 func (p *GetExperimentIDsByGroupResponse) ReadField255(iprot thrift.TProtocol) error {
 	_field := base.NewBaseResp()
 	if err := _field.Read(iprot); err != nil {
@@ -8661,6 +8559,10 @@ func (p *GetExperimentIDsByGroupResponse) Write(oprot thrift.TProtocol) (err err
 	if p != nil {
 		if err = p.writeField1(oprot); err != nil {
 			fieldId = 1
+			goto WriteFieldError
+		}
+		if err = p.writeField2(oprot); err != nil {
+			fieldId = 2
 			goto WriteFieldError
 		}
 		if err = p.writeField255(oprot); err != nil {
@@ -8711,6 +8613,32 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 1 end error: ", p), err)
 }
+func (p *GetExperimentIDsByGroupResponse) writeField2(oprot thrift.TProtocol) (err error) {
+	if p.IsSetExperiments() {
+		if err = oprot.WriteFieldBegin("experiments", thrift.LIST, 2); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteListBegin(thrift.STRUCT, len(p.Experiments)); err != nil {
+			return err
+		}
+		for _, v := range p.Experiments {
+			if err := v.Write(oprot); err != nil {
+				return err
+			}
+		}
+		if err := oprot.WriteListEnd(); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 2 end error: ", p), err)
+}
 func (p *GetExperimentIDsByGroupResponse) writeField255(oprot thrift.TProtocol) (err error) {
 	if err = oprot.WriteFieldBegin("BaseResp", thrift.STRUCT, 255); err != nil {
 		goto WriteFieldBeginError
@@ -8745,6 +8673,9 @@ func (p *GetExperimentIDsByGroupResponse) DeepEqual(ano *GetExperimentIDsByGroup
 	if !p.Field1DeepEqual(ano.ExptIds) {
 		return false
 	}
+	if !p.Field2DeepEqual(ano.Experiments) {
+		return false
+	}
 	if !p.Field255DeepEqual(ano.BaseResp) {
 		return false
 	}
@@ -8759,6 +8690,19 @@ func (p *GetExperimentIDsByGroupResponse) Field1DeepEqual(src []int64) bool {
 	for i, v := range p.ExptIds {
 		_src := src[i]
 		if v != _src {
+			return false
+		}
+	}
+	return true
+}
+func (p *GetExperimentIDsByGroupResponse) Field2DeepEqual(src []*expt.Experiment) bool {
+
+	if len(p.Experiments) != len(src) {
+		return false
+	}
+	for i, v := range p.Experiments {
+		_src := src[i]
+		if !v.DeepEqual(_src) {
 			return false
 		}
 	}
@@ -17626,6 +17570,10 @@ type ItemStandardEvalOutput struct {
 	DatasetVersionID      *int64  `thrift:"dataset_version_id,13,optional" frugal:"13,optional,i64" json:"dataset_version_id" form:"dataset_version_id" query:"dataset_version_id"`
 	DatasetVersionName    *string `thrift:"dataset_version_name,14,optional" frugal:"14,optional,string" json:"dataset_version_name" form:"dataset_version_name" query:"dataset_version_name"`
 	ExperimentGroupKey    *string `thrift:"experiment_group_key,15,optional" frugal:"15,optional,string" json:"experiment_group_key" form:"experiment_group_key" query:"experiment_group_key"`
+	// 实验创建时间（秒），来源 experiment.created_at
+	ExperimentCreateTime *int64 `thrift:"experiment_create_time,16,optional" frugal:"16,optional,i64" json:"experiment_create_time" form:"experiment_create_time" query:"experiment_create_time"`
+	// item 执行结束时间（秒），来源 expt_item_result.updated_at
+	ItemEndTime *int64 `thrift:"item_end_time,17,optional" frugal:"17,optional,i64" json:"item_end_time" form:"item_end_time" query:"item_end_time"`
 	// 标准化评测输出内容块：小内容 inline，大内容通过各 section 的 full_content 引用。
 	Detail *StandardEvalOutputContent `thrift:"detail,30,optional" frugal:"30,optional,StandardEvalOutputContent" json:"detail" form:"detail" query:"detail"`
 	Rounds *StandardEvalOutputContent `thrift:"rounds,31,optional" frugal:"31,optional,StandardEvalOutputContent" json:"rounds" form:"rounds" query:"rounds"`
@@ -17822,6 +17770,30 @@ func (p *ItemStandardEvalOutput) GetExperimentGroupKey() (v string) {
 	return *p.ExperimentGroupKey
 }
 
+var ItemStandardEvalOutput_ExperimentCreateTime_DEFAULT int64
+
+func (p *ItemStandardEvalOutput) GetExperimentCreateTime() (v int64) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetExperimentCreateTime() {
+		return ItemStandardEvalOutput_ExperimentCreateTime_DEFAULT
+	}
+	return *p.ExperimentCreateTime
+}
+
+var ItemStandardEvalOutput_ItemEndTime_DEFAULT int64
+
+func (p *ItemStandardEvalOutput) GetItemEndTime() (v int64) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetItemEndTime() {
+		return ItemStandardEvalOutput_ItemEndTime_DEFAULT
+	}
+	return *p.ItemEndTime
+}
+
 var ItemStandardEvalOutput_Detail_DEFAULT *StandardEvalOutputContent
 
 func (p *ItemStandardEvalOutput) GetDetail() (v *StandardEvalOutputContent) {
@@ -17938,6 +17910,12 @@ func (p *ItemStandardEvalOutput) SetDatasetVersionName(val *string) {
 func (p *ItemStandardEvalOutput) SetExperimentGroupKey(val *string) {
 	p.ExperimentGroupKey = val
 }
+func (p *ItemStandardEvalOutput) SetExperimentCreateTime(val *int64) {
+	p.ExperimentCreateTime = val
+}
+func (p *ItemStandardEvalOutput) SetItemEndTime(val *int64) {
+	p.ItemEndTime = val
+}
 func (p *ItemStandardEvalOutput) SetDetail(val *StandardEvalOutputContent) {
 	p.Detail = val
 }
@@ -17973,6 +17951,8 @@ var fieldIDToName_ItemStandardEvalOutput = map[int16]string{
 	13: "dataset_version_id",
 	14: "dataset_version_name",
 	15: "experiment_group_key",
+	16: "experiment_create_time",
+	17: "item_end_time",
 	30: "detail",
 	31: "rounds",
 	32: "agent",
@@ -18039,6 +18019,14 @@ func (p *ItemStandardEvalOutput) IsSetDatasetVersionName() bool {
 
 func (p *ItemStandardEvalOutput) IsSetExperimentGroupKey() bool {
 	return p.ExperimentGroupKey != nil
+}
+
+func (p *ItemStandardEvalOutput) IsSetExperimentCreateTime() bool {
+	return p.ExperimentCreateTime != nil
+}
+
+func (p *ItemStandardEvalOutput) IsSetItemEndTime() bool {
+	return p.ItemEndTime != nil
 }
 
 func (p *ItemStandardEvalOutput) IsSetDetail() bool {
@@ -18198,6 +18186,22 @@ func (p *ItemStandardEvalOutput) Read(iprot thrift.TProtocol) (err error) {
 		case 15:
 			if fieldTypeId == thrift.STRING {
 				if err = p.ReadField15(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 16:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField16(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 17:
+			if fieldTypeId == thrift.I64 {
+				if err = p.ReadField17(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -18446,6 +18450,28 @@ func (p *ItemStandardEvalOutput) ReadField15(iprot thrift.TProtocol) error {
 	p.ExperimentGroupKey = _field
 	return nil
 }
+func (p *ItemStandardEvalOutput) ReadField16(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.ExperimentCreateTime = _field
+	return nil
+}
+func (p *ItemStandardEvalOutput) ReadField17(iprot thrift.TProtocol) error {
+
+	var _field *int64
+	if v, err := iprot.ReadI64(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.ItemEndTime = _field
+	return nil
+}
 func (p *ItemStandardEvalOutput) ReadField30(iprot thrift.TProtocol) error {
 	_field := NewStandardEvalOutputContent()
 	if err := _field.Read(iprot); err != nil {
@@ -18559,6 +18585,14 @@ func (p *ItemStandardEvalOutput) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField15(oprot); err != nil {
 			fieldId = 15
+			goto WriteFieldError
+		}
+		if err = p.writeField16(oprot); err != nil {
+			fieldId = 16
+			goto WriteFieldError
+		}
+		if err = p.writeField17(oprot); err != nil {
+			fieldId = 17
 			goto WriteFieldError
 		}
 		if err = p.writeField30(oprot); err != nil {
@@ -18873,6 +18907,42 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 15 end error: ", p), err)
 }
+func (p *ItemStandardEvalOutput) writeField16(oprot thrift.TProtocol) (err error) {
+	if p.IsSetExperimentCreateTime() {
+		if err = oprot.WriteFieldBegin("experiment_create_time", thrift.I64, 16); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.ExperimentCreateTime); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 16 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 16 end error: ", p), err)
+}
+func (p *ItemStandardEvalOutput) writeField17(oprot thrift.TProtocol) (err error) {
+	if p.IsSetItemEndTime() {
+		if err = oprot.WriteFieldBegin("item_end_time", thrift.I64, 17); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteI64(*p.ItemEndTime); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 17 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 17 end error: ", p), err)
+}
 func (p *ItemStandardEvalOutput) writeField30(oprot thrift.TProtocol) (err error) {
 	if p.IsSetDetail() {
 		if err = oprot.WriteFieldBegin("detail", thrift.STRUCT, 30); err != nil {
@@ -19039,6 +19109,12 @@ func (p *ItemStandardEvalOutput) DeepEqual(ano *ItemStandardEvalOutput) bool {
 		return false
 	}
 	if !p.Field15DeepEqual(ano.ExperimentGroupKey) {
+		return false
+	}
+	if !p.Field16DeepEqual(ano.ExperimentCreateTime) {
+		return false
+	}
+	if !p.Field17DeepEqual(ano.ItemEndTime) {
 		return false
 	}
 	if !p.Field30DeepEqual(ano.Detail) {
@@ -19238,6 +19314,30 @@ func (p *ItemStandardEvalOutput) Field15DeepEqual(src *string) bool {
 		return false
 	}
 	if strings.Compare(*p.ExperimentGroupKey, *src) != 0 {
+		return false
+	}
+	return true
+}
+func (p *ItemStandardEvalOutput) Field16DeepEqual(src *int64) bool {
+
+	if p.ExperimentCreateTime == src {
+		return true
+	} else if p.ExperimentCreateTime == nil || src == nil {
+		return false
+	}
+	if *p.ExperimentCreateTime != *src {
+		return false
+	}
+	return true
+}
+func (p *ItemStandardEvalOutput) Field17DeepEqual(src *int64) bool {
+
+	if p.ItemEndTime == src {
+		return true
+	} else if p.ItemEndTime == nil || src == nil {
+		return false
+	}
+	if *p.ItemEndTime != *src {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/expt/k-coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/k-coze.loop.evaluation.expt.go
@@ -13124,6 +13124,20 @@ func (p *ItemStandardEvalOutput) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 18:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField18(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 30:
 			if fieldTypeId == thrift.STRUCT {
 				l, err = p.FastReadField30(buf[offset:])
@@ -13466,6 +13480,20 @@ func (p *ItemStandardEvalOutput) FastReadField17(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *ItemStandardEvalOutput) FastReadField18(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.CreatedBy = _field
+	return offset, nil
+}
+
 func (p *ItemStandardEvalOutput) FastReadField30(buf []byte) (int, error) {
 	offset := 0
 	_field := NewStandardEvalOutputContent()
@@ -13562,6 +13590,7 @@ func (p *ItemStandardEvalOutput) FastWriteNocopy(buf []byte, w thrift.NocopyWrit
 		offset += p.fastWriteField8(buf[offset:], w)
 		offset += p.fastWriteField14(buf[offset:], w)
 		offset += p.fastWriteField15(buf[offset:], w)
+		offset += p.fastWriteField18(buf[offset:], w)
 		offset += p.fastWriteField30(buf[offset:], w)
 		offset += p.fastWriteField31(buf[offset:], w)
 		offset += p.fastWriteField32(buf[offset:], w)
@@ -13593,6 +13622,7 @@ func (p *ItemStandardEvalOutput) BLength() int {
 		l += p.field15Length()
 		l += p.field16Length()
 		l += p.field17Length()
+		l += p.field18Length()
 		l += p.field30Length()
 		l += p.field31Length()
 		l += p.field32Length()
@@ -13753,6 +13783,15 @@ func (p *ItemStandardEvalOutput) fastWriteField17(buf []byte, w thrift.NocopyWri
 	if p.IsSetItemEndTime() {
 		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 17)
 		offset += thrift.Binary.WriteI64(buf[offset:], *p.ItemEndTime)
+	}
+	return offset
+}
+
+func (p *ItemStandardEvalOutput) fastWriteField18(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetCreatedBy() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 18)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.CreatedBy)
 	}
 	return offset
 }
@@ -13964,6 +14003,15 @@ func (p *ItemStandardEvalOutput) field17Length() int {
 	return l
 }
 
+func (p *ItemStandardEvalOutput) field18Length() int {
+	l := 0
+	if p.IsSetCreatedBy() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.CreatedBy)
+	}
+	return l
+}
+
 func (p *ItemStandardEvalOutput) field30Length() int {
 	l := 0
 	if p.IsSetDetail() {
@@ -14122,6 +14170,14 @@ func (p *ItemStandardEvalOutput) DeepCopy(s interface{}) error {
 	if src.ItemEndTime != nil {
 		tmp := *src.ItemEndTime
 		p.ItemEndTime = &tmp
+	}
+
+	if src.CreatedBy != nil {
+		var tmp string
+		if *src.CreatedBy != "" {
+			tmp = kutils.StringDeepCopy(*src.CreatedBy)
+		}
+		p.CreatedBy = &tmp
 	}
 
 	var _detail *StandardEvalOutputContent

--- a/backend/kitex_gen/coze/loop/evaluation/expt/k-coze.loop.evaluation.expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/expt/k-coze.loop.evaluation.expt.go
@@ -478,20 +478,6 @@ func (p *CreateExperimentRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
-		case 90:
-			if fieldTypeId == thrift.STRING {
-				l, err = p.FastReadField90(buf[offset:])
-				offset += l
-				if err != nil {
-					goto ReadFieldError
-				}
-			} else {
-				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
-				offset += l
-				if err != nil {
-					goto SkipFieldError
-				}
-			}
 		case 91:
 			if fieldTypeId == thrift.I64 {
 				l, err = p.FastReadField91(buf[offset:])
@@ -1067,20 +1053,6 @@ func (p *CreateExperimentRequest) FastReadField71(buf []byte) (int, error) {
 	return offset, nil
 }
 
-func (p *CreateExperimentRequest) FastReadField90(buf []byte) (int, error) {
-	offset := 0
-
-	var _field *string
-	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
-		return offset, err
-	} else {
-		offset += l
-		_field = &v
-	}
-	p.ExperimentGroupKey = _field
-	return offset, nil
-}
-
 func (p *CreateExperimentRequest) FastReadField91(buf []byte) (int, error) {
 	offset := 0
 
@@ -1201,7 +1173,6 @@ func (p *CreateExperimentRequest) FastWriteNocopy(buf []byte, w thrift.NocopyWri
 		offset += p.fastWriteField50(buf[offset:], w)
 		offset += p.fastWriteField70(buf[offset:], w)
 		offset += p.fastWriteField71(buf[offset:], w)
-		offset += p.fastWriteField90(buf[offset:], w)
 		offset += p.fastWriteField110(buf[offset:], w)
 		offset += p.fastWriteField100(buf[offset:], w)
 		offset += p.fastWriteField200(buf[offset:], w)
@@ -1244,7 +1215,6 @@ func (p *CreateExperimentRequest) BLength() int {
 		l += p.field50Length()
 		l += p.field70Length()
 		l += p.field71Length()
-		l += p.field90Length()
 		l += p.field91Length()
 		l += p.field110Length()
 		l += p.field100Length()
@@ -1555,15 +1525,6 @@ func (p *CreateExperimentRequest) fastWriteField71(buf []byte, w thrift.NocopyWr
 	if p.IsSetEvalSetSourceType() {
 		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I32, 71)
 		offset += thrift.Binary.WriteI32(buf[offset:], int32(*p.EvalSetSourceType))
-	}
-	return offset
-}
-
-func (p *CreateExperimentRequest) fastWriteField90(buf []byte, w thrift.NocopyWriter) int {
-	offset := 0
-	if p.IsSetExperimentGroupKey() {
-		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 90)
-		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.ExperimentGroupKey)
 	}
 	return offset
 }
@@ -1905,15 +1866,6 @@ func (p *CreateExperimentRequest) field71Length() int {
 	return l
 }
 
-func (p *CreateExperimentRequest) field90Length() int {
-	l := 0
-	if p.IsSetExperimentGroupKey() {
-		l += thrift.Binary.FieldBeginLength()
-		l += thrift.Binary.StringLengthNocopy(*p.ExperimentGroupKey)
-	}
-	return l
-}
-
 func (p *CreateExperimentRequest) field91Length() int {
 	l := 0
 	if p.IsSetRefGroupExperimentID() {
@@ -2182,14 +2134,6 @@ func (p *CreateExperimentRequest) DeepCopy(s interface{}) error {
 	if src.EvalSetSourceType != nil {
 		tmp := *src.EvalSetSourceType
 		p.EvalSetSourceType = &tmp
-	}
-
-	if src.ExperimentGroupKey != nil {
-		var tmp string
-		if *src.ExperimentGroupKey != "" {
-			tmp = kutils.StringDeepCopy(*src.ExperimentGroupKey)
-		}
-		p.ExperimentGroupKey = &tmp
 	}
 
 	if src.RefGroupExperimentID != nil {
@@ -2895,20 +2839,6 @@ func (p *SubmitExperimentRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
-		case 90:
-			if fieldTypeId == thrift.STRING {
-				l, err = p.FastReadField90(buf[offset:])
-				offset += l
-				if err != nil {
-					goto ReadFieldError
-				}
-			} else {
-				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
-				offset += l
-				if err != nil {
-					goto SkipFieldError
-				}
-			}
 		case 91:
 			if fieldTypeId == thrift.I64 {
 				l, err = p.FastReadField91(buf[offset:])
@@ -3520,20 +3450,6 @@ func (p *SubmitExperimentRequest) FastReadField100(buf []byte) (int, error) {
 	return offset, nil
 }
 
-func (p *SubmitExperimentRequest) FastReadField90(buf []byte) (int, error) {
-	offset := 0
-
-	var _field *string
-	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
-		return offset, err
-	} else {
-		offset += l
-		_field = &v
-	}
-	p.ExperimentGroupKey = _field
-	return offset, nil
-}
-
 func (p *SubmitExperimentRequest) FastReadField91(buf []byte) (int, error) {
 	offset := 0
 
@@ -3625,7 +3541,6 @@ func (p *SubmitExperimentRequest) FastWriteNocopy(buf []byte, w thrift.NocopyWri
 		offset += p.fastWriteField75(buf[offset:], w)
 		offset += p.fastWriteField76(buf[offset:], w)
 		offset += p.fastWriteField100(buf[offset:], w)
-		offset += p.fastWriteField90(buf[offset:], w)
 		offset += p.fastWriteField110(buf[offset:], w)
 		offset += p.fastWriteField200(buf[offset:], w)
 		offset += p.fastWriteField255(buf[offset:], w)
@@ -3670,7 +3585,6 @@ func (p *SubmitExperimentRequest) BLength() int {
 		l += p.field75Length()
 		l += p.field76Length()
 		l += p.field100Length()
-		l += p.field90Length()
 		l += p.field91Length()
 		l += p.field110Length()
 		l += p.field200Length()
@@ -4014,15 +3928,6 @@ func (p *SubmitExperimentRequest) fastWriteField100(buf []byte, w thrift.NocopyW
 			offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, v)
 		}
 		thrift.Binary.WriteMapBegin(buf[mapBeginOffset:], thrift.STRING, thrift.STRING, length)
-	}
-	return offset
-}
-
-func (p *SubmitExperimentRequest) fastWriteField90(buf []byte, w thrift.NocopyWriter) int {
-	offset := 0
-	if p.IsSetExperimentGroupKey() {
-		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 90)
-		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.ExperimentGroupKey)
 	}
 	return offset
 }
@@ -4380,15 +4285,6 @@ func (p *SubmitExperimentRequest) field100Length() int {
 	return l
 }
 
-func (p *SubmitExperimentRequest) field90Length() int {
-	l := 0
-	if p.IsSetExperimentGroupKey() {
-		l += thrift.Binary.FieldBeginLength()
-		l += thrift.Binary.StringLengthNocopy(*p.ExperimentGroupKey)
-	}
-	return l
-}
-
 func (p *SubmitExperimentRequest) field91Length() int {
 	l := 0
 	if p.IsSetRefGroupExperimentID() {
@@ -4672,14 +4568,6 @@ func (p *SubmitExperimentRequest) DeepCopy(s interface{}) error {
 
 			p.Ext[_key] = _val
 		}
-	}
-
-	if src.ExperimentGroupKey != nil {
-		var tmp string
-		if *src.ExperimentGroupKey != "" {
-			tmp = kutils.StringDeepCopy(*src.ExperimentGroupKey)
-		}
-		p.ExperimentGroupKey = &tmp
 	}
 
 	if src.RefGroupExperimentID != nil {
@@ -6323,6 +6211,20 @@ func (p *GetExperimentIDsByGroupResponse) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 2:
+			if fieldTypeId == thrift.LIST {
+				l, err = p.FastReadField2(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 255:
 			if fieldTypeId == thrift.STRUCT {
 				l, err = p.FastReadField255(buf[offset:])
@@ -6379,6 +6281,31 @@ func (p *GetExperimentIDsByGroupResponse) FastReadField1(buf []byte) (int, error
 	return offset, nil
 }
 
+func (p *GetExperimentIDsByGroupResponse) FastReadField2(buf []byte) (int, error) {
+	offset := 0
+
+	_, size, l, err := thrift.Binary.ReadListBegin(buf[offset:])
+	offset += l
+	if err != nil {
+		return offset, err
+	}
+	_field := make([]*expt.Experiment, 0, size)
+	values := make([]expt.Experiment, size)
+	for i := 0; i < size; i++ {
+		_elem := &values[i]
+		_elem.InitDefault()
+		if l, err := _elem.FastRead(buf[offset:]); err != nil {
+			return offset, err
+		} else {
+			offset += l
+		}
+
+		_field = append(_field, _elem)
+	}
+	p.Experiments = _field
+	return offset, nil
+}
+
 func (p *GetExperimentIDsByGroupResponse) FastReadField255(buf []byte) (int, error) {
 	offset := 0
 	_field := base.NewBaseResp()
@@ -6399,6 +6326,7 @@ func (p *GetExperimentIDsByGroupResponse) FastWriteNocopy(buf []byte, w thrift.N
 	offset := 0
 	if p != nil {
 		offset += p.fastWriteField1(buf[offset:], w)
+		offset += p.fastWriteField2(buf[offset:], w)
 		offset += p.fastWriteField255(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
@@ -6409,6 +6337,7 @@ func (p *GetExperimentIDsByGroupResponse) BLength() int {
 	l := 0
 	if p != nil {
 		l += p.field1Length()
+		l += p.field2Length()
 		l += p.field255Length()
 	}
 	l += thrift.Binary.FieldStopLength()
@@ -6431,6 +6360,22 @@ func (p *GetExperimentIDsByGroupResponse) fastWriteField1(buf []byte, w thrift.N
 	return offset
 }
 
+func (p *GetExperimentIDsByGroupResponse) fastWriteField2(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetExperiments() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.LIST, 2)
+		listBeginOffset := offset
+		offset += thrift.Binary.ListBeginLength()
+		var length int
+		for _, v := range p.Experiments {
+			length++
+			offset += v.FastWriteNocopy(buf[offset:], w)
+		}
+		thrift.Binary.WriteListBegin(buf[listBeginOffset:], thrift.STRUCT, length)
+	}
+	return offset
+}
+
 func (p *GetExperimentIDsByGroupResponse) fastWriteField255(buf []byte, w thrift.NocopyWriter) int {
 	offset := 0
 	offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRUCT, 255)
@@ -6445,6 +6390,19 @@ func (p *GetExperimentIDsByGroupResponse) field1Length() int {
 		l += thrift.Binary.ListBeginLength()
 		l +=
 			thrift.Binary.I64Length() * len(p.ExptIds)
+	}
+	return l
+}
+
+func (p *GetExperimentIDsByGroupResponse) field2Length() int {
+	l := 0
+	if p.IsSetExperiments() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.ListBeginLength()
+		for _, v := range p.Experiments {
+			_ = v
+			l += v.BLength()
+		}
 	}
 	return l
 }
@@ -6468,6 +6426,21 @@ func (p *GetExperimentIDsByGroupResponse) DeepCopy(s interface{}) error {
 			var _elem int64
 			_elem = elem
 			p.ExptIds = append(p.ExptIds, _elem)
+		}
+	}
+
+	if src.Experiments != nil {
+		p.Experiments = make([]*expt.Experiment, 0, len(src.Experiments))
+		for _, elem := range src.Experiments {
+			var _elem *expt.Experiment
+			if elem != nil {
+				_elem = &expt.Experiment{}
+				if err := _elem.DeepCopy(elem); err != nil {
+					return err
+				}
+			}
+
+			p.Experiments = append(p.Experiments, _elem)
 		}
 	}
 
@@ -13123,6 +13096,34 @@ func (p *ItemStandardEvalOutput) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 16:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField16(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
+		case 17:
+			if fieldTypeId == thrift.I64 {
+				l, err = p.FastReadField17(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		case 30:
 			if fieldTypeId == thrift.STRUCT {
 				l, err = p.FastReadField30(buf[offset:])
@@ -13437,6 +13438,34 @@ func (p *ItemStandardEvalOutput) FastReadField15(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *ItemStandardEvalOutput) FastReadField16(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.ExperimentCreateTime = _field
+	return offset, nil
+}
+
+func (p *ItemStandardEvalOutput) FastReadField17(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *int64
+	if v, l, err := thrift.Binary.ReadI64(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.ItemEndTime = _field
+	return offset, nil
+}
+
 func (p *ItemStandardEvalOutput) FastReadField30(buf []byte) (int, error) {
 	offset := 0
 	_field := NewStandardEvalOutputContent()
@@ -13525,6 +13554,8 @@ func (p *ItemStandardEvalOutput) FastWriteNocopy(buf []byte, w thrift.NocopyWrit
 		offset += p.fastWriteField11(buf[offset:], w)
 		offset += p.fastWriteField12(buf[offset:], w)
 		offset += p.fastWriteField13(buf[offset:], w)
+		offset += p.fastWriteField16(buf[offset:], w)
+		offset += p.fastWriteField17(buf[offset:], w)
 		offset += p.fastWriteField3(buf[offset:], w)
 		offset += p.fastWriteField4(buf[offset:], w)
 		offset += p.fastWriteField5(buf[offset:], w)
@@ -13560,6 +13591,8 @@ func (p *ItemStandardEvalOutput) BLength() int {
 		l += p.field13Length()
 		l += p.field14Length()
 		l += p.field15Length()
+		l += p.field16Length()
+		l += p.field17Length()
 		l += p.field30Length()
 		l += p.field31Length()
 		l += p.field32Length()
@@ -13702,6 +13735,24 @@ func (p *ItemStandardEvalOutput) fastWriteField15(buf []byte, w thrift.NocopyWri
 	if p.IsSetExperimentGroupKey() {
 		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 15)
 		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.ExperimentGroupKey)
+	}
+	return offset
+}
+
+func (p *ItemStandardEvalOutput) fastWriteField16(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetExperimentCreateTime() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 16)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.ExperimentCreateTime)
+	}
+	return offset
+}
+
+func (p *ItemStandardEvalOutput) fastWriteField17(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetItemEndTime() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.I64, 17)
+		offset += thrift.Binary.WriteI64(buf[offset:], *p.ItemEndTime)
 	}
 	return offset
 }
@@ -13895,6 +13946,24 @@ func (p *ItemStandardEvalOutput) field15Length() int {
 	return l
 }
 
+func (p *ItemStandardEvalOutput) field16Length() int {
+	l := 0
+	if p.IsSetExperimentCreateTime() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
+func (p *ItemStandardEvalOutput) field17Length() int {
+	l := 0
+	if p.IsSetItemEndTime() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.I64Length()
+	}
+	return l
+}
+
 func (p *ItemStandardEvalOutput) field30Length() int {
 	l := 0
 	if p.IsSetDetail() {
@@ -14043,6 +14112,16 @@ func (p *ItemStandardEvalOutput) DeepCopy(s interface{}) error {
 			tmp = kutils.StringDeepCopy(*src.ExperimentGroupKey)
 		}
 		p.ExperimentGroupKey = &tmp
+	}
+
+	if src.ExperimentCreateTime != nil {
+		tmp := *src.ExperimentCreateTime
+		p.ExperimentCreateTime = &tmp
+	}
+
+	if src.ItemEndTime != nil {
+		tmp := *src.ItemEndTime
+		p.ItemEndTime = &tmp
 	}
 
 	var _detail *StandardEvalOutputContent

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/coze.loop.evaluation.openapi.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/coze.loop.evaluation.openapi.go
@@ -24894,10 +24894,8 @@ type SubmitExperimentOApiRequest struct {
 	// 通知配置
 	NotificationConf *experiment.ExptNotificationConf `thrift:"notification_conf,50,optional" frugal:"50,optional,experiment.ExptNotificationConf" form:"notification_conf" json:"notification_conf,omitempty"`
 	Ext              map[string]string                `thrift:"ext,100,optional" frugal:"100,optional,map<string:string>" form:"ext" json:"ext,omitempty"`
-	// 实验分组 key: 显式传入时服务端校验跨 space 隔离(不允许其它空间已占用该 key), 撞车拒绝创建; 缺省则以实验 ID 兜底。同一空间内允许多个实验共享同一 group key。
-	// 与内部 Submit 的 experiment_group_key 对齐, application 层直接指针透传给 CreateExperiment。
-	ExperimentGroupKey *string `thrift:"experiment_group_key,101,optional" frugal:"101,optional,string" json:"experiment_group_key" form:"experiment_group_key" `
-	// 引用分组实验 id: 填写时校验其为当前空间内的实验 id, 通过后本实验的 group key 复用该引用实验的 group key(归入同一分组); 优先级高于 experiment_group_key。
+	// 实验分组 key 默认以实验 ID 兜底；填写 ref_group_experiment_id 时复用该引用实验的 group key（归入同一分组）。
+	// 引用分组实验 id: 填写时校验其为当前空间内的实验 id。
 	RefGroupExperimentID *int64       `thrift:"ref_group_experiment_id,102,optional" frugal:"102,optional,i64" json:"ref_group_experiment_id" form:"ref_group_experiment_id" `
 	Extra                *extra.Extra `thrift:"extra,254,optional" frugal:"254,optional,extra.Extra" form:"extra" json:"extra,omitempty" query:"extra"`
 	Base                 *base.Base   `thrift:"Base,255,optional" frugal:"255,optional,base.Base" form:"Base" json:"Base,omitempty" query:"Base"`
@@ -25102,18 +25100,6 @@ func (p *SubmitExperimentOApiRequest) GetExt() (v map[string]string) {
 	return p.Ext
 }
 
-var SubmitExperimentOApiRequest_ExperimentGroupKey_DEFAULT string
-
-func (p *SubmitExperimentOApiRequest) GetExperimentGroupKey() (v string) {
-	if p == nil {
-		return
-	}
-	if !p.IsSetExperimentGroupKey() {
-		return SubmitExperimentOApiRequest_ExperimentGroupKey_DEFAULT
-	}
-	return *p.ExperimentGroupKey
-}
-
 var SubmitExperimentOApiRequest_RefGroupExperimentID_DEFAULT int64
 
 func (p *SubmitExperimentOApiRequest) GetRefGroupExperimentID() (v int64) {
@@ -25197,9 +25183,6 @@ func (p *SubmitExperimentOApiRequest) SetNotificationConf(val *experiment.ExptNo
 func (p *SubmitExperimentOApiRequest) SetExt(val map[string]string) {
 	p.Ext = val
 }
-func (p *SubmitExperimentOApiRequest) SetExperimentGroupKey(val *string) {
-	p.ExperimentGroupKey = val
-}
 func (p *SubmitExperimentOApiRequest) SetRefGroupExperimentID(val *int64) {
 	p.RefGroupExperimentID = val
 }
@@ -25227,7 +25210,6 @@ var fieldIDToName_SubmitExperimentOApiRequest = map[int16]string{
 	46:  "enable_extract_trajectory",
 	50:  "notification_conf",
 	100: "ext",
-	101: "experiment_group_key",
 	102: "ref_group_experiment_id",
 	254: "extra",
 	255: "Base",
@@ -25295,10 +25277,6 @@ func (p *SubmitExperimentOApiRequest) IsSetNotificationConf() bool {
 
 func (p *SubmitExperimentOApiRequest) IsSetExt() bool {
 	return p.Ext != nil
-}
-
-func (p *SubmitExperimentOApiRequest) IsSetExperimentGroupKey() bool {
-	return p.ExperimentGroupKey != nil
 }
 
 func (p *SubmitExperimentOApiRequest) IsSetRefGroupExperimentID() bool {
@@ -25454,14 +25432,6 @@ func (p *SubmitExperimentOApiRequest) Read(iprot thrift.TProtocol) (err error) {
 		case 100:
 			if fieldTypeId == thrift.MAP {
 				if err = p.ReadField100(iprot); err != nil {
-					goto ReadFieldError
-				}
-			} else if err = iprot.Skip(fieldTypeId); err != nil {
-				goto SkipFieldError
-			}
-		case 101:
-			if fieldTypeId == thrift.STRING {
-				if err = p.ReadField101(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -25735,17 +25705,6 @@ func (p *SubmitExperimentOApiRequest) ReadField100(iprot thrift.TProtocol) error
 	p.Ext = _field
 	return nil
 }
-func (p *SubmitExperimentOApiRequest) ReadField101(iprot thrift.TProtocol) error {
-
-	var _field *string
-	if v, err := iprot.ReadString(); err != nil {
-		return err
-	} else {
-		_field = &v
-	}
-	p.ExperimentGroupKey = _field
-	return nil
-}
 func (p *SubmitExperimentOApiRequest) ReadField102(iprot thrift.TProtocol) error {
 
 	var _field *int64
@@ -25842,10 +25801,6 @@ func (p *SubmitExperimentOApiRequest) Write(oprot thrift.TProtocol) (err error) 
 		}
 		if err = p.writeField100(oprot); err != nil {
 			fieldId = 100
-			goto WriteFieldError
-		}
-		if err = p.writeField101(oprot); err != nil {
-			fieldId = 101
 			goto WriteFieldError
 		}
 		if err = p.writeField102(oprot); err != nil {
@@ -26201,24 +26156,6 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 100 end error: ", p), err)
 }
-func (p *SubmitExperimentOApiRequest) writeField101(oprot thrift.TProtocol) (err error) {
-	if p.IsSetExperimentGroupKey() {
-		if err = oprot.WriteFieldBegin("experiment_group_key", thrift.STRING, 101); err != nil {
-			goto WriteFieldBeginError
-		}
-		if err := oprot.WriteString(*p.ExperimentGroupKey); err != nil {
-			return err
-		}
-		if err = oprot.WriteFieldEnd(); err != nil {
-			goto WriteFieldEndError
-		}
-	}
-	return nil
-WriteFieldBeginError:
-	return thrift.PrependError(fmt.Sprintf("%T write field 101 begin error: ", p), err)
-WriteFieldEndError:
-	return thrift.PrependError(fmt.Sprintf("%T write field 101 end error: ", p), err)
-}
 func (p *SubmitExperimentOApiRequest) writeField102(oprot thrift.TProtocol) (err error) {
 	if p.IsSetRefGroupExperimentID() {
 		if err = oprot.WriteFieldBegin("ref_group_experiment_id", thrift.I64, 102); err != nil {
@@ -26334,9 +26271,6 @@ func (p *SubmitExperimentOApiRequest) DeepEqual(ano *SubmitExperimentOApiRequest
 		return false
 	}
 	if !p.Field100DeepEqual(ano.Ext) {
-		return false
-	}
-	if !p.Field101DeepEqual(ano.ExperimentGroupKey) {
 		return false
 	}
 	if !p.Field102DeepEqual(ano.RefGroupExperimentID) {
@@ -26519,18 +26453,6 @@ func (p *SubmitExperimentOApiRequest) Field100DeepEqual(src map[string]string) b
 		if strings.Compare(v, _src) != 0 {
 			return false
 		}
-	}
-	return true
-}
-func (p *SubmitExperimentOApiRequest) Field101DeepEqual(src *string) bool {
-
-	if p.ExperimentGroupKey == src {
-		return true
-	} else if p.ExperimentGroupKey == nil || src == nil {
-		return false
-	}
-	if strings.Compare(*p.ExperimentGroupKey, *src) != 0 {
-		return false
 	}
 	return true
 }

--- a/backend/kitex_gen/coze/loop/evaluation/openapi/k-coze.loop.evaluation.openapi.go
+++ b/backend/kitex_gen/coze/loop/evaluation/openapi/k-coze.loop.evaluation.openapi.go
@@ -18111,20 +18111,6 @@ func (p *SubmitExperimentOApiRequest) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
-		case 101:
-			if fieldTypeId == thrift.STRING {
-				l, err = p.FastReadField101(buf[offset:])
-				offset += l
-				if err != nil {
-					goto ReadFieldError
-				}
-			} else {
-				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
-				offset += l
-				if err != nil {
-					goto SkipFieldError
-				}
-			}
 		case 102:
 			if fieldTypeId == thrift.I64 {
 				l, err = p.FastReadField102(buf[offset:])
@@ -18450,20 +18436,6 @@ func (p *SubmitExperimentOApiRequest) FastReadField100(buf []byte) (int, error) 
 	return offset, nil
 }
 
-func (p *SubmitExperimentOApiRequest) FastReadField101(buf []byte) (int, error) {
-	offset := 0
-
-	var _field *string
-	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
-		return offset, err
-	} else {
-		offset += l
-		_field = &v
-	}
-	p.ExperimentGroupKey = _field
-	return offset, nil
-}
-
 func (p *SubmitExperimentOApiRequest) FastReadField102(buf []byte) (int, error) {
 	offset := 0
 
@@ -18526,7 +18498,6 @@ func (p *SubmitExperimentOApiRequest) FastWriteNocopy(buf []byte, w thrift.Nocop
 		offset += p.fastWriteField22(buf[offset:], w)
 		offset += p.fastWriteField50(buf[offset:], w)
 		offset += p.fastWriteField100(buf[offset:], w)
-		offset += p.fastWriteField101(buf[offset:], w)
 		offset += p.fastWriteField254(buf[offset:], w)
 		offset += p.fastWriteField255(buf[offset:], w)
 	}
@@ -18553,7 +18524,6 @@ func (p *SubmitExperimentOApiRequest) BLength() int {
 		l += p.field46Length()
 		l += p.field50Length()
 		l += p.field100Length()
-		l += p.field101Length()
 		l += p.field102Length()
 		l += p.field254Length()
 		l += p.field255Length()
@@ -18731,15 +18701,6 @@ func (p *SubmitExperimentOApiRequest) fastWriteField100(buf []byte, w thrift.Noc
 			offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, v)
 		}
 		thrift.Binary.WriteMapBegin(buf[mapBeginOffset:], thrift.STRING, thrift.STRING, length)
-	}
-	return offset
-}
-
-func (p *SubmitExperimentOApiRequest) fastWriteField101(buf []byte, w thrift.NocopyWriter) int {
-	offset := 0
-	if p.IsSetExperimentGroupKey() {
-		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 101)
-		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.ExperimentGroupKey)
 	}
 	return offset
 }
@@ -18933,15 +18894,6 @@ func (p *SubmitExperimentOApiRequest) field100Length() int {
 	return l
 }
 
-func (p *SubmitExperimentOApiRequest) field101Length() int {
-	l := 0
-	if p.IsSetExperimentGroupKey() {
-		l += thrift.Binary.FieldBeginLength()
-		l += thrift.Binary.StringLengthNocopy(*p.ExperimentGroupKey)
-	}
-	return l
-}
-
 func (p *SubmitExperimentOApiRequest) field102Length() int {
 	l := 0
 	if p.IsSetRefGroupExperimentID() {
@@ -19121,14 +19073,6 @@ func (p *SubmitExperimentOApiRequest) DeepCopy(s interface{}) error {
 
 			p.Ext[_key] = _val
 		}
-	}
-
-	if src.ExperimentGroupKey != nil {
-		var tmp string
-		if *src.ExperimentGroupKey != "" {
-			tmp = kutils.StringDeepCopy(*src.ExperimentGroupKey)
-		}
-		p.ExperimentGroupKey = &tmp
 	}
 
 	if src.RefGroupExperimentID != nil {

--- a/backend/modules/evaluation/application/convertor/experiment/expt.go
+++ b/backend/modules/evaluation/application/convertor/experiment/expt.go
@@ -385,6 +385,9 @@ func ToExptDTO(experiment *entity.Experiment) *domain_expt.Experiment {
 	if experiment.EndAt != nil {
 		res.EndTime = gptr.Of(experiment.EndAt.Unix())
 	}
+	if experiment.CreatedAt != nil {
+		res.CreateTime = gptr.Of(experiment.CreatedAt.Unix())
+	}
 	if experiment.EvalConf != nil {
 		if experiment.EvalConf.ItemConcurNum != nil {
 			res.ItemConcurNum = gptr.Of(int32(gptr.Indirect(experiment.EvalConf.ItemConcurNum)))
@@ -837,7 +840,6 @@ func ConvertCreateReq(cer *expt.CreateExperimentRequest, evaluatorVersionRunConf
 		EvaluatorVersionIds:   cer.GetEvaluatorVersionIds(),
 		Name:                  cer.GetName(),
 		Desc:                  cer.GetDesc(),
-		ExperimentGroupKey:    strings.TrimSpace(cer.GetExperimentGroupKey()),
 		RefGroupExperimentID:  cer.GetRefGroupExperimentID(),
 		EvalSetID:             cer.GetEvalSetID(),
 		TargetID:              cer.TargetID,

--- a/backend/modules/evaluation/application/convertor/experiment/expt_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/expt_test.go
@@ -4,7 +4,9 @@
 package experiment
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/bytedance/gg/gptr"
 	"github.com/stretchr/testify/assert"
@@ -1842,6 +1844,30 @@ func TestToExptDTO_RuntimeParam(t *testing.T) {
 	}
 }
 
+func TestToExptDTO_CreateTime(t *testing.T) {
+	t.Parallel()
+
+	t.Run("created_at is converted to Unix seconds", func(t *testing.T) {
+		t.Parallel()
+		createdAt := time.Unix(1_725_555_555, 987_654_321)
+
+		result := ToExptDTO(&entity.Experiment{CreatedAt: &createdAt})
+
+		require.NotNil(t, result)
+		require.NotNil(t, result.CreateTime)
+		assert.Equal(t, createdAt.Unix(), *result.CreateTime)
+	})
+
+	t.Run("nil created_at leaves create_time unset", func(t *testing.T) {
+		t.Parallel()
+
+		result := ToExptDTO(&entity.Experiment{})
+
+		require.NotNil(t, result)
+		assert.Nil(t, result.CreateTime)
+	})
+}
+
 func TestConvertCreateReq(t *testing.T) {
 	tests := []struct {
 		name                       string
@@ -1949,6 +1975,22 @@ func TestConvertCreateReq(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ref group experiment id is passed without legacy group key", func(t *testing.T) {
+		const refGroupExperimentID int64 = 123456
+		_, hasLegacyRequestField := reflect.TypeOf(expt.CreateExperimentRequest{}).FieldByName("ExperimentGroupKey")
+		assert.False(t, hasLegacyRequestField, "experiment_group_key must stay removed from CreateExperimentRequest")
+
+		got, err := ConvertCreateReq(&expt.CreateExperimentRequest{
+			WorkspaceID:          1,
+			RefGroupExperimentID: gptr.Of(refGroupExperimentID),
+		}, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, refGroupExperimentID, got.RefGroupExperimentID)
+		assert.Empty(t, got.ExperimentGroupKey, "removed experiment_group_key must not enter CreateExptParam")
+	})
 }
 
 func TestBuildTemplateScoreWeightConfigDTO_FromTripleConfig(t *testing.T) {

--- a/backend/modules/evaluation/application/convertor/target/eval_target.go
+++ b/backend/modules/evaluation/application/convertor/target/eval_target.go
@@ -606,13 +606,14 @@ func SandboxAgentDTO2DO(dtoObj *dto.SandboxAgent) *do.SandboxAgent {
 		return nil
 	}
 	return &do.SandboxAgent{
-		Name:          gptr.Indirect(dtoObj.Name),
-		Type:          do.SandboxAgentType(gptr.Indirect(dtoObj.Type)),
-		ModelName:     gptr.Indirect(dtoObj.ModelName),
-		AgentSetupCmd: gptr.Indirect(dtoObj.AgentSetupCmd),
-		AgentRunCmd:   gptr.Indirect(dtoObj.AgentRunCmd),
-		Envs:          SandboxEnvVarsDTO2DO(dtoObj.Envs),
-		Image:         gptr.Indirect(dtoObj.Image),
+		Name:           gptr.Indirect(dtoObj.Name),
+		Type:           do.SandboxAgentType(gptr.Indirect(dtoObj.Type)),
+		ModelName:      gptr.Indirect(dtoObj.ModelName),
+		AgentSetupCmd:  gptr.Indirect(dtoObj.AgentSetupCmd),
+		AgentRunCmd:    gptr.Indirect(dtoObj.AgentRunCmd),
+		Envs:           SandboxEnvVarsDTO2DO(dtoObj.Envs),
+		Image:          gptr.Indirect(dtoObj.Image),
+		EnableAnalysis: gptr.Indirect(dtoObj.EnableAnalysis),
 	}
 }
 
@@ -621,13 +622,14 @@ func SandboxAgentDO2DTO(doObj *do.SandboxAgent) *dto.SandboxAgent {
 		return nil
 	}
 	return &dto.SandboxAgent{
-		Name:          gptr.Of(doObj.Name),
-		Type:          gptr.Of(dto.SandboxAgentType(doObj.Type)),
-		ModelName:     gptr.Of(doObj.ModelName),
-		AgentSetupCmd: gptr.Of(doObj.AgentSetupCmd),
-		AgentRunCmd:   gptr.Of(doObj.AgentRunCmd),
-		Envs:          SandboxEnvVarsDO2DTO(doObj.Envs),
-		Image:         gptr.Of(doObj.Image),
+		Name:           gptr.Of(doObj.Name),
+		Type:           gptr.Of(dto.SandboxAgentType(doObj.Type)),
+		ModelName:      gptr.Of(doObj.ModelName),
+		AgentSetupCmd:  gptr.Of(doObj.AgentSetupCmd),
+		AgentRunCmd:    gptr.Of(doObj.AgentRunCmd),
+		Envs:           SandboxEnvVarsDO2DTO(doObj.Envs),
+		Image:          gptr.Of(doObj.Image),
+		EnableAnalysis: gptr.Of(doObj.EnableAnalysis),
 	}
 }
 

--- a/backend/modules/evaluation/application/convertor/target/eval_target_test.go
+++ b/backend/modules/evaluation/application/convertor/target/eval_target_test.go
@@ -4,10 +4,12 @@
 package target
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/bytedance/gg/gptr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	commondto "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain/common"
 	dto "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain/eval_target"
@@ -1236,6 +1238,37 @@ func TestSandboxAgentDO2DTO(t *testing.T) {
 			assert.Nil(t, got.Envs)
 		}
 	})
+}
+
+func TestSandboxAgentEnableAnalysisRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, enableAnalysis := range []bool{true, false} {
+		enableAnalysis := enableAnalysis
+		t.Run(fmt.Sprintf("enable_analysis_%t", enableAnalysis), func(t *testing.T) {
+			t.Parallel()
+
+			dtoInput := &dto.SandboxAgent{EnableAnalysis: gptr.Of(enableAnalysis)}
+			doFromDTO := SandboxAgentDTO2DO(dtoInput)
+			require.NotNil(t, doFromDTO)
+			assert.Equal(t, enableAnalysis, doFromDTO.EnableAnalysis)
+
+			dtoRoundTrip := SandboxAgentDO2DTO(doFromDTO)
+			require.NotNil(t, dtoRoundTrip)
+			require.NotNil(t, dtoRoundTrip.EnableAnalysis)
+			assert.Equal(t, enableAnalysis, *dtoRoundTrip.EnableAnalysis)
+
+			doInput := &do.SandboxAgent{EnableAnalysis: enableAnalysis}
+			dtoFromDO := SandboxAgentDO2DTO(doInput)
+			require.NotNil(t, dtoFromDO)
+			require.NotNil(t, dtoFromDO.EnableAnalysis)
+			assert.Equal(t, enableAnalysis, *dtoFromDO.EnableAnalysis)
+
+			doRoundTrip := SandboxAgentDTO2DO(dtoFromDO)
+			require.NotNil(t, doRoundTrip)
+			assert.Equal(t, enableAnalysis, doRoundTrip.EnableAnalysis)
+		})
+	}
 }
 
 func TestSandboxEnvVarsDTO2DO(t *testing.T) {

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -1096,9 +1096,7 @@ func (e *EvalOpenAPIApplication) SubmitExperimentOApi(ctx context.Context, req *
 		Ext:                     req.GetExt(),
 		// ★ 透传分流依据: OpenAPI 字符串枚举 → kitex enum, 供下游平台层统一以 source_type 分流。
 		EvalSetSourceType: gptr.Of(srcType),
-		// ★ 透传实验分组 key: 与内部 Submit(experiment_app.go) 对齐, 下游 CreateExperiment 校验跨空间隔离。
-		ExperimentGroupKey: req.ExperimentGroupKey,
-		// ★ 透传引用分组实验 id: 命中当前空间实验则复用其 group key(归入同一分组), 优先级高于 experiment_group_key。
+		// ★ 透传引用分组实验 id: 命中当前空间实验则复用其 group key(归入同一分组); 缺省则以实验 id 兜底。
 		RefGroupExperimentID: req.RefGroupExperimentID,
 	}
 

--- a/backend/modules/evaluation/application/eval_openapi_app_test.go
+++ b/backend/modules/evaluation/application/eval_openapi_app_test.go
@@ -2053,10 +2053,10 @@ func TestEvalOpenAPIApplication_SubmitExperimentOApi(t *testing.T) {
 			},
 		},
 		{
-			name: "success with experiment group key",
+			name: "success with ref group experiment id",
 			buildReq: func() *openapi.SubmitExperimentOApiRequest {
 				req := buildBaseReq()
-				req.ExperimentGroupKey = gptr.Of("oapi-gk-transparent")
+				req.RefGroupExperimentID = gptr.Of(int64(6001))
 				return req
 			},
 			setup: func(req *openapi.SubmitExperimentOApiRequest, auth *rpcmocks.MockIAuthProvider, manager *servicemocks.MockIExptManager, versionSvc *servicemocks.MockEvaluationSetVersionService, evaluatorSvc *servicemocks.MockEvaluatorService, fakeApp *fakeExperimentApp) {
@@ -2169,8 +2169,8 @@ func TestEvalOpenAPIApplication_SubmitExperimentOApi(t *testing.T) {
 					assert.Equal(t, workspaceID, fakeApp.lastReq.GetWorkspaceID())
 					assert.Len(t, fakeApp.lastReq.EvaluatorVersionIds, 1)
 					assert.Equal(t, evaluatorVersionID, fakeApp.lastReq.EvaluatorVersionIds[0])
-					// experiment_group_key 透传: 显式传入时应原样透传给内部 SubmitExperimentRequest。
-					assert.Equal(t, req.ExperimentGroupKey, fakeApp.lastReq.ExperimentGroupKey)
+					// ref_group_experiment_id 透传: 显式传入时应原样透传给内部 SubmitExperimentRequest。
+					assert.Equal(t, req.RefGroupExperimentID, fakeApp.lastReq.RefGroupExperimentID)
 				}
 			}
 

--- a/backend/modules/evaluation/application/experiment_app.go
+++ b/backend/modules/evaluation/application/experiment_app.go
@@ -547,7 +547,6 @@ func (e *experimentApplication) SubmitExperiment(ctx context.Context, req *expt.
 		// 分流唯一以 eval_set_source_type 为准 (== MultiSetConfig 走新路径), configs 仅作权威源数据。
 		EvalSetConfigs:       req.EvalSetConfigs,
 		EvalSetSourceType:    req.EvalSetSourceType,
-		ExperimentGroupKey:   req.ExperimentGroupKey,
 		RefGroupExperimentID: req.RefGroupExperimentID,
 		NotificationConf:     req.NotificationConf,
 	}

--- a/backend/modules/evaluation/application/experiment_app.go
+++ b/backend/modules/evaluation/application/experiment_app.go
@@ -1078,9 +1078,21 @@ func (e *experimentApplication) GetExperimentIDsByGroup(ctx context.Context, req
 		return nil, err
 	}
 
+	// 反查实验基础信息（仅查 experiment 单表，不 join eval_set/target/evaluator，也不发用户 RPC），
+	// 携带 create_time 等基础字段返回；空列表跳过，避免无谓查询。
+	var exptDTOs []*domain_expt.Experiment
+	if len(exptIDs) > 0 {
+		expts, err := e.manager.MGetBasicByID(ctx, exptIDs)
+		if err != nil {
+			return nil, err
+		}
+		exptDTOs = experiment.ToExptDTOs(expts)
+	}
+
 	return &expt.GetExperimentIDsByGroupResponse{
-		ExptIds:  exptIDs,
-		BaseResp: base.NewBaseResp(),
+		ExptIds:     exptIDs,
+		Experiments: exptDTOs,
+		BaseResp:    base.NewBaseResp(),
 	}, nil
 }
 

--- a/backend/modules/evaluation/application/experiment_app_test.go
+++ b/backend/modules/evaluation/application/experiment_app_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/bytedance/gg/gptr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	repo_mocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/repo/mocks"
@@ -1619,6 +1620,216 @@ func TestExperimentApplication_BatchGetExperiments(t *testing.T) {
 				assert.Equal(t, wantExpt.GetBaseInfo().GetCreatedBy().GetUserID(),
 					gotExpt.GetBaseInfo().GetCreatedBy().GetUserID())
 			}
+		})
+	}
+}
+
+func TestExperimentApplication_GetExperimentIDsByGroup(t *testing.T) {
+	const (
+		workspaceID = int64(123)
+		groupKey    = "group-key"
+	)
+
+	authErr := errors.New("authorization failed")
+	getIDsErr := errors.New("get experiment ids failed")
+	mGetBasicErr := errors.New("mget basic experiments failed")
+	createdAt1 := time.Date(2026, time.July, 23, 10, 30, 0, 0, time.UTC)
+	createdAt2 := time.Date(2026, time.July, 23, 11, 45, 0, 0, time.UTC)
+	exptIDs := []int64{456, 457}
+	expts := []*entity.Experiment{
+		{
+			ID:                 exptIDs[0],
+			SpaceID:            workspaceID,
+			Name:               "experiment-1",
+			ExperimentGroupKey: groupKey,
+			CreatedBy:          "creator-1",
+			CreatedAt:          &createdAt1,
+		},
+		{
+			ID:                 exptIDs[1],
+			SpaceID:            workspaceID,
+			Name:               "experiment-2",
+			ExperimentGroupKey: groupKey,
+			CreatedBy:          "creator-2",
+			CreatedAt:          &createdAt2,
+		},
+	}
+
+	type testMocks struct {
+		manager  *servicemocks.MockIExptManager
+		auth     *rpcmocks.MockIAuthProvider
+		userInfo *userinfomocks.MockUserInfoService
+	}
+
+	expectAuthorization := func(t *testing.T, auth *rpcmocks.MockIAuthProvider, retErr error) {
+		auth.EXPECT().
+			Authorization(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, param *rpc.AuthorizationParam) error {
+				require.NotNil(t, param)
+				require.Equal(t, strconv.FormatInt(workspaceID, 10), param.ObjectID)
+				require.Equal(t, workspaceID, param.SpaceID)
+				require.Len(t, param.ActionObjects, 1)
+				require.NotNil(t, param.ActionObjects[0].Action)
+				require.Equal(t, consts.ActionReadExpt, *param.ActionObjects[0].Action)
+				require.NotNil(t, param.ActionObjects[0].EntityType)
+				require.Equal(t, rpc.AuthEntityType_Space, *param.ActionObjects[0].EntityType)
+				return retErr
+			})
+	}
+
+	tests := []struct {
+		name       string
+		groupKey   string
+		setupMocks func(t *testing.T, mocks testMocks)
+		check      func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error)
+	}{
+		{
+			name:     "authorization failed",
+			groupKey: groupKey,
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, authErr)
+				// No manager or user-info expectation: any call must fail the test.
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.ErrorIs(t, err, authErr)
+				require.Nil(t, resp)
+			},
+		},
+		{
+			name:     "empty group key returns empty response",
+			groupKey: "",
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, nil)
+				// No manager or user-info expectation: any call must fail the test.
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Empty(t, resp.GetExptIds())
+				require.Empty(t, resp.GetExperiments())
+				require.NotNil(t, resp.GetBaseResp())
+			},
+		},
+		{
+			name:     "blank group key returns empty response",
+			groupKey: " \t\n ",
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, nil)
+				// No manager or user-info expectation: any call must fail the test.
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Empty(t, resp.GetExptIds())
+				require.Empty(t, resp.GetExperiments())
+				require.NotNil(t, resp.GetBaseResp())
+			},
+		},
+		{
+			name:     "get ids by group key failed",
+			groupKey: groupKey,
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, nil)
+				mocks.manager.EXPECT().
+					GetIDsByGroupKey(gomock.Any(), workspaceID, groupKey, &entity.Session{}).
+					Return(nil, getIDsErr)
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.ErrorIs(t, err, getIDsErr)
+				require.Nil(t, resp)
+			},
+		},
+		{
+			name:     "empty ids skips mget basic",
+			groupKey: groupKey,
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, nil)
+				mocks.manager.EXPECT().
+					GetIDsByGroupKey(gomock.Any(), workspaceID, groupKey, &entity.Session{}).
+					Return([]int64{}, nil)
+				// No MGetBasicByID or user-info expectation: any call must fail the test.
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Empty(t, resp.GetExptIds())
+				require.Empty(t, resp.GetExperiments())
+				require.NotNil(t, resp.GetBaseResp())
+			},
+		},
+		{
+			name:     "success returns ids and basic experiments without user rpc",
+			groupKey: "  " + groupKey + "  ",
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, nil)
+				gomock.InOrder(
+					mocks.manager.EXPECT().
+						GetIDsByGroupKey(gomock.Any(), workspaceID, groupKey, &entity.Session{}).
+						Return(exptIDs, nil),
+					mocks.manager.EXPECT().
+						MGetBasicByID(gomock.Any(), exptIDs).
+						Return(expts, nil),
+				)
+				// No user-info expectation: PackUserInfo must not be called.
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, resp)
+				require.Equal(t, exptIDs, resp.GetExptIds())
+				require.Len(t, resp.GetExperiments(), len(expts))
+				require.NotNil(t, resp.GetBaseResp())
+
+				for i, got := range resp.GetExperiments() {
+					require.NotNil(t, got)
+					require.Equal(t, expts[i].ID, got.GetID())
+					require.Equal(t, expts[i].CreatedAt.Unix(), got.GetCreateTime())
+					require.Equal(t, expts[i].CreatedBy, got.GetCreatorBy())
+					require.Equal(t, expts[i].ExperimentGroupKey, got.GetExperimentGroupKey())
+				}
+			},
+		},
+		{
+			name:     "mget basic by id failed",
+			groupKey: groupKey,
+			setupMocks: func(t *testing.T, mocks testMocks) {
+				expectAuthorization(t, mocks.auth, nil)
+				gomock.InOrder(
+					mocks.manager.EXPECT().
+						GetIDsByGroupKey(gomock.Any(), workspaceID, groupKey, &entity.Session{}).
+						Return(exptIDs, nil),
+					mocks.manager.EXPECT().
+						MGetBasicByID(gomock.Any(), exptIDs).
+						Return(nil, mGetBasicErr),
+				)
+			},
+			check: func(t *testing.T, resp *exptpb.GetExperimentIDsByGroupResponse, err error) {
+				require.ErrorIs(t, err, mGetBasicErr)
+				require.Nil(t, resp)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mocks := testMocks{
+				manager:  servicemocks.NewMockIExptManager(ctrl),
+				auth:     rpcmocks.NewMockIAuthProvider(ctrl),
+				userInfo: userinfomocks.NewMockUserInfoService(ctrl),
+			}
+			tt.setupMocks(t, mocks)
+
+			app := &experimentApplication{
+				manager:         mocks.manager,
+				auth:            mocks.auth,
+				userInfoService: mocks.userInfo,
+			}
+			resp, err := app.GetExperimentIDsByGroup(context.Background(), &exptpb.GetExperimentIDsByGroupRequest{
+				WorkspaceID:        workspaceID,
+				ExperimentGroupKey: tt.groupKey,
+			})
+
+			tt.check(t, resp, err)
 		})
 	}
 }

--- a/backend/modules/evaluation/application/standard_eval_output.go
+++ b/backend/modules/evaluation/application/standard_eval_output.go
@@ -378,7 +378,9 @@ func newItemStandardEvalOutput(item *entity.ItemResult, opt standardEvalOutputBu
 		if item.SystemInfo != nil {
 			status := exptdomain.ItemRunState(item.SystemInfo.RunState)
 			res.Status = &status
-			if item.SystemInfo.EndTime != nil {
+			// ItemEndTime 来源 expt_item_result.updated_at，表示当前/latest run 终态同步到主结果表的时间，
+			// 不代表精确的执行结束时刻；非终态不输出。
+			if entity.IsItemRunFinished(item.SystemInfo.RunState) && item.SystemInfo.EndTime != nil {
 				res.ItemEndTime = gptr.Of(item.SystemInfo.EndTime.Unix())
 			}
 		}

--- a/backend/modules/evaluation/application/standard_eval_output.go
+++ b/backend/modules/evaluation/application/standard_eval_output.go
@@ -220,6 +220,9 @@ func (e *experimentApplication) resolveStandardEvalOutputMQMeta(ctx context.Cont
 		meta.EvalTargetWorkspaceID = expt.Target.SpaceID
 		meta.SourceTargetID = expt.Target.SourceTargetID
 	}
+	if expt.CreatedAt != nil {
+		meta.ExptCreateTime = expt.CreatedAt.Unix()
+	}
 	// 归属集详情：多评测集从 EvalSetDetails 收集，单评测集/老实验用主集 EvalSet。
 	// dataset_workspace_id 取任一集的 SpaceID（同空间场景与 expt.SpaceID 一致）。
 	for _, d := range expt.EvalSetDetails {
@@ -264,6 +267,8 @@ type standardEvalOutputMQMeta struct {
 	EvalTargetWorkspaceID int64
 	SourceTargetID        string
 	DatasetWorkspaceID    int64
+	// ExptCreateTime: 实验创建时间（秒），来源 experiment.created_at。
+	ExptCreateTime int64
 	// EvalSetByID: 归属集 id -> EvaluationSet（含 version），用于按 item 的 dataset_id 分流取版本信息。
 	EvalSetByID map[int64]*entity.EvaluationSet
 	// PrimaryEvalSetID: 主集 id（单评测集/老实验回退用）。
@@ -370,6 +375,9 @@ func newItemStandardEvalOutput(item *entity.ItemResult, opt standardEvalOutputBu
 		if item.SystemInfo != nil {
 			status := exptdomain.ItemRunState(item.SystemInfo.RunState)
 			res.Status = &status
+			if item.SystemInfo.EndTime != nil {
+				res.ItemEndTime = gptr.Of(item.SystemInfo.EndTime.Unix())
+			}
 		}
 	}
 	fillStandardEvalOutputMQMeta(res, item, opt)
@@ -398,6 +406,9 @@ func fillStandardEvalOutputMQMeta(res *expt.ItemStandardEvalOutput, item *entity
 		}
 		if meta.DatasetWorkspaceID != 0 {
 			res.DatasetWorkspaceID = gptr.Of(meta.DatasetWorkspaceID)
+		}
+		if meta.ExptCreateTime != 0 {
+			res.ExperimentCreateTime = gptr.Of(meta.ExptCreateTime)
 		}
 	}
 

--- a/backend/modules/evaluation/application/standard_eval_output.go
+++ b/backend/modules/evaluation/application/standard_eval_output.go
@@ -223,6 +223,7 @@ func (e *experimentApplication) resolveStandardEvalOutputMQMeta(ctx context.Cont
 	if expt.CreatedAt != nil {
 		meta.ExptCreateTime = expt.CreatedAt.Unix()
 	}
+	meta.ExptCreatedBy = expt.CreatedBy
 	// 归属集详情：多评测集从 EvalSetDetails 收集，单评测集/老实验用主集 EvalSet。
 	// dataset_workspace_id 取任一集的 SpaceID（同空间场景与 expt.SpaceID 一致）。
 	for _, d := range expt.EvalSetDetails {
@@ -269,6 +270,8 @@ type standardEvalOutputMQMeta struct {
 	DatasetWorkspaceID    int64
 	// ExptCreateTime: 实验创建时间（秒），来源 experiment.created_at。
 	ExptCreateTime int64
+	// ExptCreatedBy: 实验创建人 userID，来源 experiment.created_by（实验级恒定）。
+	ExptCreatedBy string
 	// EvalSetByID: 归属集 id -> EvaluationSet（含 version），用于按 item 的 dataset_id 分流取版本信息。
 	EvalSetByID map[int64]*entity.EvaluationSet
 	// PrimaryEvalSetID: 主集 id（单评测集/老实验回退用）。
@@ -409,6 +412,9 @@ func fillStandardEvalOutputMQMeta(res *expt.ItemStandardEvalOutput, item *entity
 		}
 		if meta.ExptCreateTime != 0 {
 			res.ExperimentCreateTime = gptr.Of(meta.ExptCreateTime)
+		}
+		if meta.ExptCreatedBy != "" {
+			res.CreatedBy = gptr.Of(meta.ExptCreatedBy)
 		}
 	}
 

--- a/backend/modules/evaluation/application/standard_eval_output_test.go
+++ b/backend/modules/evaluation/application/standard_eval_output_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/bytedance/gg/gptr"
 	"github.com/stretchr/testify/assert"
@@ -143,6 +144,41 @@ func TestBuildItemStandardEvalOutput_FailOnlyReturnsMetadata(t *testing.T) {
 	assert.Nil(t, got.Output)
 	assert.Nil(t, got.Eval)
 	assert.Nil(t, got.Extra)
+}
+
+func TestBuildItemStandardEvalOutput_ItemEndTime(t *testing.T) {
+	endTime := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name            string
+		runState        entity.ItemRunState
+		endTime         *time.Time
+		wantItemEndTime bool
+	}{
+		{name: "unknown does not fill", runState: entity.ItemRunState_Unknown, endTime: &endTime},
+		{name: "queueing does not fill", runState: entity.ItemRunState_Queueing, endTime: &endTime},
+		{name: "processing does not fill", runState: entity.ItemRunState_Processing, endTime: &endTime},
+		{name: "success fills", runState: entity.ItemRunState_Success, endTime: &endTime, wantItemEndTime: true},
+		{name: "fail fills", runState: entity.ItemRunState_Fail, endTime: &endTime, wantItemEndTime: true},
+		{name: "terminal fills", runState: entity.ItemRunState_Terminal, endTime: &endTime, wantItemEndTime: true},
+		{name: "nil end time does not fill", runState: entity.ItemRunState_Success},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := makeStandardEvalOutputReportResult(20, 30, 10, 1, 100).ItemResults[0]
+			item.SystemInfo.RunState = tt.runState
+			item.SystemInfo.EndTime = tt.endTime
+
+			got, err := buildItemStandardEvalOutput(item, standardEvalOutputBuildOptions{ExptID: 20})
+			require.NoError(t, err)
+			if !tt.wantItemEndTime {
+				assert.Nil(t, got.ItemEndTime)
+				return
+			}
+			require.NotNil(t, got.ItemEndTime)
+			assert.Equal(t, endTime.Unix(), got.GetItemEndTime())
+		})
+	}
 }
 
 func TestExperimentApplication_MGetExperimentStandardEvalOutputs_ItemIDsLimit(t *testing.T) {

--- a/backend/modules/evaluation/application/standard_eval_output_test.go
+++ b/backend/modules/evaluation/application/standard_eval_output_test.go
@@ -23,6 +23,12 @@ import (
 	"github.com/coze-dev/coze-loop/backend/pkg/json"
 )
 
+const (
+	standardEvalOutputExptCreateUnix = int64(1_700_000_000)
+	standardEvalOutputItemEndUnix    = int64(1_700_000_100)
+	standardEvalOutputCreatedBy      = "creator-1"
+)
+
 func TestExperimentApplication_MGetExperimentStandardEvalOutputs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -110,6 +116,9 @@ func TestExperimentApplication_MGetExperimentStandardEvalOutputs(t *testing.T) {
 	assert.Equal(t, workspaceID, got.GetDatasetWorkspaceID())
 	assert.Equal(t, int64(1001), got.GetDatasetVersionID())
 	assert.Equal(t, "1.2.0", got.GetDatasetVersionName())
+	assert.Equal(t, standardEvalOutputExptCreateUnix, got.GetExperimentCreateTime())
+	assert.Equal(t, standardEvalOutputCreatedBy, got.GetCreatedBy())
+	assert.Equal(t, standardEvalOutputItemEndUnix, got.GetItemEndTime())
 }
 
 func TestBuildItemStandardEvalOutput_ProcessingOnlyReturnsMetadata(t *testing.T) {
@@ -223,6 +232,33 @@ func TestExperimentApplication_MGetExperimentStandardEvalOutputs_Auth(t *testing
 	require.Len(t, resp.Items, 1)
 }
 
+func TestExperimentApplication_MGetExperimentStandardEvalOutputs_ProcessingOmitsItemEndTime(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockAuth := rpcmocks.NewMockIAuthProvider(ctrl)
+	mockAuth.EXPECT().Authorization(gomock.Any(), gomock.Any()).Return(nil)
+	mockResultSvc := servicemocks.NewMockExptResultService(ctrl)
+	result := makeStandardEvalOutputReportResult(2, 3, 4, 5, 6)
+	result.ItemResults[0].SystemInfo.RunState = entity.ItemRunState_Processing
+	mockResultSvc.EXPECT().MGetExperimentResult(gomock.Any(), gomock.Any()).Return(result, nil)
+	mockTargetSvc := servicemocks.NewMockIEvalTargetService(ctrl)
+	mockTargetSvc.EXPECT().GetEvalTarget(gomock.Any(), int64(200)).Return(&entity.EvalTarget{ID: 200, SpaceID: 1, SourceTargetID: "src-200"}, nil)
+	mockManager := servicemocks.NewMockIExptManager(ctrl)
+	mockManager.EXPECT().GetDetail(gomock.Any(), int64(2), int64(1), gomock.Any()).Return(makeStandardEvalOutputExpt(2, 1), nil)
+	app := &experimentApplication{auth: mockAuth, resultSvc: mockResultSvc, evalTargetService: mockTargetSvc, manager: mockManager}
+
+	resp, err := app.MGetExperimentStandardEvalOutputs(context.Background(), &exptpb.MGetExperimentStandardEvalOutputsRequest{
+		WorkspaceID: 1,
+		ExptID:      2,
+		ItemIds:     []int64{4},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, exptdomain.ItemRunState_Processing, resp.Items[0].GetStatus())
+	assert.Nil(t, resp.Items[0].ItemEndTime)
+}
+
 func TestExperimentApplication_ListExperimentStandardEvalOutputs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -260,6 +296,10 @@ func TestExperimentApplication_ListExperimentStandardEvalOutputs(t *testing.T) {
 	require.Len(t, resp.Items, 1)
 	require.NotNil(t, resp.Total)
 	assert.Equal(t, int64(1), *resp.Total)
+	got := resp.Items[0]
+	assert.Equal(t, standardEvalOutputExptCreateUnix, got.GetExperimentCreateTime())
+	assert.Equal(t, standardEvalOutputCreatedBy, got.GetCreatedBy())
+	assert.Equal(t, standardEvalOutputItemEndUnix, got.GetItemEndTime())
 }
 
 func TestExperimentApplication_ListExperimentStandardEvalOutputs_OnlyItemIDs(t *testing.T) {
@@ -317,6 +357,7 @@ func makeStandardEvalOutputReportResult(exptID, exptRunID, itemID, turnID, targe
 	score := 0.8
 	latency := int64(123)
 	turnIndex := int64(0)
+	itemEndTime := time.Unix(standardEvalOutputItemEndUnix, 0)
 	return &entity.MGetExperimentReportResult{
 		Total: 1,
 		ItemResults: []*entity.ItemResult{{
@@ -325,6 +366,7 @@ func makeStandardEvalOutputReportResult(exptID, exptRunID, itemID, turnID, targe
 			Ext:       map[string]string{"dataset_key": "dataset-1", "item_key": "case-1"},
 			SystemInfo: &entity.ItemSystemInfo{
 				RunState: entity.ItemRunState_Success,
+				EndTime:  &itemEndTime,
 			},
 			TurnResults: []*entity.TurnResult{{
 				TurnID:    turnID,
@@ -384,9 +426,12 @@ func makeStandardEvalOutputReportResult(exptID, exptRunID, itemID, turnID, targe
 // makeStandardEvalOutputExpt 构造标准输出 MQ 元信息测试用的实验详情，
 // 主评测集 id=100（与 makeStandardEvalOutputReportResult 的 payload EvalSetID 对齐），target id=200。
 func makeStandardEvalOutputExpt(exptID, spaceID int64) *entity.Experiment {
+	createdAt := time.Unix(standardEvalOutputExptCreateUnix, 0)
 	return &entity.Experiment{
 		ID:                 exptID,
 		SpaceID:            spaceID,
+		CreatedBy:          standardEvalOutputCreatedBy,
+		CreatedAt:          &createdAt,
 		LatestRunID:        3,
 		ExperimentGroupKey: "group-key-1",
 		TargetID:           200,

--- a/backend/modules/evaluation/domain/component/item_complete_publisher.go
+++ b/backend/modules/evaluation/domain/component/item_complete_publisher.go
@@ -25,6 +25,8 @@ type ItemCompleteEvent struct {
 	// EnableAnalysis 评测对象是否开启分析，来源 eval_target 的 SandboxAgent.EnableAnalysis。
 	// 商业化侧 producer 据此与 TCC 空间白名单 AND，决定是否发送本事件。
 	EnableAnalysis bool `json:"enable_analysis"`
+	// CreatedBy 实验创建人 userID，来源 experiment.created_by（实验级恒定）。
+	CreatedBy string `json:"created_by"`
 }
 
 type IItemCompletePublisher interface {

--- a/backend/modules/evaluation/domain/component/item_complete_publisher.go
+++ b/backend/modules/evaluation/domain/component/item_complete_publisher.go
@@ -22,6 +22,9 @@ type ItemCompleteEvent struct {
 	ExperimentGroupKey    string `json:"experiment_group_key"`     // 实验组 Key（关联同组实验），默认为实验 ID，空间内唯一
 	ItemID                string `json:"item_id"`                  // 数据集某一行的 ID
 	ItemKey               string `json:"item_key"`                 // 评测集 item 的实体 ItemKey（下游 data 服务写入）；直接透传，为空则空、不降级
+	// EnableAnalysis 评测对象是否开启分析，来源 eval_target 的 SandboxAgent.EnableAnalysis。
+	// 商业化侧 producer 据此与 TCC 空间白名单 AND，决定是否发送本事件。
+	EnableAnalysis bool `json:"enable_analysis"`
 }
 
 type IItemCompletePublisher interface {

--- a/backend/modules/evaluation/domain/entity/expt.go
+++ b/backend/modules/evaluation/domain/entity/expt.go
@@ -185,8 +185,10 @@ type Experiment struct {
 
 	CreditCost CreditCost
 
-	StartAt *time.Time
-	EndAt   *time.Time
+	// CreatedAt 实验创建时间，来源 experiment.created_at 列（DB 非空，PO2DO 透传）。
+	CreatedAt *time.Time
+	StartAt   *time.Time
+	EndAt     *time.Time
 
 	ExptType     ExptType
 	MaxAliveTime int64

--- a/backend/modules/evaluation/domain/entity/expt_result.go
+++ b/backend/modules/evaluation/domain/entity/expt_result.go
@@ -233,6 +233,8 @@ type ExptItemResult struct {
 	ItemIdx       int32
 	LogID         string
 	Ext           map[string]string
+	// UpdatedAt item 结果最后更新时间，来源 expt_item_result.updated_at；item 到终态时即执行结束时间。
+	UpdatedAt *time.Time
 }
 
 type ExptItemResultRunLog struct {
@@ -790,6 +792,8 @@ type ItemSystemInfo struct {
 	RunState ItemRunState
 	LogID    *string
 	Error    *RunError
+	// EndTime item 执行结束时间，来源 expt_item_result.updated_at（item 到终态时最后一次更新）。
+	EndTime *time.Time
 }
 
 type RunError struct {

--- a/backend/modules/evaluation/domain/entity/target_builtin_sandbox_agent.go
+++ b/backend/modules/evaluation/domain/entity/target_builtin_sandbox_agent.go
@@ -24,4 +24,7 @@ type SandboxAgent struct {
 	Image         string           `json:"image"`
 	// 自定义输出结果，与 CustomRPCServer.CustomFieldSchemas 对齐
 	CustomFieldSchemas []*CustomFieldSchema `json:"custom_field_schemas,omitempty"`
+	// EnableAnalysis 是否开启分析：创建评测对象时从 application.usages（含 "analysis"）反查固化，
+	// 控制 item-complete MQ 是否发送（与 TCC 空间白名单 AND）。
+	EnableAnalysis bool `json:"enable_analysis,omitempty"`
 }

--- a/backend/modules/evaluation/domain/service/expt_manage.go
+++ b/backend/modules/evaluation/domain/service/expt_manage.go
@@ -39,6 +39,9 @@ type IExptConfigManager interface {
 	Get(ctx context.Context, exptID, spaceID int64, session *entity.Session) (*entity.Experiment, error)
 	MGet(ctx context.Context, exptIDs []int64, spaceID int64, session *entity.Session) ([]*entity.Experiment, error)
 	GetIDsByGroupKey(ctx context.Context, spaceID int64, groupKey string, session *entity.Session) ([]int64, error)
+	// MGetBasicByID 仅查 experiment 单表（不 join eval_set/target/evaluator 等），返回基础字段。
+	// 用于只需实验基础信息（如 create_time）、无需完整详情的场景，避免 MGetDetail 的多表查询与用户 RPC。
+	MGetBasicByID(ctx context.Context, exptIDs []int64) ([]*entity.Experiment, error)
 
 	Clone(ctx context.Context, exptID, spaceID int64, session *entity.Session) (*entity.Experiment, error)
 

--- a/backend/modules/evaluation/domain/service/expt_manage_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_manage_impl.go
@@ -1033,28 +1033,16 @@ func (e *ExptMangerImpl) CreateExpt(ctx context.Context, req *entity.CreateExptP
 	if triggerType == "" {
 		triggerType = "manual"
 	}
-	experimentGroupKey := strings.TrimSpace(req.ExperimentGroupKey)
+	// 实验分组 key：默认用新实验 ID；填写 ref_group_experiment_id 时复用被引用实验的 group key（归入同一分组）。
+	experimentGroupKey := strconv.FormatInt(ids[0], 10)
 	if req.RefGroupExperimentID > 0 {
-		// 引用某实验分组: 校验引用 id 是「当前空间」内的实验, 通过后复用其 group key(归入同一分组, 无需跨空间校验)。
-		// 优先级高于 experiment_group_key: 命中 ref 时忽略用户显式传入的 group key。
+		// 引用某实验分组：校验引用 id 是「当前空间」内的实验，通过后复用其 group key（归入同一分组）。
 		refExpt, err := e.exptRepo.GetByID(ctx, req.RefGroupExperimentID, req.WorkspaceID)
-		if err != nil || refExpt == nil {
+		if err != nil || refExpt == nil || refExpt.SpaceID != req.WorkspaceID {
 			return nil, errorx.NewByCode(errno.RefGroupExperimentInvalidCode,
 				errorx.WithExtraMsg(fmt.Sprintf("ref_group_experiment_id %d", req.RefGroupExperimentID)))
 		}
 		experimentGroupKey = refExpt.ExperimentGroupKey
-	} else if experimentGroupKey == "" {
-		// 未显式传入: 默认用新实验 ID 作为 group key, 天然不会与其它空间冲突, 无需校验。
-		experimentGroupKey = strconv.FormatInt(ids[0], 10)
-	} else {
-		// 显式传入: 校验跨空间隔离(不允许其它空间已占用该 key); 同空间内允许多实验共享。撞车拒绝创建。
-		pass, err := e.CheckGroupKey(ctx, experimentGroupKey, req.WorkspaceID, session)
-		if err != nil {
-			return nil, err
-		}
-		if !pass {
-			return nil, errorx.NewByCode(errno.ExperimentGroupKeyExistedCode, errorx.WithExtraMsg(fmt.Sprintf("group_key %s", experimentGroupKey)))
-		}
 	}
 	do := &entity.Experiment{
 		ID:                  ids[0],

--- a/backend/modules/evaluation/domain/service/expt_manage_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_manage_impl.go
@@ -1233,6 +1233,14 @@ func (e *ExptMangerImpl) GetIDsByGroupKey(ctx context.Context, spaceID int64, gr
 	return e.exptRepo.GetIDsByGroupKey(ctx, spaceID, groupKey)
 }
 
+// MGetBasicByID 仅查 experiment 单表（PO2DO 传 nil refs，不 join eval_set/target/evaluator），返回基础字段。
+func (e *ExptMangerImpl) MGetBasicByID(ctx context.Context, exptIDs []int64) ([]*entity.Experiment, error) {
+	if len(exptIDs) == 0 {
+		return nil, nil
+	}
+	return e.exptRepo.MGetBasicByID(ctx, exptIDs)
+}
+
 func (e *ExptMangerImpl) List(ctx context.Context, page, pageSize int32, spaceID int64, filter *entity.ExptListFilter, orderBys []*entity.OrderBy, session *entity.Session) ([]*entity.Experiment, int64, error) {
 	expts, count, err := e.exptRepo.List(ctx, page, pageSize, filter, orderBys, spaceID)
 	if err != nil {

--- a/backend/modules/evaluation/domain/service/expt_manage_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_manage_impl_test.go
@@ -34,6 +34,8 @@ import (
 	eventsMocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/events/mocks"
 	repoMocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/repo/mocks"
 	svcMocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/service/mocks"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/pkg/errno"
+	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -352,6 +354,106 @@ func TestExptMangerImpl_CreateExpt(t *testing.T) {
 				t.Errorf("CreateExpt() EnableScoreWeight should be false when ScoreWeight is nil")
 			}
 		}
+	})
+
+	// group_key 分组逻辑（移除 group_key 入参后）:
+	//  - 无 ref: group key 回落为新实验 ID 字符串（GenMultiIDs 返回 [1,2] -> "1"）。
+	//  - 有合法 ref（同空间）: 继承 ref 的 group key。
+	//  - 跨空间 ref: 报 601204019 (RefGroupExperimentInvalidCode)。
+	t.Run("无ref时group_key回落为实验ID", func(t *testing.T) {
+		p := &entity.CreateExptParam{
+			WorkspaceID:         1,
+			Name:                "expt_group_no_ref",
+			EvalSetID:           2,
+			EvalSetVersionID:    3,
+			EvaluatorVersionIds: []int64{10},
+		}
+		expt, err := mgr.CreateExpt(ctx, p, session)
+		if err == nil && expt != nil {
+			assert.Equal(t, "1", expt.ExperimentGroupKey)
+		}
+	})
+
+	t.Run("合法ref继承group_key", func(t *testing.T) {
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			GetByID(ctx, int64(777), int64(1)).
+			Return(&entity.Experiment{ID: 777, SpaceID: 1, ExperimentGroupKey: "grp-777"}, nil).AnyTimes()
+		p := &entity.CreateExptParam{
+			WorkspaceID:          1,
+			Name:                 "expt_group_valid_ref",
+			EvalSetID:            2,
+			EvalSetVersionID:     3,
+			EvaluatorVersionIds:  []int64{10},
+			RefGroupExperimentID: 777,
+		}
+		expt, err := mgr.CreateExpt(ctx, p, session)
+		if err == nil && expt != nil {
+			assert.Equal(t, "grp-777", expt.ExperimentGroupKey)
+		}
+	})
+
+	t.Run("跨空间ref报601204019", func(t *testing.T) {
+		// ref 实验落在 space 2, 与请求 workspace 1 不一致 -> 越权拒绝。
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			GetByID(ctx, int64(888), int64(1)).
+			Return(&entity.Experiment{ID: 888, SpaceID: 2, ExperimentGroupKey: "grp-888"}, nil).AnyTimes()
+		p := &entity.CreateExptParam{
+			WorkspaceID:          1,
+			Name:                 "expt_group_cross_space_ref",
+			EvalSetID:            2,
+			EvalSetVersionID:     3,
+			EvaluatorVersionIds:  []int64{10},
+			RefGroupExperimentID: 888,
+		}
+		_, err := mgr.CreateExpt(ctx, p, session)
+		// 跨空间 ref 必然报错。注：本测试套的 tuple mock 未完整覆盖 target/evalset 访问校验，
+		// CreateExpt 可能在到达 ref 守卫（expt_manage_impl.go:1038）前先因访问校验 601200101 返回；
+		// 故这里断言"报错"，并在确实走到 ref 守卫时校验精确错误码为 601204019（越权拒绝）。
+		require.Error(t, err)
+		if statusErr, ok := errorx.FromStatusError(err); ok && statusErr.Code() == int32(errno.RefGroupExperimentInvalidCode) {
+			assert.Equal(t, int32(errno.RefGroupExperimentInvalidCode), statusErr.Code())
+		}
+	})
+}
+
+func TestExptMangerImpl_MGetBasicByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mgr := newTestExptManager(ctrl)
+	ctx := context.Background()
+
+	t.Run("空入参直接返回nil不查库", func(t *testing.T) {
+		// 空 exptIDs 时不应调用 exptRepo.MGetBasicByID（gomock 无 EXPECT 即验证零调用）。
+		got, err := mgr.MGetBasicByID(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+
+		got, err = mgr.MGetBasicByID(ctx, []int64{})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("正常多id透传repo", func(t *testing.T) {
+		want := []*entity.Experiment{{ID: 1, CreatedBy: "u1"}, {ID: 2, CreatedBy: "u2"}}
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			MGetBasicByID(ctx, []int64{1, 2}).
+			Return(want, nil)
+		got, err := mgr.MGetBasicByID(ctx, []int64{1, 2})
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("repo错误透传", func(t *testing.T) {
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			MGetBasicByID(ctx, []int64{9}).
+			Return(nil, errors.New("dao error"))
+		got, err := mgr.MGetBasicByID(ctx, []int64{9})
+		require.Error(t, err)
+		assert.Nil(t, got)
 	})
 }
 

--- a/backend/modules/evaluation/domain/service/expt_manage_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_manage_impl_test.go
@@ -355,66 +355,149 @@ func TestExptMangerImpl_CreateExpt(t *testing.T) {
 			}
 		}
 	})
+}
 
-	// group_key 分组逻辑（移除 group_key 入参后）:
-	//  - 无 ref: group key 回落为新实验 ID 字符串（GenMultiIDs 返回 [1,2] -> "1"）。
-	//  - 有合法 ref（同空间）: 继承 ref 的 group key。
-	//  - 跨空间 ref: 报 601204019 (RefGroupExperimentInvalidCode)。
-	t.Run("无ref时group_key回落为实验ID", func(t *testing.T) {
-		p := &entity.CreateExptParam{
-			WorkspaceID:         1,
-			Name:                "expt_group_no_ref",
-			EvalSetID:           2,
-			EvalSetVersionID:    3,
-			EvaluatorVersionIds: []int64{10},
-		}
-		expt, err := mgr.CreateExpt(ctx, p, session)
-		if err == nil && expt != nil {
-			assert.Equal(t, "1", expt.ExperimentGroupKey)
-		}
-	})
+func TestExptMangerImpl_CreateExpt_GroupKey(t *testing.T) {
+	const (
+		workspaceID   int64 = 1
+		evalSetID     int64 = 2
+		evalSetVerID  int64 = 3
+		newExptID     int64 = 101
+		newExptStatID int64 = 102
+		refExptID     int64 = 777
+	)
 
-	t.Run("合法ref继承group_key", func(t *testing.T) {
-		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+	setup := func(t *testing.T, expectCreate bool) (*ExptMangerImpl, context.Context, *entity.Session, *entity.CreateExptParam) {
+		t.Helper()
+
+		ctrl := gomock.NewController(t)
+		mgr := newTestExptManager(ctrl)
+		ctx := context.Background()
+		session := &entity.Session{UserID: "creator"}
+		param := &entity.CreateExptParam{
+			WorkspaceID:      workspaceID,
+			Name:             "group_key_test",
+			EvalSetID:        evalSetID,
+			EvalSetVersionID: evalSetVerID,
+			ExptType:         entity.ExptType_Online,
+			ExptConf:         &entity.EvaluationConfiguration{},
+		}
+
+		version := &entity.EvaluationSetVersion{ID: evalSetVerID}
+		mgr.evaluationSetVersionService.(*svcMocks.MockEvaluationSetVersionService).
 			EXPECT().
-			GetByID(ctx, int64(777), int64(1)).
-			Return(&entity.Experiment{ID: 777, SpaceID: 1, ExperimentGroupKey: "grp-777"}, nil).AnyTimes()
-		p := &entity.CreateExptParam{
-			WorkspaceID:          1,
-			Name:                 "expt_group_valid_ref",
-			EvalSetID:            2,
-			EvalSetVersionID:     3,
-			EvaluatorVersionIds:  []int64{10},
-			RefGroupExperimentID: 777,
-		}
-		expt, err := mgr.CreateExpt(ctx, p, session)
-		if err == nil && expt != nil {
-			assert.Equal(t, "grp-777", expt.ExperimentGroupKey)
-		}
-	})
-
-	t.Run("跨空间ref报601204019", func(t *testing.T) {
-		// ref 实验落在 space 2, 与请求 workspace 1 不一致 -> 越权拒绝。
-		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			GetEvaluationSetVersion(ctx, workspaceID, evalSetVerID, gptr.Of(true)).
+			Return(version, &entity.EvaluationSet{ID: evalSetID, SpaceID: workspaceID}, nil)
+		mgr.idgenerator.(*idgenMocks.MockIIDGenerator).
 			EXPECT().
-			GetByID(ctx, int64(888), int64(1)).
-			Return(&entity.Experiment{ID: 888, SpaceID: 2, ExperimentGroupKey: "grp-888"}, nil).AnyTimes()
-		p := &entity.CreateExptParam{
-			WorkspaceID:          1,
-			Name:                 "expt_group_cross_space_ref",
-			EvalSetID:            2,
-			EvalSetVersionID:     3,
-			EvaluatorVersionIds:  []int64{10},
-			RefGroupExperimentID: 888,
+			GenMultiIDs(ctx, 2).
+			Return([]int64{newExptID, newExptStatID}, nil)
+
+		if expectCreate {
+			mgr.audit.(*auditMocks.MockIAuditService).
+				EXPECT().
+				Audit(ctx, gomock.Any()).
+				Return(audit.AuditRecord{AuditStatus: audit.AuditStatus_Approved}, nil)
+			mgr.exptResultService.(*svcMocks.MockExptResultService).
+				EXPECT().
+				CreateStats(ctx, gomock.Any(), session).
+				Return(nil)
+			mgr.exptResultService.(*svcMocks.MockExptResultService).
+				EXPECT().
+				InsertExptTurnResultFilterKeyMappings(ctx, gomock.Any()).
+				Return(nil)
+			mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+				EXPECT().
+				GetByName(ctx, param.Name, workspaceID).
+				Return(nil, false, nil)
+			mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+				EXPECT().
+				Create(ctx, gomock.Any(), gomock.Any()).
+				Return(nil)
+			mgr.lwt.(*lwtMocks.MockILatestWriteTracker).
+				EXPECT().
+				SetWriteFlag(ctx, platestwrite.ResourceTypeExperiment, newExptID)
 		}
-		_, err := mgr.CreateExpt(ctx, p, session)
-		// 跨空间 ref 必然报错。注：本测试套的 tuple mock 未完整覆盖 target/evalset 访问校验，
-		// CreateExpt 可能在到达 ref 守卫（expt_manage_impl.go:1038）前先因访问校验 601200101 返回；
-		// 故这里断言"报错"，并在确实走到 ref 守卫时校验精确错误码为 601204019（越权拒绝）。
+
+		return mgr, ctx, session, param
+	}
+
+	requireRefGroupError := func(t *testing.T, err error) {
+		t.Helper()
 		require.Error(t, err)
-		if statusErr, ok := errorx.FromStatusError(err); ok && statusErr.Code() == int32(errno.RefGroupExperimentInvalidCode) {
-			assert.Equal(t, int32(errno.RefGroupExperimentInvalidCode), statusErr.Code())
-		}
+		statusErr, ok := errorx.FromStatusError(err)
+		require.True(t, ok, "expected status error, got %T: %v", err, err)
+		require.Equal(t, int32(errno.RefGroupExperimentInvalidCode), statusErr.Code())
+	}
+
+	t.Run("no ref defaults group key to new experiment ID", func(t *testing.T) {
+		mgr, ctx, session, param := setup(t, true)
+
+		expt, err := mgr.CreateExpt(ctx, param, session)
+		require.NoError(t, err)
+		require.NotNil(t, expt)
+		require.Equal(t, "101", expt.ExperimentGroupKey)
+	})
+
+	t.Run("same-space ref inherits group key", func(t *testing.T) {
+		mgr, ctx, session, param := setup(t, true)
+		param.RefGroupExperimentID = refExptID
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			GetByID(ctx, refExptID, workspaceID).
+			Return(&entity.Experiment{
+				ID:                 refExptID,
+				SpaceID:            workspaceID,
+				ExperimentGroupKey: "inherited-group",
+			}, nil)
+
+		expt, err := mgr.CreateExpt(ctx, param, session)
+		require.NoError(t, err)
+		require.NotNil(t, expt)
+		require.Equal(t, "inherited-group", expt.ExperimentGroupKey)
+	})
+
+	t.Run("ref lookup error returns exact invalid-ref code", func(t *testing.T) {
+		mgr, ctx, session, param := setup(t, false)
+		param.RefGroupExperimentID = refExptID
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			GetByID(ctx, refExptID, workspaceID).
+			Return(nil, errors.New("repo error"))
+
+		expt, err := mgr.CreateExpt(ctx, param, session)
+		require.Nil(t, expt)
+		requireRefGroupError(t, err)
+	})
+
+	t.Run("nil ref returns exact invalid-ref code", func(t *testing.T) {
+		mgr, ctx, session, param := setup(t, false)
+		param.RefGroupExperimentID = refExptID
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			GetByID(ctx, refExptID, workspaceID).
+			Return(nil, nil)
+
+		expt, err := mgr.CreateExpt(ctx, param, session)
+		require.Nil(t, expt)
+		requireRefGroupError(t, err)
+	})
+
+	t.Run("cross-space ref returns exact invalid-ref code", func(t *testing.T) {
+		mgr, ctx, session, param := setup(t, false)
+		param.RefGroupExperimentID = refExptID
+		mgr.exptRepo.(*repoMocks.MockIExperimentRepo).
+			EXPECT().
+			GetByID(ctx, refExptID, workspaceID).
+			Return(&entity.Experiment{
+				ID:                 refExptID,
+				SpaceID:            workspaceID + 1,
+				ExperimentGroupKey: "other-space-group",
+			}, nil)
+
+		expt, err := mgr.CreateExpt(ctx, param, session)
+		require.Nil(t, expt)
+		requireRefGroupError(t, err)
 	})
 }
 

--- a/backend/modules/evaluation/domain/service/expt_result_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl.go
@@ -1318,10 +1318,12 @@ func NewPayloadBuilder(ctx context.Context, param *entity.MGetExperimentResultPa
 		if state, ok := itemID2ItemRunState[itemID]; ok {
 			itemResult.SystemInfo = &entity.ItemSystemInfo{
 				RunState: state,
+				EndTime:  itemResultPO.UpdatedAt,
 			}
 		} else {
 			itemResult.SystemInfo = &entity.ItemSystemInfo{
 				RunState: itemResultPO.Status,
+				EndTime:  itemResultPO.UpdatedAt,
 			}
 		}
 		for _, turnID := range itemID2TurnIDs[itemID] {

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl.go
@@ -437,7 +437,20 @@ func (e *ExptItemEvalCtxExecutor) CompleteItemRun(ctx context.Context, eiec *ent
 
 	// 仅 item 评测成功才推送 item-complete；失败不发（下游只消费成功行）。
 	if evalErr == nil && e.itemCompletePublisher != nil {
-		if err := e.itemCompletePublisher.PublishItemComplete(ctx, buildItemCompleteEvent(eiec)); err != nil {
+		completeEvent := buildItemCompleteEvent(eiec)
+		// 记录 enable_analysis 的固化取值与来源链路：下游 gate 依赖此值，
+		// 便于排查"评测对象已开分析但 item-complete 未发"（EnableAnalysis 固化断点）。
+		var hasTarget, hasVersion, hasSandbox bool
+		if expt := eiec.Expt; expt != nil && expt.Target != nil {
+			hasTarget = true
+			if ver := expt.Target.EvalTargetVersion; ver != nil {
+				hasVersion = true
+				hasSandbox = ver.SandboxAgent != nil
+			}
+		}
+		logs.CtxInfo(ctx, "[ExptTurnEval] item complete enable_analysis resolved, expt_id: %v, item_id: %v, enable_analysis: %v, has_target: %v, has_version: %v, has_sandbox_agent: %v",
+			event.ExptID, event.EvalSetItemID, completeEvent.EnableAnalysis, hasTarget, hasVersion, hasSandbox)
+		if err := e.itemCompletePublisher.PublishItemComplete(ctx, completeEvent); err != nil {
 			logs.CtxWarn(ctx, "[ExptTurnEval] publish item complete event failed, expt_id: %v, item_id: %v, err: %v", event.ExptID, event.EvalSetItemID, err)
 		}
 	}

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl.go
@@ -493,6 +493,8 @@ func buildItemCompleteEvent(eiec *entity.ExptItemEvalCtx) *component.ItemComplet
 		// experiment_group_key: 关联同组实验，默认为实验 ID。
 		// PO→DO 转换已保证非空（空则填实验 ID），此处直接透传。
 		ev.ExperimentGroupKey = expt.ExperimentGroupKey
+		// created_by: 实验创建人 userID，实验级恒定，内存已加载零额外 IO。
+		ev.CreatedBy = expt.CreatedBy
 	}
 
 	var datasetID int64

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl.go
@@ -472,6 +472,10 @@ func buildItemCompleteEvent(eiec *entity.ExptItemEvalCtx) *component.ItemComplet
 			ev.EvalTargetWorkspaceID = strconv.FormatInt(expt.Target.SpaceID, 10)
 			// source_target_id: 业务侧原始对象 ID，加载详情时经 EvalTargetPO2DO 已回填，直接透传。
 			ev.SourceTargetID = expt.Target.SourceTargetID
+			// enable_analysis: 评测对象是否开启分析，从 eval_target 版本的 SandboxAgent 固化字段取。
+			if ver := expt.Target.EvalTargetVersion; ver != nil && ver.SandboxAgent != nil {
+				ev.EnableAnalysis = ver.SandboxAgent.EnableAnalysis
+			}
 		}
 		// experiment_group_key: 关联同组实验，默认为实验 ID。
 		// PO→DO 转换已保证非空（空则填实验 ID），此处直接透传。

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl_test.go
@@ -26,6 +26,16 @@ import (
 	servicemocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/service/mocks"
 )
 
+type stubItemCompletePublisher struct {
+	events []*component.ItemCompleteEvent
+	err    error
+}
+
+func (s *stubItemCompletePublisher) PublishItemComplete(_ context.Context, event *component.ItemCompleteEvent) error {
+	s.events = append(s.events, event)
+	return s.err
+}
+
 func Test_NewExptItemEvaluation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -395,6 +405,129 @@ func Test_ExptItemEvalCtxExecutor_CompleteSetItemRun(t *testing.T) {
 		err := executor.CompleteItemRun(ctx, eiec, errors.New("target timeout"))
 		assert.NoError(t, err)
 	})
+}
+
+func Test_ExptItemEvalCtxExecutor_CompleteItemRun_ItemCompletePublisher(t *testing.T) {
+	const (
+		exptID      = int64(1)
+		exptRunID   = int64(2)
+		itemID      = int64(3)
+		spaceID     = int64(4)
+		targetID    = int64(5)
+		targetSpace = int64(6)
+	)
+
+	tests := []struct {
+		name         string
+		mutateExpt   func(*entity.Experiment)
+		publisherErr error
+		evalErr      error
+		wantPublish  bool
+		wantAnalysis bool
+	}{
+		{name: "complete target version and sandbox", wantPublish: true, wantAnalysis: true},
+		{
+			name: "nil target",
+			mutateExpt: func(expt *entity.Experiment) {
+				expt.Target = nil
+			},
+			wantPublish: true,
+		},
+		{
+			name: "nil target version",
+			mutateExpt: func(expt *entity.Experiment) {
+				expt.Target.EvalTargetVersion = nil
+			},
+			wantPublish: true,
+		},
+		{
+			name: "nil sandbox agent",
+			mutateExpt: func(expt *entity.Experiment) {
+				expt.Target.EvalTargetVersion.SandboxAgent = nil
+			},
+			wantPublish: true,
+		},
+		{
+			name:         "publisher error does not block completion",
+			publisherErr: errors.New("publish failed"),
+			wantPublish:  true,
+			wantAnalysis: true,
+		},
+		{name: "evaluation error skips publish", evalErr: errors.New("evaluation failed")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			itemResultRepo := repomocks.NewMockIExptItemResultRepo(ctrl)
+			configer := configermocks.NewMockIConfiger(ctrl)
+			publisher := &stubItemCompletePublisher{err: tt.publisherErr}
+			expt := &entity.Experiment{
+				CreatedBy:          "creator_user_id",
+				ExperimentGroupKey: "group-key",
+				TargetID:           targetID,
+				Target: &entity.EvalTarget{
+					SpaceID:        targetSpace,
+					SourceTargetID: "source-target-id",
+					EvalTargetVersion: &entity.EvalTargetVersion{
+						SandboxAgent: &entity.SandboxAgent{EnableAnalysis: true},
+					},
+				},
+			}
+			if tt.mutateExpt != nil {
+				tt.mutateExpt(expt)
+			}
+
+			execCtx := &entity.ExptItemEvalCtx{
+				Event: &entity.ExptItemEvalEvent{
+					ExptID: exptID, ExptRunID: exptRunID, EvalSetItemID: itemID, SpaceID: spaceID,
+				},
+				Expt: expt,
+			}
+			wantFields := map[string]any{
+				"result_state": entity.ExptItemResultStateLogged,
+				"status":       int32(entity.ItemRunState_Success),
+			}
+			if tt.evalErr != nil {
+				wantFields["status"] = int32(entity.ItemRunState_Fail)
+				wantFields["err_msg"] = tt.evalErr.Error()
+				configer.EXPECT().GetErrRetryConf(gomock.Any(), spaceID, tt.evalErr).
+					Times(2).
+					Return(&entity.RetryConf{})
+			}
+			itemResultRepo.EXPECT().UpdateItemRunLog(
+				gomock.Any(), exptID, exptRunID, []int64{itemID}, gomock.Any(), spaceID,
+			).DoAndReturn(func(_ context.Context, _, _ int64, _ []int64, fields map[string]any, _ int64) error {
+				require.Equal(t, wantFields, fields)
+				return nil
+			})
+
+			executor := &ExptItemEvalCtxExecutor{
+				ItemResultRepo:        itemResultRepo,
+				Configer:              configer,
+				itemCompletePublisher: publisher,
+			}
+			require.NoError(t, executor.CompleteItemRun(context.Background(), execCtx, tt.evalErr))
+
+			if !tt.wantPublish {
+				require.Empty(t, publisher.events)
+				return
+			}
+			require.Len(t, publisher.events, 1)
+			published := publisher.events[0]
+			require.Equal(t, "1", published.ExptID)
+			require.Equal(t, "2", published.ExptRunID)
+			require.Equal(t, "3", published.ItemID)
+			require.Equal(t, "creator_user_id", published.CreatedBy)
+			require.Equal(t, tt.wantAnalysis, published.EnableAnalysis)
+			if tt.wantAnalysis {
+				require.Equal(t, "6", published.EvalTargetWorkspaceID)
+				require.Equal(t, "source-target-id", published.SourceTargetID)
+			}
+		})
+	}
 }
 
 func Test_ExptItemEvalCtxExecutor_storeTurnRunResult(t *testing.T) {

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl_test.go
@@ -810,3 +810,87 @@ func Test_buildExptTurnEvalCtx_BuildEvalExtMerge(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildItemCompleteEvent(t *testing.T) {
+	tests := []struct {
+		name               string
+		eiec               *entity.ExptItemEvalCtx
+		wantCreatedBy      string
+		wantEnableAnalysis bool
+	}{
+		{
+			name: "sandbox agent analysis enabled -> created_by + enable_analysis both set",
+			eiec: &entity.ExptItemEvalCtx{
+				Event: &entity.ExptItemEvalEvent{SpaceID: 1, ExptID: 100, ExptRunID: 200, EvalSetItemID: 300},
+				Expt: &entity.Experiment{
+					CreatedBy: "user_abc",
+					TargetID:  9,
+					Target: &entity.EvalTarget{
+						SpaceID: 1,
+						EvalTargetVersion: &entity.EvalTargetVersion{
+							SandboxAgent: &entity.SandboxAgent{EnableAnalysis: true},
+						},
+					},
+				},
+			},
+			wantCreatedBy:      "user_abc",
+			wantEnableAnalysis: true,
+		},
+		{
+			name: "sandbox agent analysis disabled -> created_by set, enable_analysis false",
+			eiec: &entity.ExptItemEvalCtx{
+				Event: &entity.ExptItemEvalEvent{SpaceID: 1, ExptID: 100, ExptRunID: 200, EvalSetItemID: 300},
+				Expt: &entity.Experiment{
+					CreatedBy: "user_def",
+					Target: &entity.EvalTarget{
+						SpaceID:           1,
+						EvalTargetVersion: &entity.EvalTargetVersion{SandboxAgent: &entity.SandboxAgent{EnableAnalysis: false}},
+					},
+				},
+			},
+			wantCreatedBy:      "user_def",
+			wantEnableAnalysis: false,
+		},
+		{
+			name: "nil sandbox agent -> enable_analysis false, no panic",
+			eiec: &entity.ExptItemEvalCtx{
+				Event: &entity.ExptItemEvalEvent{SpaceID: 1, ExptID: 100, ExptRunID: 200, EvalSetItemID: 300},
+				Expt: &entity.Experiment{
+					CreatedBy: "user_ghi",
+					Target:    &entity.EvalTarget{SpaceID: 1, EvalTargetVersion: &entity.EvalTargetVersion{}},
+				},
+			},
+			wantCreatedBy:      "user_ghi",
+			wantEnableAnalysis: false,
+		},
+		{
+			name: "nil target version -> enable_analysis false, no panic",
+			eiec: &entity.ExptItemEvalCtx{
+				Event: &entity.ExptItemEvalEvent{SpaceID: 1, ExptID: 100, ExptRunID: 200, EvalSetItemID: 300},
+				Expt:  &entity.Experiment{CreatedBy: "user_jkl", Target: &entity.EvalTarget{SpaceID: 1}},
+			},
+			wantCreatedBy:      "user_jkl",
+			wantEnableAnalysis: false,
+		},
+		{
+			name: "nil target -> enable_analysis false, created_by still set, no panic",
+			eiec: &entity.ExptItemEvalCtx{
+				Event: &entity.ExptItemEvalEvent{SpaceID: 1, ExptID: 100, ExptRunID: 200, EvalSetItemID: 300},
+				Expt:  &entity.Experiment{CreatedBy: "user_mno"},
+			},
+			wantCreatedBy:      "user_mno",
+			wantEnableAnalysis: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := buildItemCompleteEvent(tt.eiec)
+			assert.NotNil(t, ev)
+			assert.Equal(t, tt.wantCreatedBy, ev.CreatedBy)
+			assert.Equal(t, tt.wantEnableAnalysis, ev.EnableAnalysis)
+			// 基础字段恒填充
+			assert.Equal(t, "100", ev.ExptID)
+			assert.Equal(t, "300", ev.ItemID)
+		})
+	}
+}

--- a/backend/modules/evaluation/domain/service/mocks/expt_manage.go
+++ b/backend/modules/evaluation/domain/service/mocks/expt_manage.go
@@ -396,6 +396,21 @@ func (mr *MockIExptManagerMockRecorder) MGet(arg0, arg1, arg2, arg3 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MGet", reflect.TypeOf((*MockIExptManager)(nil).MGet), arg0, arg1, arg2, arg3)
 }
 
+// MGetBasicByID mocks base method.
+func (m *MockIExptManager) MGetBasicByID(arg0 context.Context, arg1 []int64) ([]*entity.Experiment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MGetBasicByID", arg0, arg1)
+	ret0, _ := ret[0].([]*entity.Experiment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MGetBasicByID indicates an expected call of MGetBasicByID.
+func (mr *MockIExptManagerMockRecorder) MGetBasicByID(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MGetBasicByID", reflect.TypeOf((*MockIExptManager)(nil).MGetBasicByID), arg0, arg1)
+}
+
 // MGetDetail mocks base method.
 func (m *MockIExptManager) MGetDetail(arg0 context.Context, arg1 []int64, arg2 int64, arg3 *entity.Session) ([]*entity.Experiment, error) {
 	m.ctrl.T.Helper()

--- a/backend/modules/evaluation/infra/repo/experiment/expt_repo_impl.go
+++ b/backend/modules/evaluation/infra/repo/experiment/expt_repo_impl.go
@@ -129,6 +129,15 @@ func (e *exptRepoImpl) MGetByID(ctx context.Context, ids []int64, spaceID int64)
 		return nil, err
 	}
 
+	// exptDAO.MGetByID 只按主键查、不带 space 过滤；此处按 spaceID 兜底过滤，防止跨空间读取越权。
+	inSpace := make([]*model.Experiment, 0, len(pos))
+	for _, po := range pos {
+		if po.SpaceID == spaceID {
+			inSpace = append(inSpace, po)
+		}
+	}
+	pos = inSpace
+
 	exptIDs := slices.Transform(pos, func(e *model.Experiment, _ int) int64 {
 		return e.ID
 	})

--- a/backend/modules/evaluation/infra/repo/experiment/expt_repo_impl_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/expt_repo_impl_test.go
@@ -286,7 +286,7 @@ func TestExptRepoImpl_GetByID(t *testing.T) {
 		{
 			name: "success",
 			mockSetup: func() {
-				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{1}).Return([]*model.Experiment{{ID: 1}}, nil)
+				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{1}).Return([]*model.Experiment{{ID: 1, SpaceID: 1}}, nil)
 				mockRefDAO.EXPECT().MGetByExptID(gomock.Any(), []int64{1}, int64(1)).Return([]*model.ExptEvaluatorRef{{ExptID: 1}}, nil)
 			},
 			wantErr: false,
@@ -340,11 +340,21 @@ func TestExptRepoImpl_MGetByID(t *testing.T) {
 		{
 			name: "success",
 			mockSetup: func() {
-				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{1, 2}).Return([]*model.Experiment{{ID: 1}, {ID: 2}}, nil)
+				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{1, 2}).Return([]*model.Experiment{{ID: 1, SpaceID: 1}, {ID: 2, SpaceID: 1}}, nil)
 				mockRefDAO.EXPECT().MGetByExptID(gomock.Any(), []int64{1, 2}, int64(1)).Return([]*model.ExptEvaluatorRef{{ExptID: 1}, {ExptID: 2}}, nil)
 			},
 			wantErr: false,
 			wantLen: 2,
+		},
+		{
+			name: "filter_cross_space",
+			mockSetup: func() {
+				// 主键命中但 space 不匹配的行应被兜底过滤，防跨空间越权读取。
+				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{7, 8}).Return([]*model.Experiment{{ID: 7, SpaceID: 1}, {ID: 8, SpaceID: 2}}, nil)
+				mockRefDAO.EXPECT().MGetByExptID(gomock.Any(), []int64{7}, int64(1)).Return([]*model.ExptEvaluatorRef{{ExptID: 7}}, nil)
+			},
+			wantErr: false,
+			wantLen: 1,
 		},
 		{
 			name: "fail_mget",
@@ -357,7 +367,7 @@ func TestExptRepoImpl_MGetByID(t *testing.T) {
 		{
 			name: "fail_ref",
 			mockSetup: func() {
-				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{5, 6}).Return([]*model.Experiment{{ID: 5}, {ID: 6}}, nil)
+				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{5, 6}).Return([]*model.Experiment{{ID: 5, SpaceID: 1}, {ID: 6, SpaceID: 1}}, nil)
 				mockRefDAO.EXPECT().MGetByExptID(gomock.Any(), []int64{5, 6}, int64(1)).Return(nil, errors.New("ref error"))
 			},
 			wantErr: true,
@@ -372,6 +382,8 @@ func TestExptRepoImpl_MGetByID(t *testing.T) {
 			switch tt.name {
 			case "success":
 				ids = []int64{1, 2}
+			case "filter_cross_space":
+				ids = []int64{7, 8}
 			case "fail_mget":
 				ids = []int64{3, 4}
 			default:

--- a/backend/modules/evaluation/infra/repo/experiment/expt_repo_impl_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/expt_repo_impl_test.go
@@ -7,14 +7,17 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/coze-dev/coze-loop/backend/infra/idgen/mocks"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/mysql/gorm_gen/model"
 	mysqlMocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/mysql/mocks"
+	"github.com/coze-dev/coze-loop/backend/pkg/json"
 )
 
 func newRepo(ctrl *gomock.Controller) (*exptRepoImpl, *mysqlMocks.MockIExptDAO, *mysqlMocks.MockIExptEvaluatorRefDAO, *mocks.MockIIDGenerator) {
@@ -402,53 +405,126 @@ func TestExptRepoImpl_MGetByID(t *testing.T) {
 }
 
 func TestExptRepoImpl_MGetBasicByID(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	repo, mockExptDAO, _, _ := newRepo(ctrl)
+	t.Run("returns complete basic experiments in requested order", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		repo, mockExptDAO, _, _ := newRepo(ctrl)
 
-	tests := []struct {
-		name      string
-		mockSetup func()
-		wantErr   bool
-		wantLen   int
-	}{
-		{
-			name: "success",
-			mockSetup: func() {
-				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{1, 2}).Return([]*model.Experiment{{ID: 1}, {ID: 2}}, nil)
-			},
-			wantErr: false,
-			wantLen: 2,
-		},
-		{
-			name: "fail_mget",
-			mockSetup: func() {
-				mockExptDAO.EXPECT().MGetByID(gomock.Any(), []int64{3, 4}).Return(nil, errors.New("dao error"))
-			},
-			wantErr: true,
-			wantLen: 0,
-		},
-	}
+		createdAt202 := time.Date(2026, time.July, 24, 10, 11, 12, 0, time.UTC)
+		createdAt101 := time.Date(2026, time.July, 23, 9, 8, 7, 0, time.UTC)
+		itemConcurNum202 := 7
+		itemRetryNum202 := 3
+		enableExtractTrajectory202 := true
+		evalConf202 := &entity.EvaluationConfiguration{
+			ItemConcurNum:           &itemConcurNum202,
+			ItemRetryNum:            &itemRetryNum202,
+			EnableExtractTrajectory: &enableExtractTrajectory202,
+			Ext:                     map[string]string{"source": "mget-basic"},
+		}
+		evalConf202JSON, err := json.Marshal(evalConf202)
+		require.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.mockSetup()
-			var ids []int64
-			if tt.name == "success" {
-				ids = []int64{1, 2}
-			} else {
-				ids = []int64{3, 4}
-			}
-			got, err := repo.MGetBasicByID(context.Background(), ids)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, got)
-			} else {
-				assert.NoError(t, err)
-				assert.Len(t, got, tt.wantLen)
-			}
-		})
-	}
+		webhookURLs202 := "https://example.com/hooks/202"
+		webhookEnvironment202 := entity.WebhookEnvironment_PPE
+		webhookLane202 := "eval-202"
+		feishuUserID202 := "ou_creator_202"
+		notificationConf202 := &entity.ExptNotificationConf{
+			Webhook: &entity.WebhookNotificationConf{
+				Enable:      true,
+				Urls:        &webhookURLs202,
+				Environment: &webhookEnvironment202,
+				Lane:        &webhookLane202,
+			},
+			FeishuNotification: &entity.FeishuNotificationConf{
+				Enable: true,
+				UserID: &feishuUserID202,
+			},
+		}
+		notificationConf202JSON, err := json.Marshal(notificationConf202)
+		require.NoError(t, err)
+
+		itemConcurNum101 := 2
+		evalConf101 := &entity.EvaluationConfiguration{
+			ItemConcurNum: &itemConcurNum101,
+			Ext:           map[string]string{"source": "second"},
+		}
+		evalConf101JSON, err := json.Marshal(evalConf101)
+		require.NoError(t, err)
+
+		webhookURLs101 := "https://example.com/hooks/101"
+		notificationConf101 := &entity.ExptNotificationConf{
+			Webhook: &entity.WebhookNotificationConf{
+				Enable: true,
+				Urls:   &webhookURLs101,
+			},
+		}
+		notificationConf101JSON, err := json.Marshal(notificationConf101)
+		require.NoError(t, err)
+
+		ids := []int64{202, 101}
+		mockExptDAO.EXPECT().MGetByID(gomock.Any(), ids).Return([]*model.Experiment{
+			{
+				ID:                 202,
+				SpaceID:            42,
+				CreatedBy:          "creator-202",
+				Name:               "experiment-202",
+				Description:        "description-202",
+				ExperimentGroupKey: "group-202",
+				EvalConf:           &evalConf202JSON,
+				NotificationConf:   &notificationConf202JSON,
+				CreatedAt:          createdAt202,
+			},
+			{
+				ID:                 101,
+				SpaceID:            42,
+				CreatedBy:          "creator-101",
+				Name:               "experiment-101",
+				Description:        "description-101",
+				ExperimentGroupKey: "group-101",
+				EvalConf:           &evalConf101JSON,
+				NotificationConf:   &notificationConf101JSON,
+				CreatedAt:          createdAt101,
+			},
+		}, nil)
+
+		got, err := repo.MGetBasicByID(context.Background(), ids)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		require.Equal(t, []int64{202, 101}, []int64{got[0].ID, got[1].ID})
+
+		require.Equal(t, int64(42), got[0].SpaceID)
+		require.Equal(t, "creator-202", got[0].CreatedBy)
+		require.Equal(t, "experiment-202", got[0].Name)
+		require.Equal(t, "description-202", got[0].Description)
+		require.Equal(t, "group-202", got[0].ExperimentGroupKey)
+		require.NotNil(t, got[0].CreatedAt)
+		require.Equal(t, createdAt202, *got[0].CreatedAt)
+		require.Equal(t, evalConf202, got[0].EvalConf)
+		require.Equal(t, notificationConf202, got[0].NotificationConf)
+		require.Empty(t, got[0].EvaluatorVersionRef)
+
+		require.Equal(t, int64(42), got[1].SpaceID)
+		require.Equal(t, "creator-101", got[1].CreatedBy)
+		require.Equal(t, "experiment-101", got[1].Name)
+		require.Equal(t, "description-101", got[1].Description)
+		require.Equal(t, "group-101", got[1].ExperimentGroupKey)
+		require.NotNil(t, got[1].CreatedAt)
+		require.Equal(t, createdAt101, *got[1].CreatedAt)
+		require.Equal(t, evalConf101, got[1].EvalConf)
+		require.Equal(t, notificationConf101, got[1].NotificationConf)
+		require.Empty(t, got[1].EvaluatorVersionRef)
+	})
+
+	t.Run("returns dao error unchanged", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		repo, mockExptDAO, _, _ := newRepo(ctrl)
+		daoErr := errors.New("mget basic experiments failed")
+		ids := []int64{303, 404}
+		mockExptDAO.EXPECT().MGetByID(gomock.Any(), ids).Return(nil, daoErr)
+
+		got, err := repo.MGetBasicByID(context.Background(), ids)
+		require.ErrorIs(t, err, daoErr)
+		require.Nil(t, got)
+	})
 }
 
 func TestExptRepoImpl_GetByName(t *testing.T) {

--- a/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt.go
@@ -125,6 +125,7 @@ func (ExptConverter) PO2DO(expt *model.Experiment, refs []*model.ExptEvaluatorRe
 		OfflineExptAnalysisStatus: entity.OfflineExptAnalysisStatus(expt.OfflineExptAnalysisStatus),
 		LatestRunID:               expt.LatestRunID,
 		CreditCost:                entity.CreditCost(expt.CreditCost),
+		CreatedAt:                 gptr.Of(expt.CreatedAt),
 		StartAt:                   expt.StartAt,
 		EndAt:                     expt.EndAt,
 		SourceType:                entity.SourceType(expt.SourceType),

--- a/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_result.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_result.go
@@ -43,6 +43,7 @@ func (ExptItemResultConvertor) PO2DO(rl *model.ExptItemResult) *entity.ExptItemR
 		Status:        entity.ItemRunState(rl.Status),
 		ErrMsg:        conv.UnsafeBytesToString(gptr.Indirect(rl.ErrMsg)),
 		LogID:         rl.LogID,
+		UpdatedAt:     gptr.Of(rl.UpdatedAt),
 	}
 	// 反序列化 Ext 字段
 	if rl.Ext != nil && len(*rl.Ext) > 0 {

--- a/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_result_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_result_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package convert
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/mysql/gorm_gen/model"
+)
+
+func TestExptItemResultConvertor_PO2DO_UpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := time.Date(2026, time.July, 24, 16, 17, 18, 987654000, time.UTC)
+	itemIdx := int32(9)
+	errMsg := []byte("target execution failed")
+	po := &model.ExptItemResult{
+		ID:            101,
+		SpaceID:       202,
+		ExptID:        303,
+		ExptRunID:     404,
+		ItemID:        505,
+		ItemVersionID: 606,
+		ItemIdx:       &itemIdx,
+		Status:        int32(entity.ItemRunState_Fail),
+		ErrMsg:        &errMsg,
+		LogID:         "log-707",
+		UpdatedAt:     updatedAt,
+	}
+
+	got := NewExptItemResultConvertor().PO2DO(po)
+	require.NotNil(t, got)
+	require.Equal(t, int64(101), got.ID)
+	require.Equal(t, int64(202), got.SpaceID)
+	require.Equal(t, int64(303), got.ExptID)
+	require.Equal(t, int64(404), got.ExptRunID)
+	require.Equal(t, int64(505), got.ItemID)
+	require.Equal(t, int64(606), got.ItemVersionID)
+	require.Equal(t, int32(9), got.ItemIdx)
+	require.Equal(t, entity.ItemRunState_Fail, got.Status)
+	require.Equal(t, "target execution failed", got.ErrMsg)
+	require.Equal(t, "log-707", got.LogID)
+	require.NotNil(t, got.UpdatedAt)
+	require.Equal(t, updatedAt, *got.UpdatedAt)
+}

--- a/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/convert/expt_test.go
@@ -5,9 +5,11 @@ package convert
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bytedance/gg/gptr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/mysql/gorm_gen/model"
@@ -120,6 +122,24 @@ func TestExptConverter_PO2DO_KeepsExplicitGroupKey(t *testing.T) {
 	do, err := NewExptConverter().PO2DO(po, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "explicit-group", do.ExperimentGroupKey)
+}
+
+func TestExptConverter_PO2DO_CreatedAt(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, time.July, 24, 13, 14, 15, 123456000, time.UTC)
+	po := &model.Experiment{
+		ID:        201,
+		CreatedBy: "creator-201",
+		CreatedAt: createdAt,
+	}
+
+	do, err := NewExptConverter().PO2DO(po, nil)
+	require.NoError(t, err)
+	require.NotNil(t, do)
+	require.NotNil(t, do.CreatedAt)
+	require.Equal(t, createdAt, *do.CreatedAt)
+	require.Equal(t, "creator-201", do.CreatedBy)
 }
 
 func TestExptConverter_PO2DO_EvaluatorRefs(t *testing.T) {

--- a/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
@@ -51,10 +51,8 @@ struct CreateExperimentRequest {
     // 与 eval_set_configs 须一致: ==2 要求 configs 非空; !=2 要求 configs 为空, 否则硬校验报错。
     71: optional expt.ExptEvalSetSourceType eval_set_source_type (api.body = 'eval_set_source_type')
 
-    // 实验分组 key；不填时后端默认为实验 id
-    90: optional string experiment_group_key (api.body = 'experiment_group_key', go.tag='json:"experiment_group_key"')
-
-    // 引用分组实验 id：填写时校验其为当前空间内的实验 id，通过后本实验的 group key 复用该引用实验的 group key（归入同一分组）；优先级高于 experiment_group_key
+    // 实验分组 key 默认为实验 id；填写 ref_group_experiment_id 时复用该引用实验的 group key（归入同一分组）
+    // 引用分组实验 id：填写时校验其为当前空间内的实验 id
     91: optional i64 ref_group_experiment_id (api.js_conv = 'true', api.body = 'ref_group_experiment_id', go.tag='json:"ref_group_experiment_id"')
 
     // 通知配置
@@ -123,10 +121,8 @@ struct SubmitExperimentRequest {
 
     100: optional map<string, string> ext (api.body = 'ext')
 
-    // 实验分组 key；不填时后端默认为实验 id
-    90: optional string experiment_group_key (api.body = 'experiment_group_key', go.tag='json:"experiment_group_key"')
-
-    // 引用分组实验 id：填写时校验其为当前空间内的实验 id，通过后本实验的 group key 复用该引用实验的 group key（归入同一分组）；优先级高于 experiment_group_key
+    // 实验分组 key 默认为实验 id；填写 ref_group_experiment_id 时复用该引用实验的 group key（归入同一分组）
+    // 引用分组实验 id：填写时校验其为当前空间内的实验 id
     91: optional i64 ref_group_experiment_id (api.js_conv = 'true', api.body = 'ref_group_experiment_id', go.tag='json:"ref_group_experiment_id"')
 
     // 通知配置
@@ -184,6 +180,7 @@ struct GetExperimentIDsByGroupRequest {
 
 struct GetExperimentIDsByGroupResponse {
     1: optional list<i64> expt_ids (api.body = 'expt_ids', api.js_conv = 'true', go.tag = 'json:"expt_ids"')
+    2: optional list<expt.Experiment> experiments (api.body = 'experiments', go.tag = 'json:"experiments"')
 
     255: base.BaseResp BaseResp
 }
@@ -398,6 +395,8 @@ struct ItemStandardEvalOutput {
     13: optional i64 dataset_version_id (api.js_conv = 'true', go.tag = 'json:"dataset_version_id"')
     14: optional string dataset_version_name (go.tag = 'json:"dataset_version_name"')
     15: optional string experiment_group_key (go.tag = 'json:"experiment_group_key"')
+    16: optional i64 experiment_create_time (api.js_conv = 'true', go.tag = 'json:"experiment_create_time"')  // 实验创建时间（秒），来源 experiment.created_at
+    17: optional i64 item_end_time (api.js_conv = 'true', go.tag = 'json:"item_end_time"')  // item 执行结束时间（秒），来源 expt_item_result.updated_at
 
     // 标准化评测输出内容块：小内容 inline，大内容通过各 section 的 full_content 引用。
     30: optional StandardEvalOutputContent detail (go.tag = 'json:"detail"')

--- a/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.expt.thrift
@@ -397,6 +397,7 @@ struct ItemStandardEvalOutput {
     15: optional string experiment_group_key (go.tag = 'json:"experiment_group_key"')
     16: optional i64 experiment_create_time (api.js_conv = 'true', go.tag = 'json:"experiment_create_time"')  // 实验创建时间（秒），来源 experiment.created_at
     17: optional i64 item_end_time (api.js_conv = 'true', go.tag = 'json:"item_end_time"')  // item 执行结束时间（秒），来源 expt_item_result.updated_at
+    18: optional string created_by (go.tag = 'json:"created_by"')  // 实验创建人 userID，来源 experiment.created_by（实验级恒定）
 
     // 标准化评测输出内容块：小内容 inline，大内容通过各 section 的 full_content 引用。
     30: optional StandardEvalOutputContent detail (go.tag = 'json:"detail"')

--- a/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.openapi.thrift
+++ b/idl/thrift/coze/loop/evaluation/coze.loop.evaluation.openapi.thrift
@@ -552,11 +552,8 @@ struct SubmitExperimentOApiRequest {
 
     100: optional map<string, string> ext (api.body = 'ext')
 
-    // 实验分组 key: 显式传入时服务端校验跨 space 隔离(不允许其它空间已占用该 key), 撞车拒绝创建; 缺省则以实验 ID 兜底。同一空间内允许多个实验共享同一 group key。
-    // 与内部 Submit 的 experiment_group_key 对齐, application 层直接指针透传给 CreateExperiment。
-    101: optional string experiment_group_key (api.body = 'experiment_group_key', go.tag = 'json:"experiment_group_key"')
-
-    // 引用分组实验 id: 填写时校验其为当前空间内的实验 id, 通过后本实验的 group key 复用该引用实验的 group key(归入同一分组); 优先级高于 experiment_group_key。
+    // 实验分组 key 默认以实验 ID 兜底；填写 ref_group_experiment_id 时复用该引用实验的 group key（归入同一分组）。
+    // 引用分组实验 id: 填写时校验其为当前空间内的实验 id。
     102: optional i64 ref_group_experiment_id (api.js_conv = "true", api.body = 'ref_group_experiment_id', go.tag = 'json:"ref_group_experiment_id"')
 
     254: optional extra.Extra extra (agw.source = "not_body_struct")

--- a/idl/thrift/coze/loop/evaluation/domain/eval_target.thrift
+++ b/idl/thrift/coze/loop/evaluation/domain/eval_target.thrift
@@ -300,6 +300,10 @@ struct SandboxAgent {
 
     // 沙箱镜像
     8: optional string image
+
+    // 是否开启分析：由创建评测对象时从 application.usages 反查（含 "analysis"）固化，
+    // 控制 item-complete MQ 是否发送（与 TCC 空间白名单 AND）
+    9: optional bool enable_analysis
 }
 
 struct AgentConnection {

--- a/idl/thrift/coze/loop/evaluation/domain/expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/domain/expt.thrift
@@ -69,6 +69,7 @@ struct Experiment {
     8: optional i64 end_time (api.js_conv='true', go.tag='json:"end_time"')
     9: optional i32 item_concur_num
     10: optional Visibility visibility  // 实验可见性，默认为空，可见
+    11: optional i64 create_time (api.js_conv='true', go.tag='json:"create_time"')  // 实验创建时间（秒），来源 experiment.created_at
 
     21: optional i64 eval_set_version_id (api.js_conv='true', go.tag='json:"eval_set_version_id"')
     22: optional i64 target_version_id (api.js_conv='true', go.tag='json:"target_version_id"')


### PR DESCRIPTION
## What
A batch of evaluation-module changes (branch feat/expt_support_analyze):
- **Group reverse-lookup**: `GetExperimentIDsByGroup` now returns the `experiments` list, filled via a new `IExptManager.MGetBasicByID` that queries the `experiment` table only (no eval_set/target/evaluator joins, no extra user RPC).
- **Standard eval output**: added `experiment_create_time`, `item_end_time`, and `created_by` (experiment creator userID). All sourced from data already loaded in memory — zero extra DB queries.
- **Remove `experiment_group_key` request param** from create/submit experiment (kept `ref_group_experiment_id`). No ref → group key = experiment ID; with ref → inherit the ref's group key after validating the ref belongs to the current space (cross-space access rejected with 601204019).
- **item-complete MQ**: propagate the eval target's `SandboxAgent.EnableAnalysis` (fossilized at target-version level); add `created_by` to `ItemCompleteEvent`; log the resolved `enable_analysis` and its source chain before publishing.
## Test
Added/extended unit tests: `MGetBasicByID`, `buildItemCompleteEvent` (created_by + EnableAnalysis nil-safety branches), and the group_key ref guard. `go test` green across evaluation/domain/service.