### PR TITLE
[fix][evaluation] write NULL (not 0) for absent evaluator score to fix N/A miscounting in aggregation

### DIFF
--- a/backend/modules/evaluation/infra/repo/evaluator/evaluator_record_impl.go
+++ b/backend/modules/evaluation/infra/repo/evaluator/evaluator_record_impl.go
@@ -159,9 +159,11 @@ func (r *EvaluatorRecordRepoImpl) BatchGetEvaluatorRecordForAggr(ctx context.Con
 }
 
 func (r *EvaluatorRecordRepoImpl) UpdateEvaluatorRecordResult(ctx context.Context, recordID int64, status entity.EvaluatorRunStatus, outputData *entity.EvaluatorOutputData) error {
-	var score float64
+	// 只有拿到有效分数才写具体值; 无分数(失败/未产出)时传 nil, 让 DAO 写 NULL 而非 0,
+	// 保证 score 列语义诚实: 有值=有分, NULL=无分。聚合窄查询依赖此不变量做 score IS NOT NULL 过滤。
+	var score *float64
 	if outputData != nil && outputData.EvaluatorResult != nil && outputData.EvaluatorResult.Score != nil {
-		score = *outputData.EvaluatorResult.Score
+		score = outputData.EvaluatorResult.Score
 	}
 
 	var outputDataStr string

--- a/backend/modules/evaluation/infra/repo/evaluator/evaluator_record_impl_test.go
+++ b/backend/modules/evaluation/infra/repo/evaluator/evaluator_record_impl_test.go
@@ -589,7 +589,7 @@ func TestEvaluatorRecordRepoImpl_UpdateEvaluatorRecordResult(t *testing.T) {
 		recordID          int64
 		status            entity.EvaluatorRunStatus
 		outputData        *entity.EvaluatorOutputData
-		wantScore         float64
+		wantScore         *float64
 		wantOutputDataStr string
 		daoErr            error
 	}{
@@ -598,7 +598,7 @@ func TestEvaluatorRecordRepoImpl_UpdateEvaluatorRecordResult(t *testing.T) {
 			recordID:          1,
 			status:            entity.EvaluatorRunStatusSuccess,
 			outputData:        nil,
-			wantScore:         0,
+			wantScore:         nil,
 			wantOutputDataStr: "",
 		},
 		{
@@ -608,7 +608,7 @@ func TestEvaluatorRecordRepoImpl_UpdateEvaluatorRecordResult(t *testing.T) {
 			outputData: &entity.EvaluatorOutputData{
 				EvaluatorResult: nil,
 			},
-			wantScore:         0,
+			wantScore:         nil,
 			wantOutputDataStr: pkgjson.Jsonify(&entity.EvaluatorOutputData{EvaluatorResult: nil}),
 		},
 		{
@@ -623,7 +623,7 @@ func TestEvaluatorRecordRepoImpl_UpdateEvaluatorRecordResult(t *testing.T) {
 					},
 				},
 			},
-			wantScore: 0,
+			wantScore: nil,
 			wantOutputDataStr: pkgjson.Jsonify(&entity.EvaluatorOutputData{
 				EvaluatorResult: &entity.EvaluatorResult{
 					Score: nil,
@@ -642,7 +642,7 @@ func TestEvaluatorRecordRepoImpl_UpdateEvaluatorRecordResult(t *testing.T) {
 					Score: gptr.Of(float64(1.25)),
 				},
 			},
-			wantScore: 1.25,
+			wantScore: gptr.Of(float64(1.25)),
 			wantOutputDataStr: pkgjson.Jsonify(&entity.EvaluatorOutputData{
 				EvaluatorResult: &entity.EvaluatorResult{
 					Score: gptr.Of(float64(1.25)),
@@ -658,7 +658,7 @@ func TestEvaluatorRecordRepoImpl_UpdateEvaluatorRecordResult(t *testing.T) {
 					Score: gptr.Of(float64(3)),
 				},
 			},
-			wantScore: 3,
+			wantScore: gptr.Of(float64(3)),
 			wantOutputDataStr: pkgjson.Jsonify(&entity.EvaluatorOutputData{
 				EvaluatorResult: &entity.EvaluatorResult{
 					Score: gptr.Of(float64(3)),

--- a/backend/modules/evaluation/infra/repo/evaluator/mysql/evaluator_record.go
+++ b/backend/modules/evaluation/infra/repo/evaluator/mysql/evaluator_record.go
@@ -23,7 +23,7 @@ import (
 type EvaluatorRecordDAO interface {
 	CreateEvaluatorRecord(ctx context.Context, evaluatorRecord *model.EvaluatorRecord, opts ...db.Option) error
 	UpdateEvaluatorRecord(ctx context.Context, evaluatorRecord *model.EvaluatorRecord, opts ...db.Option) error
-	UpdateEvaluatorRecordResult(ctx context.Context, recordID int64, status int8, score float64, outputData string, opts ...db.Option) error
+	UpdateEvaluatorRecordResult(ctx context.Context, recordID int64, status int8, score *float64, outputData string, opts ...db.Option) error
 	GetEvaluatorRecord(ctx context.Context, evaluatorRecordID int64, includeDeleted bool, opts ...db.Option) (*model.EvaluatorRecord, error)
 	BatchGetEvaluatorRecord(ctx context.Context, evaluatorRecordIDs []int64, includeDeleted bool, opts ...db.Option) ([]*model.EvaluatorRecord, error)
 	// BatchGetEvaluatorRecordForAggr 聚合专用窄查询: 只 SELECT id, score, status, 不取 input_data/output_data/ext
@@ -72,9 +72,11 @@ func (dao *EvaluatorRecordDAOImpl) UpdateEvaluatorRecord(ctx context.Context, ev
 		Save(evaluatorRecord).Error
 }
 
-func (dao *EvaluatorRecordDAOImpl) UpdateEvaluatorRecordResult(ctx context.Context, recordID int64, status int8, score float64, outputData string, opts ...db.Option) error {
+func (dao *EvaluatorRecordDAOImpl) UpdateEvaluatorRecordResult(ctx context.Context, recordID int64, status int8, score *float64, outputData string, opts ...db.Option) error {
 	dbsession := dao.provider.NewSession(ctx, opts...)
 
+	// score 传 nil 时写 NULL(而非 0): 失败/无有效分数的 record 不应在 score 列留下 0,
+	// 否则聚合窄查询 (status=Success AND score IS NOT NULL) 无法区分"真 0 分"与"无分数", 会把无分数误算进均值/分布。
 	return dbsession.WithContext(ctx).
 		Model(&model.EvaluatorRecord{}).
 		Where("id = ? AND deleted_at IS NULL", recordID).

--- a/backend/modules/evaluation/infra/repo/evaluator/mysql/evaluator_record_aggr_test.go
+++ b/backend/modules/evaluation/infra/repo/evaluator/mysql/evaluator_record_aggr_test.go
@@ -5,10 +5,12 @@ package mysql
 
 import (
 	"context"
+	"database/sql/driver"
 	"errors"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bytedance/gg/gptr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"gorm.io/driver/mysql"
@@ -80,4 +82,53 @@ func TestBatchGetEvaluatorRecordForAggr_DAOError(t *testing.T) {
 	got, err := dao.BatchGetEvaluatorRecordForAggr(context.Background(), []int64{1})
 	assert.Error(t, err)
 	assert.Nil(t, got)
+}
+
+// TestUpdateEvaluatorRecordResult_ScoreNullability 锁定"无分数写 NULL、有分数写值"的不变量。
+// GORM map-Updates 的列顺序不固定, 故用 AnyArg 占位, 只对 score 位用自定义匹配器断言 NULL vs 具体值——
+// 这是聚合窄查询 score IS NOT NULL 能过滤掉"幽灵 0 分"的写入侧前提。
+func TestUpdateEvaluatorRecordResult_ScoreNullability(t *testing.T) {
+	cases := []struct {
+		name     string
+		score    *float64
+		wantNull bool
+	}{
+		{name: "nil score 写 NULL", score: nil, wantNull: true},
+		{name: "有分数写具体值", score: gptr.Of(4.5), wantNull: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			dao, mock, cleanup := newAggrTestDAO(t, ctrl)
+			defer cleanup()
+
+			// GORM 生成的 SET 列序为 output_data, score, status, updated_at, 末尾 WHERE id;
+			// 只对 score 位用自定义匹配器断言 NULL/具体值, 其余用 AnyArg。
+			scoreMatcher := scoreArg{wantNull: c.wantNull, wantVal: c.score}
+			mock.ExpectBegin()
+			mock.ExpectExec("UPDATE `evaluator_record` SET").
+				WithArgs(sqlmock.AnyArg(), scoreMatcher, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			err := dao.UpdateEvaluatorRecordResult(context.Background(), 7, int8(entity.EvaluatorRunStatusFail), c.score, "{}")
+			assert.NoError(t, err)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// scoreArg 是 sqlmock 自定义参数匹配器: 断言 score 绑定值是否为 NULL(nil)。
+type scoreArg struct {
+	wantNull bool
+	wantVal  *float64
+}
+
+func (s scoreArg) Match(v driver.Value) bool {
+	if s.wantNull {
+		return v == nil
+	}
+	f, ok := v.(float64)
+	return ok && s.wantVal != nil && f == *s.wantVal
 }

--- a/backend/modules/evaluation/infra/repo/evaluator/mysql/mocks/evaluator_record_mock.go
+++ b/backend/modules/evaluation/infra/repo/evaluator/mysql/mocks/evaluator_record_mock.go
@@ -140,7 +140,7 @@ func (mr *MockEvaluatorRecordDAOMockRecorder) UpdateEvaluatorRecord(arg0, arg1 a
 }
 
 // UpdateEvaluatorRecordResult mocks base method.
-func (m *MockEvaluatorRecordDAO) UpdateEvaluatorRecordResult(arg0 context.Context, arg1 int64, arg2 int8, arg3 float64, arg4 string, arg5 ...db.Option) error {
+func (m *MockEvaluatorRecordDAO) UpdateEvaluatorRecordResult(arg0 context.Context, arg1 int64, arg2 int8, arg3 *float64, arg4 string, arg5 ...db.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3, arg4}
 	for _, a := range arg5 {


### PR DESCRIPTION
Background

A nil/null score is a legitimate signal in the evaluator protocol for expressing "Not Applicable (N/A)": when an evaluator cannot judge an input (e.g. an image with no text), it returns a nil score plus a reasoning. score is optional in the SPI DTO and a pointer in the DO by design. Such records can carry status=Success:
Async report path: status is supplied by the external agent callback (POST /v1/loop/evaluation/evaluators/result); the converter does not require a score when status=SUCCESS, and ReportEvaluatorInvokeResult performs no status/score consistency check.
Sync prompt path: a successful parse yields Success, and a nil score is not rejected.
Problem

UpdateEvaluatorRecordResult (async path, introduced in #421) used a value-typed var score float64, so a nil score was coerced to 0 and persisted as 0 (not NULL).

Previously this was harmless: aggregation deserialized output_data and skipped nil scores (hasScore=false), never reading the score column. After #590 switched aggregation to read the score column directly (to avoid OOM), the filter status=Success AND score IS NOT NULL can no longer exclude a literal 0, so N/A records are miscounted as 0 and drag down the average / distribution.

Fix
Change the score parameter from float64 to *float64 in both the repo impl and the DAO, writing NULL (not 0) when there is no score, so the score column semantics are honest.
This aligns the async update path with the sync create path (ConvertEvaluatorRecordDO2PO, which has always written a *float64 / NULL).
Add DAO-level tests for NULL vs. concrete-value writes, a repo-level nil case, and regenerate the mock signature.
After this fix, the narrow aggregation query's score IS NOT NULL filter is fully consistent with the old in-memory "skip nil" semantics.
━━━━━━━━━━━━━━━━━━━━━━━━━