### PR TITLE
[fix][evaluation] anchor strategy-4 score regex to the score key position

### DIFF
--- a/backend/modules/evaluation/domain/service/evaluator_source_prompt_impl.go
+++ b/backend/modules/evaluation/domain/service/evaluator_source_prompt_impl.go
@@ -478,7 +478,13 @@ func parseRegexExtractedJSON(ctx context.Context, content string, output *entity
 
 // parseScoreWithRegex 策略4：通过正则解析score字段，优先尝试用正则提取reason字段作为reason，否则使用完整内容作为reason
 func parseScoreWithRegex(ctx context.Context, content string, output *entity.EvaluatorOutputData) (bool, error) {
-	scoreRegex := regexp.MustCompile(`(?i)score[^0-9]*([0-9]+(?:\.[0-9]+)?)`)
+	// Anchor the `score` key before capturing digits: a quoted `"score"` must follow `{`/`,` (a real
+	// JSON field position) or the content start, and a bare `score` only at content start (prose like
+	// `score: 0.85, reason: ...`). This rejects a `score:` substring inside the `reason` value, which
+	// the previous `score[^0-9]*` silently parsed as the score (e.g. `{"score": "优秀", "reason": "请用score: 3"}`
+	// became Score=3). The lazy `[^"]*?` keeps non-digit prefixes inside a quoted value (`得分8分`->8,
+	// `90分`->90) without crossing the closing quote; `[+-]?` preserves explicit signs (scenarios 3/30/31/33-42).
+	scoreRegex := regexp.MustCompile(`(?i)(?:(?:^|[{,])\s*"score"|^\s*score)\s*:\s*"?[^"]*?([+-]?[0-9]+(?:\.[0-9]+)?)"?`)
 	scoreMatches := scoreRegex.FindStringSubmatch(content)
 	if len(scoreMatches) > 1 {
 		scoreStr := scoreMatches[1]

--- a/backend/modules/evaluation/domain/service/evaluator_source_prompt_impl_test.go
+++ b/backend/modules/evaluation/domain/service/evaluator_source_prompt_impl_test.go
@@ -1547,6 +1547,122 @@ func Test_parseContentOutput(t *testing.T) {
 		assert.Equal(t, content, output.EvaluatorResult.Reasoning) // 使用完整输出作为reason
 		assert.Nil(t, output.EvaluatorRunError)
 	})
+
+	t.Run("场景37: score为无数字字符串且reason含数字（策略4跨字段bug回归）", func(t *testing.T) {
+		// Bug回归：原策略4正则 `score[^0-9]*` 的lookahead会跨过整个reason字段值，
+		// 导致 `{"score": "优秀", "reason": "答案3个要点都覆盖了"}` 把reason里的"3"误解析为score（SCORE=3）。
+		// 修复后正则锚定到score字段值内，所有策略失败，函数返回错误，Score保持nil。
+		content := `{"score": "优秀", "reason": "答案3个要点都覆盖了"}`
+		replyItem := &entity.ReplyItem{Content: &content}
+		output := &entity.EvaluatorOutputData{
+			EvaluatorResult: &entity.EvaluatorResult{},
+		}
+
+		// Act: 调用被测函数
+		err := parseContentOutput(ctx, evaluatorVersion, replyItem, output)
+
+		// Assert: 修复前Score被错误解析为3；修复后所有策略失败
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "All parsing strategies failed")
+		assert.Nil(t, output.EvaluatorResult.Score)
+	})
+
+	t.Run("场景38: score为无数字字符串且reason也无数字（本就不可解析）", func(t *testing.T) {
+		// 无数字字符串score在策略1-4全部失败是正确行为。与场景37区分：此处reason也不含数字，
+		// 旧正则在此同样失败——本场景锁定"无数字即失败"的基线，与场景37的"误抓reason数字"形成对照。
+		content := `{"score": "优秀", "reason": "reason only text"}`
+		replyItem := &entity.ReplyItem{Content: &content}
+		output := &entity.EvaluatorOutputData{
+			EvaluatorResult: &entity.EvaluatorResult{},
+		}
+
+		// Act: 调用被测函数
+		err := parseContentOutput(ctx, evaluatorVersion, replyItem, output)
+
+		// Assert: 所有策略失败，函数返回错误
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "All parsing strategies failed")
+		assert.Nil(t, output.EvaluatorResult.Score)
+	})
+
+	t.Run("场景39: score字符串值内含单位（90分→90，策略4值内数字）", func(t *testing.T) {
+		// 守卫：锚定score值内数字不能过度限制——值内数字+单位后缀仍需解析。
+		content := `{"score": "90分", "reason": "回答正确"}`
+		replyItem := &entity.ReplyItem{Content: &content}
+		output := &entity.EvaluatorOutputData{
+			EvaluatorResult: &entity.EvaluatorResult{},
+		}
+
+		// Act: 调用被测函数
+		err := parseContentOutput(ctx, evaluatorVersion, replyItem, output)
+
+		// Assert: score值内数字被正确提取，reason正常提取
+		assert.NoError(t, err)
+		assert.NotNil(t, output.EvaluatorResult.Score)
+		assert.InDelta(t, 90.0, *output.EvaluatorResult.Score, 0.0001)
+		assert.Equal(t, "回答正确", output.EvaluatorResult.Reasoning)
+		assert.Nil(t, output.EvaluatorRunError)
+	})
+
+	t.Run("场景40: reason值内含score: N子串（跨字段leak回归，审查发现）", func(t *testing.T) {
+		// 对抗性审查发现的第二类leak：reason值内若含字面 `score: N`（如 "请用score: 3作为答案"），
+		// 旧正则的lookahead仍会跨到reason里，把3误解析为score。新正则锚定score键位置：
+		// 带引号 `"score"` 键必须在内容开头或 `{`/`,` 后，裸 score 只能在内容开头——
+		// reason 字符串值内的 `score:` 子串（前有普通字符）永不匹配。
+		content := `{"score": "优秀", "reason": "请用score: 3作为答案"}`
+		replyItem := &entity.ReplyItem{Content: &content}
+		output := &entity.EvaluatorOutputData{
+			EvaluatorResult: &entity.EvaluatorResult{},
+		}
+
+		// Act: 调用被测函数
+		err := parseContentOutput(ctx, evaluatorVersion, replyItem, output)
+
+		// Assert: 修复前Score=3（静默错误数据）；修复后所有策略失败，Score保持nil
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "All parsing strategies failed")
+		assert.Nil(t, output.EvaluatorResult.Score)
+	})
+
+	t.Run("场景41: score字符串值内中文前缀（得分8分→8，值内数字保留）", func(t *testing.T) {
+		// 守卫：键位锚定+`[^"]*?` 惰性匹配保留值内非数字前缀（中文单位），
+		// 被 `"` 边界约束不会跨到reason字段——中文前缀值仍能正确解析。
+		content := `{"score": "得分8分", "reason": "回答正确"}`
+		replyItem := &entity.ReplyItem{Content: &content}
+		output := &entity.EvaluatorOutputData{
+			EvaluatorResult: &entity.EvaluatorResult{},
+		}
+
+		// Act: 调用被测函数
+		err := parseContentOutput(ctx, evaluatorVersion, replyItem, output)
+
+		// Assert: 值内数字被提取，reason正常提取
+		assert.NoError(t, err)
+		assert.NotNil(t, output.EvaluatorResult.Score)
+		assert.InDelta(t, 8.0, *output.EvaluatorResult.Score, 0.0001)
+		assert.Equal(t, "回答正确", output.EvaluatorResult.Reasoning)
+		assert.Nil(t, output.EvaluatorRunError)
+	})
+
+	t.Run("场景42: 策略4裸键+负数（-0.3保留符号，旧正则丢符号）", func(t *testing.T) {
+		// 守卫：策略4裸键路径下，`[+-]?` 保留显式符号。旧正则 `score[^0-9]*` 会把 `: -` 一并跨过，
+		// 把 -0.3 误解析为 +0.3——新正则修复了这一潜在bug，此处锁定。
+		content := `score: -0.3, reason: "negative score"`
+		replyItem := &entity.ReplyItem{Content: &content}
+		output := &entity.EvaluatorOutputData{
+			EvaluatorResult: &entity.EvaluatorResult{},
+		}
+
+		// Act: 调用被测函数
+		err := parseContentOutput(ctx, evaluatorVersion, replyItem, output)
+
+		// Assert: 符号保留，reason通过传统方式提取
+		assert.NoError(t, err)
+		assert.NotNil(t, output.EvaluatorResult.Score)
+		assert.InDelta(t, -0.3, *output.EvaluatorResult.Score, 0.0001)
+		assert.Equal(t, "negative score", output.EvaluatorResult.Reasoning)
+		assert.Nil(t, output.EvaluatorRunError)
+	})
 }
 
 // TestEvaluatorSourcePromptServiceImpl_Run_DisableTracing 测试追踪控制核心逻辑


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title

