### PR TITLE
[fix][evaluation] guard nil BaseInfo and nil correction to prevent panics in experiment result and record correction paths

### DIFF
--- a/backend/modules/evaluation/application/convertor/target/eval_target_record.go
+++ b/backend/modules/evaluation/application/convertor/target/eval_target_record.go
@@ -34,16 +34,14 @@ func EvalTargetRecordDO2DTO(src *entity.EvalTargetRecord) *eval_target.EvalTarge
 		EvalTargetInputData:  InputDO2DTO(src.EvalTargetInputData),
 		EvalTargetOutputData: OutputDO2DTO(src.EvalTargetOutputData),
 		Status:               StatusDO2DTO(src.Status),
-		BaseInfo: &common.BaseInfo{
-			// TODO
-			// CreatedBy: src.BaseInfo.CreatedBy,
-			// UpdatedBy: src.BaseInfo.UpdatedBy,
-			CreatedAt: src.BaseInfo.CreatedAt,
-			UpdatedAt: src.BaseInfo.UpdatedAt,
-			DeletedAt: src.BaseInfo.DeletedAt,
-		},
+		BaseInfo:             &common.BaseInfo{},
 	}
+	// src.BaseInfo 可能为 nil（线上 SG 已出现此类 target record），必须判空后再取字段，
+	// 否则 BatchGetExperimentResult 会因单条记录 panic 整次请求，网关侧表现为 502。
 	if src.BaseInfo != nil {
+		// TODO
+		// res.BaseInfo.CreatedBy = src.BaseInfo.CreatedBy
+		// res.BaseInfo.UpdatedBy = src.BaseInfo.UpdatedBy
 		res.BaseInfo.CreatedAt = src.BaseInfo.CreatedAt
 		res.BaseInfo.UpdatedAt = src.BaseInfo.UpdatedAt
 		res.BaseInfo.DeletedAt = src.BaseInfo.DeletedAt

--- a/backend/modules/evaluation/application/convertor/target/eval_target_record_test.go
+++ b/backend/modules/evaluation/application/convertor/target/eval_target_record_test.go
@@ -87,6 +87,19 @@ func TestEvalTargetRecordConversions(t *testing.T) {
 	assert.False(t, UnixMsPtr2Time(gptr.Of(int64(123))).IsZero())
 }
 
+// TestEvalTargetRecordDO2DTO_NilBaseInfo 覆盖 BaseInfo 为 nil 的记录：
+// 历史实现直接访问 src.BaseInfo.CreatedAt，会 panic 并把 BatchGetExperimentResult 打挂成 502。
+func TestEvalTargetRecordDO2DTO_NilBaseInfo(t *testing.T) {
+	assert.NotPanics(t, func() {
+		dto := EvalTargetRecordDO2DTO(&entity.EvalTargetRecord{ID: 1, BaseInfo: nil})
+		assert.NotNil(t, dto)
+		assert.NotNil(t, dto.BaseInfo)
+		assert.Nil(t, dto.BaseInfo.CreatedAt)
+		assert.Nil(t, dto.BaseInfo.UpdatedAt)
+		assert.Nil(t, dto.BaseInfo.DeletedAt)
+	})
+}
+
 func TestToInvokeOutputDataDO(t *testing.T) {
 	successStatus := spi.InvokeEvalTargetStatus_SUCCESS
 	contentType := spi.ContentTypeText

--- a/backend/modules/evaluation/application/eval_openapi_app.go
+++ b/backend/modules/evaluation/application/eval_openapi_app.go
@@ -3164,6 +3164,9 @@ func (e *EvalOpenAPIApplication) CorrectEvaluatorRecordOApi(ctx context.Context,
 	if req == nil {
 		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("req is nil"))
 	}
+	if req.Correction == nil {
+		return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("correction is nil"))
+	}
 
 	record, err := e.evaluatorRecordService.GetEvaluatorRecord(ctx, req.GetEvaluatorRecordID(), false)
 	if err != nil {

--- a/backend/modules/evaluation/application/eval_openapi_app_test.go
+++ b/backend/modules/evaluation/application/eval_openapi_app_test.go
@@ -5734,10 +5734,27 @@ func TestEvalOpenAPIApplication_CorrectEvaluatorRecordOApi(t *testing.T) {
 			wantErr: errno.CommonInvalidParamCode,
 		},
 		{
+			name: "nil correction",
+			req: &openapi.CorrectEvaluatorRecordOApiRequest{
+				WorkspaceID:       gptr.Of(workspaceID),
+				EvaluatorRecordID: gptr.Of(recordID),
+			},
+			setup: func(auth *rpcmocks.MockIAuthProvider, recordSvc *servicemocks.MockEvaluatorRecordService) {
+				// correction 缺失应在任何下游调用前返回结构化参数错误，而不是透传到领域层 panic
+				auth.EXPECT().AuthorizationWithoutSPI(gomock.Any(), gomock.Any()).Times(0)
+				recordSvc.EXPECT().GetEvaluatorRecord(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				recordSvc.EXPECT().CorrectEvaluatorRecord(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			},
+			wantErr: errno.CommonInvalidParamCode,
+		},
+		{
 			name: "record not found",
 			req: &openapi.CorrectEvaluatorRecordOApiRequest{
 				WorkspaceID:       gptr.Of(workspaceID),
 				EvaluatorRecordID: gptr.Of(recordID),
+				Correction: &openapiEvaluator.Correction{
+					Score: gptr.Of(0.8),
+				},
 			},
 			setup: func(_ *rpcmocks.MockIAuthProvider, recordSvc *servicemocks.MockEvaluatorRecordService) {
 				recordSvc.EXPECT().GetEvaluatorRecord(gomock.Any(), recordID, false).Return(nil, nil)
@@ -5749,6 +5766,9 @@ func TestEvalOpenAPIApplication_CorrectEvaluatorRecordOApi(t *testing.T) {
 			req: &openapi.CorrectEvaluatorRecordOApiRequest{
 				WorkspaceID:       gptr.Of(workspaceID),
 				EvaluatorRecordID: gptr.Of(recordID),
+				Correction: &openapiEvaluator.Correction{
+					Score: gptr.Of(0.8),
+				},
 			},
 			setup: func(auth *rpcmocks.MockIAuthProvider, recordSvc *servicemocks.MockEvaluatorRecordService) {
 				record := &entity.EvaluatorRecord{

--- a/backend/modules/evaluation/domain/service/evaluator_record_impl.go
+++ b/backend/modules/evaluation/domain/service/evaluator_record_impl.go
@@ -17,6 +17,8 @@ import (
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/events"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/repo"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/pkg/errno"
+	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
 	"github.com/coze-dev/coze-loop/backend/pkg/lang/ptr"
 	"github.com/coze-dev/coze-loop/backend/pkg/logs"
 )
@@ -65,6 +67,12 @@ type EvaluatorRecordServiceImpl struct {
 
 // CorrectEvaluatorRecord 创建 evaluator_version 运行结果
 func (s *EvaluatorRecordServiceImpl) CorrectEvaluatorRecord(ctx context.Context, evaluatorRecordDO *entity.EvaluatorRecord, correctionDO *entity.Correction) error {
+	if evaluatorRecordDO == nil {
+		return errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("evaluator record is nil"))
+	}
+	if correctionDO == nil {
+		return errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg("correction is nil"))
+	}
 	userIDInContext := session.UserIDInCtxOrEmpty(ctx)
 	correctionDO.UpdatedBy = userIDInContext
 	if evaluatorRecordDO.EvaluatorOutputData == nil {

--- a/backend/modules/evaluation/domain/service/evaluator_record_impl_test.go
+++ b/backend/modules/evaluation/domain/service/evaluator_record_impl_test.go
@@ -254,6 +254,50 @@ func TestEvaluatorRecordServiceImpl_CorrectEvaluatorRecord(t *testing.T) {
 	}
 }
 
+// TestEvaluatorRecordServiceImpl_CorrectEvaluatorRecord_NilParams 覆盖入参为 nil 的场景：
+// 历史实现直接执行 correctionDO.UpdatedBy = ...，correction 缺失时会 panic（CorrectEvaluatorRecordOApi 线上已复现）。
+// 期望返回参数错误，且不触碰 repo / publisher。
+func TestEvaluatorRecordServiceImpl_CorrectEvaluatorRecord_NilParams(t *testing.T) {
+	cases := []struct {
+		name         string
+		recordDO     *entity.EvaluatorRecord
+		correctionDO *entity.Correction
+	}{
+		{name: "correction 为 nil", recordDO: &entity.EvaluatorRecord{ID: 1}, correctionDO: nil},
+		{name: "record 为 nil", recordDO: nil, correctionDO: &entity.Correction{}},
+		{name: "两者都为 nil", recordDO: nil, correctionDO: nil},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockRepo := repo_mocks.NewMockIEvaluatorRecordRepo(ctrl)
+			mockExptPublisher := mocks.NewMockExptEventPublisher(ctrl)
+			mockEvaluatorPublisher := mocks.NewMockEvaluatorEventPublisher(ctrl)
+			mockExptRepo := repo_mocks.NewMockIExperimentRepo(ctrl)
+			// 参数校验应在任何下游调用之前拦截
+			mockRepo.EXPECT().CorrectEvaluatorRecord(gomock.Any(), gomock.Any()).Times(0)
+			mockExptRepo.EXPECT().GetByID(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+			s := &EvaluatorRecordServiceImpl{
+				evaluatorRecordRepo: mockRepo,
+				exptPublisher:       mockExptPublisher,
+				evaluatorPublisher:  mockEvaluatorPublisher,
+				exptRepo:            mockExptRepo,
+			}
+
+			var err error
+			assert.NotPanics(t, func() {
+				err = s.CorrectEvaluatorRecord(session.WithCtxUser(context.Background(), &session.User{ID: "u1"}), c.recordDO, c.correctionDO)
+			})
+			assert.Error(t, err)
+		})
+	}
+}
+
 // TestNewEvaluatorRecordServiceImpl 测试构造函数
 func TestNewEvaluatorRecordServiceImpl(t *testing.T) {
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
What type of PR is this?
fix
Check the PR title
[x] This PR title match the format: [<type>][<scope>] <description>
[x] The description of this PR title is user-oriented and clear enough for others to understand.
[ ] Add documentation if the current PR requires user awareness at the usage level.
[x] This PR is written in English. PRs not in English will not be reviewed.
(Optional) More detailed description for this PR
Fixes two independent nil pointer dereferences in the evaluation module. Both follow the same shape: a pointer field is dereferenced before it is checked, so a single record or request with a missing optional field takes down the whole call instead of degrading gracefully.
1. EvalTargetRecordDO2DTO dereferences src.BaseInfo unconditionally
The DTO is built with CreatedAt: src.BaseInfo.CreatedAt inside the struct literal. The if src.BaseInfo != nil check below it is dead as a guard, because the dereference already happened while evaluating the literal.
BaseInfo is an optional field on EvalTargetRecord, so any record that has it unset panics the conversion. Since this convertor runs in the fan-out of BatchGetExperimentResult, one such record fails the entire batch rather than just its own row, and the caller sees a 5xx instead of partial results.
Fix: initialize an empty BaseInfo in the literal and populate the timestamps inside the existing nil check. The CreatedBy / UpdatedBy TODOs move with them, so they are guarded too when someone eventually fills them in.
2. CorrectEvaluatorRecord dereferences correctionDO on its first line
EvaluatorRecordServiceImpl.CorrectEvaluatorRecord starts with correctionDO.UpdatedBy = userIDInContext, before any validation. The method already defensively initializes EvaluatorOutputData, EvaluatorResult and BaseInfo a few lines further down, so the intent is clearly to tolerate a sparsely populated record — the correction argument was simply missed.
Correction is optional in the request, and OpenAPICorrectionDTO2DO returns nil for a nil DTO by design. So a CorrectEvaluatorRecordOApi call that omits correction reaches the domain service with correctionDO == nil and panics on a caller mistake that should have been a 4xx.
Fix, at two levels:
domain service: reject nil evaluatorRecordDO / correctionDO with
CommonInvalidParamCode before touching either.
OpenAPI handler: validate req.Correction up front, so a malformed request
gets a structured invalid-param error and never reaches the domain layer.
Tests
Three regression tests, one per guarded entry point:
TestEvalTargetRecordDO2DTO_NilBaseInfo — a record with BaseInfo: nil
converts without panicking and yields a non-nil, empty BaseInfo.
TestEvaluatorRecordServiceImpl_CorrectEvaluatorRecord_NilParams — all three
nil combinations return an error, and the repo / publisher mocks assert
Times(0) so validation is proven to run before any side effect.
eval_openapi_app_test.go gains a nil correction case asserting
CommonInvalidParamCode with auth and the record service never invoked.
Each test was checked against the unpatched code and fails there with invalid memory address or nil pointer dereference, so they pin the actual defect rather than passing vacuously.
Two pre-existing cases in TestEvalOpenAPIApplication_CorrectEvaluatorRecordOApi (record not found, auth failed) omitted Correction and are now short-circuited by the new up-front check. They were given a valid correction so they still exercise their intended paths.
Note for reviewers: these packages need -gcflags="all=-N -l" (required by mockey); without it unrelated cases fail their own self-check.
