### PR TITLE
fix: [BUG] [make compose up failed] panic: failed to start tenant "cozeloop"

### DIFF
--- a/release/deployment/docker-compose/bootstrap/rmq-init/entrypoint.sh
+++ b/release/deployment/docker-compose/bootstrap/rmq-init/entrypoint.sh
@@ -20,6 +20,19 @@ print_banner "Starting..."
 
 MQADMIN_CMD="${ROCKETMQ_HOME}/bin/mqadmin"
 MQNAMESRV_ADDR=coze-loop-rmq-namesrv:9876
+MQADMIN_MAX_ATTEMPTS=3
+
+retry_mqadmin() {
+  local attempt
+  for ((attempt = 1; attempt <= MQADMIN_MAX_ATTEMPTS; attempt++)); do
+    if "${MQADMIN_CMD}" "$@"; then
+      return 0
+    fi
+    echo "[!] 'mqadmin $1' failed (attempt ${attempt}/${MQADMIN_MAX_ATTEMPTS})" >&2
+    sleep 2
+  done
+  return 1
+}
 
 declare -A topics
 {
@@ -46,13 +59,14 @@ for i in $(seq 1 60); do
 done
 
 i=1
+pids=()
 for topic in "${!topics[@]}"; do
   ii=$i
   (
     echo "+ Check if topic#$ii('$topic') exists..."
     if ! "${MQADMIN_CMD}" topicList -n "${MQNAMESRV_ADDR}" | grep -q "^$topic$"; then
       echo "[+] Topic#$ii('$topic') not exists, now creating..."
-      "${MQADMIN_CMD}" updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$topic" -r 8 -w 8
+      retry_mqadmin updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$topic" -r 8 -w 8
     else
       echo "[-] Topic#$ii('$topic') already exists."
     fi
@@ -63,11 +77,11 @@ for topic in "${!topics[@]}"; do
       echo "++ Check if consumer#$ii-$j('$group') exists..."
       if ! "${MQADMIN_CMD}" consumerProgress -n "${MQNAMESRV_ADDR}" | grep -q "^$group$"; then
         echo "[++] Consumer#$ii-$j('$group') not exists, now creating..."
-        "${MQADMIN_CMD}" updateSubGroup -n "${MQNAMESRV_ADDR}" -c DefaultCluster -g "$group"
+        retry_mqadmin updateSubGroup -n "${MQNAMESRV_ADDR}" -c DefaultCluster -g "$group"
 
         retry_topic="%RETRY%$group"
         echo "[+++] Consumer#$ii-$j('$group')'s related retry topic('$retry_topic') is creating..."
-        "${MQADMIN_CMD}" updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$retry_topic" -r 8 -w 8
+        retry_mqadmin updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$retry_topic" -r 8 -w 8
       else
         echo "[--] Consumer#$ii-$j('$group')' already exists."
       fi
@@ -76,9 +90,33 @@ for topic in "${!topics[@]}"; do
 
     echo "+ Topic#$ii('$topic') is ready! (with it's consumers and retry topics)"
   ) &
+  pids+=("$!")
   i=$((i + 1))
 done
 
-wait
+init_failed=0
+for pid in "${pids[@]}"; do
+  if ! wait "${pid}"; then
+    init_failed=1
+  fi
+done
+
+if [ "${init_failed}" -ne 0 ]; then
+  echo "[ERROR] RMQ init failed: at least one topic or consumer group could not be created."
+  exit 1
+fi
+
+registered_topics="$(retry_mqadmin topicList -n "${MQNAMESRV_ADDR}")"
+missing_topics=()
+for topic in "${!topics[@]}"; do
+  if ! grep -q "^${topic}$" <<< "${registered_topics}"; then
+    missing_topics+=("${topic}")
+  fi
+done
+
+if [ "${#missing_topics[@]}" -ne 0 ]; then
+  echo "[ERROR] RMQ init failed: topics missing from namesrv route table: ${missing_topics[*]}"
+  exit 1
+fi
 
 print_banner "Completed!"

--- a/release/deployment/helm-chart/charts/app/bootstrap/init/rmq/entrypoint.sh
+++ b/release/deployment/helm-chart/charts/app/bootstrap/init/rmq/entrypoint.sh
@@ -20,6 +20,19 @@ print_banner "RMQ Init Starting..."
 
 MQADMIN_CMD="${ROCKETMQ_HOME}/bin/mqadmin"
 MQNAMESRV_ADDR=coze-loop-rmq-namesrv:9876
+MQADMIN_MAX_ATTEMPTS=3
+
+retry_mqadmin() {
+  local attempt
+  for ((attempt = 1; attempt <= MQADMIN_MAX_ATTEMPTS; attempt++)); do
+    if "${MQADMIN_CMD}" "$@"; then
+      return 0
+    fi
+    echo "[!] 'mqadmin $1' failed (attempt ${attempt}/${MQADMIN_MAX_ATTEMPTS})" >&2
+    sleep 2
+  done
+  return 1
+}
 
 declare -A topics
 {
@@ -46,13 +59,14 @@ for i in $(seq 1 60); do
 done
 
 i=1
+pids=()
 for topic in "${!topics[@]}"; do
   ii=$i
   (
     echo "+ Check if topic#$ii('$topic') exists..."
     if ! "${MQADMIN_CMD}" topicList -n "${MQNAMESRV_ADDR}" | grep -q "^$topic$"; then
       echo "[+] Topic#$ii('$topic') not exists, now creating..."
-      "${MQADMIN_CMD}" updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$topic" -r 8 -w 8
+      retry_mqadmin updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$topic" -r 8 -w 8
     else
       echo "[-] Topic#$ii('$topic') already exists."
     fi
@@ -63,11 +77,11 @@ for topic in "${!topics[@]}"; do
       echo "++ Check if consumer#$ii-$j('$group') exists..."
       if ! "${MQADMIN_CMD}" consumerProgress -n "${MQNAMESRV_ADDR}" | grep -q "^$group$"; then
         echo "[++] Consumer#$ii-$j('$group') not exists, now creating..."
-        "${MQADMIN_CMD}" updateSubGroup -n "${MQNAMESRV_ADDR}" -c DefaultCluster -g "$group"
+        retry_mqadmin updateSubGroup -n "${MQNAMESRV_ADDR}" -c DefaultCluster -g "$group"
 
         retry_topic="%RETRY%$group"
         echo "[+++] Consumer#$ii-$j('$group')'s related retry topic('$retry_topic') is creating..."
-        "${MQADMIN_CMD}" updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$retry_topic" -r 8 -w 8
+        retry_mqadmin updateTopic -n "${MQNAMESRV_ADDR}" -c DefaultCluster -t "$retry_topic" -r 8 -w 8
       else
         echo "[--] Consumer#$ii-$j('$group')' already exists."
       fi
@@ -76,9 +90,33 @@ for topic in "${!topics[@]}"; do
 
     echo "+ Topic#$ii('$topic') is ready! (with it's consumers and retry topics)"
   ) &
+  pids+=("$!")
   i=$((i + 1))
 done
 
-wait
+init_failed=0
+for pid in "${pids[@]}"; do
+  if ! wait "${pid}"; then
+    init_failed=1
+  fi
+done
+
+if [ "${init_failed}" -ne 0 ]; then
+  echo "[ERROR] RMQ init failed: at least one topic or consumer group could not be created."
+  exit 1
+fi
+
+registered_topics="$(retry_mqadmin topicList -n "${MQNAMESRV_ADDR}")"
+missing_topics=()
+for topic in "${!topics[@]}"; do
+  if ! grep -q "^${topic}$" <<< "${registered_topics}"; then
+    missing_topics+=("${topic}")
+  fi
+done
+
+if [ "${#missing_topics[@]}" -ne 0 ]; then
+  echo "[ERROR] RMQ init failed: topics missing from namesrv route table: ${missing_topics[*]}"
+  exit 1
+fi
 
 print_banner "RMQ Init Completed!"


### PR DESCRIPTION
Fixes #515

## Root cause

RocketMQ init container reports success even when topic creation fails

## Changes

- Made the RMQ bootstrap init script fail loudly instead of silently: per-topic background jobs are now waited on individually so any failure sets a non-zero exit, mutating `mqadmin` calls (updateTopic/updateSubGroup) are retried up to 3 times, and a final verification asserts every configured topic is present in the namesrv topic list before the init container reports completion. Mirrored identically in the docker-compose and Helm bootstrap copies.