- [x] This PR title match the format: [\<type\>][\<scope\>] \<description\>. For example: [fix][backend] flaky fix
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Add documentation if the current PR requires user awareness at the usage level.
- [x] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

[fix][evaluation] 将策略4的分数正则锚定到 score 键位置，防止从 reason 字段误取分数

#### (Optional) More detailed description for this PR

en:

**Problem.** In `parseContentOutput`, strategy 4 (`parseScoreWithRegex`) uses

```go
(?i)score[^0-9]*([0-9]+(?:\.[0-9]+)?)
```

to recover a numeric score when the value is not a plain JSON number (e.g. `{"score": "优秀", ...}` falls through strategies 1-3 and reaches strategy 4). Because the regex is anchored only on the substring `score` and captures the *first* digit run that follows it, digits inside the `reason` value are silently reported as the score.

Concrete reproductions (all currently return a wrong `Score` instead of an error):

| Input | Old behavior (Score) | Expected |
|---|---|---|
| `{"score": "优秀", "reason": "答案3个要点都覆盖了"}` | `3` | error (no numeric score) |
| `{"score": "优秀", "reason": "请用score: 3作为答案"}` | `3` | error (leak from reason) |

The secondary regex also drops an explicit sign at strategy 4: `score: -0.3, reason: ...` parsed as `+0.3`.

