### PR TITLE
[fix][foundation] keep upload keys platform-independent

### DIFF
--- a/backend/modules/foundation/domain/file/service/server.go
+++ b/backend/modules/foundation/domain/file/service/server.go
@@ -13,7 +13,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"path/filepath"
+	"path"
 	"time"
 
 	"github.com/google/uuid"
@@ -50,7 +50,7 @@ func (fs fileService) UploadLoopFile(ctx context.Context, fileHeader *multipart.
 	if fileName == "" {
 		return "", errorx.NewByCode(errno.CommonInvalidParamCode)
 	}
-	fileName = filepath.Join(spaceID, "/", fileName)
+	fileName = path.Join(spaceID, "/", fileName)
 
 	f, err := fileHeader.Open()
 	if err != nil {
@@ -131,7 +131,7 @@ func (fs fileService) UploadFileForServer(ctx context.Context, mimeType string, 
 	}
 
 	// Build full path with workspace ID
-	fullPath := filepath.Join(spaceID, "/", fileName)
+	fullPath := path.Join(spaceID, "/", fileName)
 
 	// Detect content type from file data
 	fileContentType := http.DetectContentType(body)


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title

- [x] This PR title matches the format: `[<type>][<scope>] <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] No usage-level documentation is required for this internal portability fix.
- [x] This PR is written in English.

#### (Optional) Translate the PR title into Chinese

`[fix][foundation] 保持上传对象键与平台无关`

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)

en:

Object-storage keys must use `/` separators regardless of the server operating system. The upload service currently uses `filepath.Join`, which produces backslashes on Windows and breaks the existing key contract. This change uses the slash-oriented `path.Join` for both upload paths. Existing tests cover named and generated keys on all platforms.

zh(optional):

对象存储键应在所有操作系统上保持 `/` 分隔符。本修复在两条上传路径中使用 `path.Join`，避免 Windows 上生成反斜杠键。

#### Validation

- `go test -count=1 -run 'TestFileServiceImpl_Upload(LoopFile|FileForServer)$' -v ./modules/foundation/domain/file/service`
- `go test -count=1 ./modules/foundation/domain/file/service`
- `go test -count=1 ./modules/foundation/...`
- `go vet ./modules/foundation/domain/file/service`
- `go build ./modules/foundation/...`

#### (Optional) Which issue(s) this PR fixes

Fixes #629