### PR TITLE
docs: remove redundant comma and improve phrasing in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,13 @@ You can contribute to the Cozeloop project in several ways:
 * Improve documentation and code comments
 * Participate in code reviews
 
-Improvements to the core application, and documentation are all welcome. If you have any questions, please contact the project maintainers.
+Improvements to the core application and documentation are all welcome. If you have any questions, please contact the project maintainers.
 
 Before making significant changes, please open an issue to discuss your proposed changes. Make sure tests pass before submitting a pull request.
 
 ## Project Overview
 
-You could go to [README](./README.md) to find more information.
+You can refer to [README](./README.md) to find more information.
 
 ## Code Submission Process
 


### PR DESCRIPTION
## Description
This PR fixes minor punctuation and phrasing in `CONTRIBUTING.md`.

## Details
1. Removed redundant comma before conjunction (`core application, and documentation` -> `core application and documentation`).
2. Improved sentence phrasing (`You could go to` -> `You can refer to`).