**Root cause.** Strategy 4 has no key-position anchor. Any `score` substring followed by a digit run — including text inside the `reason` value — is treated as the score field/value.

**Fix.** Anchor the match to the real key position:

```go
(?i)(?:(?:^|[{,])\s*"score"|^\s*score)\s*:\s*"?[^"]*?([+-]?[0-9]+(?:\.[0-9]+)?)"?
```

- A quoted `"score"` key must appear at content start or right after `{`/`,` (a real JSON field position); a bare `score` only at content start (prose like `score: 0.85, reason: ...`).
- The lazy `[^"]*?` preserves non-digit prefixes inside a quoted value (`得分8分` → `8`, `90分` → `90`) without crossing the closing quote.
- `[+-]?` preserves an explicit sign, which the old `[^0-9]*` ate (`-0.3` → `+0.3`).

**Tests.** Added scenarios 37-42 to `Test_parseContentOutput` covering the motivating regression, the reason-field leak, digit-less no-match, Chinese unit suffixes, and sign preservation. Full suite: 42/42 pass; `go build` pass; `gofmt` clean.

**Behavior change & relation to #257.** Strategy 4 now only accepts a score anchored to a real key position: a JSON `"score"` field (at content start or right after `{`/`,`) or prose that *starts* with `score:`. Loose prose where the word appears mid-sentence (`The final score is 3`) now fails loudly instead of being silently parsed — deliberate, because the leak can only be eliminated by anchoring to the key position, and a loud failure is strictly better than a silently wrong score.

This also connects to #257's "sometimes a normal response": a non-numeric score whose `reason` contains digits previously produced a *wrong* score that looked like a normal response; this PR makes that case fail loudly instead. The digit-less class (no ASCII digits at all) remains unhandled, as discussed in the issue thread.

zh(optional):

**问题。** `parseContentOutput` 的策略4（`parseScoreWithRegex`）用 `(?i)score[^0-9]*([0-9]+...)` 在值不是纯 JSON 数字时（如 `{"score": "优秀", ...}` 落到策略4）尝试恢复分数。因为正则只锚定 `score` 子串并捕获其后第一个数字串，reason 值里的数字会被静默当作分数。

| 输入 | 旧行为（Score） | 预期 |
|---|---|---|
| `{"score": "优秀", "reason": "答案3个要点都覆盖了"}` | `3` | 报错（无数字分数） |
| `{"score": "优秀", "reason": "请用score: 3作为答案"}` | `3` | 报错（从 reason 泄漏） |

**修复。** 把匹配锚定到真实键位置（quoted `"score"` 须在内容起始或 `{`/`,` 之后；裸 `score` 仅在内容起始）。惰性 `[^"]*?` 保留带引号值内的非数字前缀且不跨过收引号；`[+-]?` 保留显式符号。

**测试。** `Test_parseContentOutput` 新增场景37-42：触发回归、reason 泄漏、无数字不匹配、中文单位后缀、符号保留。全量 42/42 通过；`go build` 通过；`gofmt` 干净。

**行为变更与 #257 的关系。** 策略4 现在只接受锚定在真实键位置的分数：JSON `"score"` 字段（内容起始或 `{`/`,` 之后）、或以 `score:` 开头的散文。句中出现的松散 `score`（如 `The final score is 3`）现在响亮失败而非静默解析——这是有意的：泄漏只能靠键位锚定消除，响亮失败严格优于静默错分。这也解释了 #257「有时正常响应」可能是错分：非数字 score 且 reason 含数字时旧代码返回错分（看似正常），本 PR 让其响亮失败；全无 ASCII 数字类仍未处理（见 issue 讨论）。

#### (Optional) Which issue(s) this PR fixes

Related to #257 (score parsing).
