### PR TITLE
[fix][llm] preserve ToolCall.Extra when converting DO tool calls to eino schema

### DIFF
--- a/backend/modules/llm/domain/entity/eino_convertor.go
+++ b/backend/modules/llm/domain/entity/eino_convertor.go
@@ -83,6 +83,7 @@ func FromDOToolCall(t *ToolCall) schema.ToolCall {
 		ID:       t.ID,
 		Type:     t.Type,
 		Function: FromDOFunctionCall(t.Function),
+		Extra:    t.Extra,
 	}
 }
 

--- a/backend/modules/llm/domain/entity/eino_convertor_test.go
+++ b/backend/modules/llm/domain/entity/eino_convertor_test.go
@@ -92,11 +92,48 @@ func TestFromDOToolCalls(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Regression test: FromDOToolCall previously dropped Extra when
+			// converting a stored ToolCall back into an eino schema.ToolCall
+			// for an outbound model request, silently losing any
+			// provider-specific metadata attached to a prior tool call
+			// (e.g. on a follow-up turn in a multi-turn tool-calling
+			// conversation), even though ToDOToolCall correctly preserves it
+			// in the reverse direction.
+			name: "test from do tool calls preserves extra",
+			args: args{
+				ts: []*ToolCall{
+					{
+						Index: ptr.Of(int64(0)),
+						ID:    "id2",
+						Type:  "function",
+						Function: &FunctionCall{
+							Name:      "name2",
+							Arguments: "args2",
+						},
+						Extra: map[string]any{"signature": "abc123"},
+					},
+				},
+			},
+			want: []schema.ToolCall{
+				{
+					Index: ptr.Of(0),
+					ID:    "id2",
+					Type:  "function",
+					Function: schema.FunctionCall{
+						Name:      "name2",
+						Arguments: "args2",
+					},
+					Extra: map[string]any{"signature": "abc123"},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, len(tt.want), len(FromDOToolCalls(tt.args.ts)))
 			assert.Equal(t, tt.want[0].Function.Arguments, FromDOToolCalls(tt.args.ts)[0].Function.Arguments)
+			assert.Equal(t, tt.want[0].Extra, FromDOToolCalls(tt.args.ts)[0].Extra)
 		})
 	}
 }


### PR DESCRIPTION
### What

`FromDOToolCall` (`entity.ToolCall` -> eino `schema.ToolCall`, in `backend/modules/llm/domain/entity/eino_convertor.go`) dropped the `Extra` field. Both types define an identical `map[string]any` `Extra` field, and the reverse conversion `ToDOToolCall` already copies it correctly - this was a one-directional gap, not an intentional omission.

### Why it matters

`FromDOMessages`/`FromDOMessage` (which call `FromDOToolCall` via `FromDOToolCalls`) are used directly as the outbound message input to `chatModel.Generate`/`Stream` in `backend/modules/llm/domain/service/llmimpl/eino/llm.go` - i.e. this conversion is applied to stored conversation history right before it's sent back to the model. Any provider-specific metadata a model attached to a prior tool call (stored in `ToolCall.Extra` by `ToDOToolCall` when that response first came in) was silently lost on every subsequent turn of a multi-turn tool-calling conversation.

### Fix

Add the missing `Extra: t.Extra` assignment - a direct one-line mirror of what `ToDOToolCall` already does in the other direction.

### Testing

Added a regression test case (`TestFromDOToolCalls`) with a populated `Extra` map, and extended the test's assertions to actually check `Extra` equality - the existing test case only covered the nil case (`Extra: nil` on both sides), which is exactly why this asymmetry wasn't caught before.

I don't have a local Go toolchain available in this environment, so I could not run `go test`/`go vet` myself. I verified the fix by reading the current `cloudwego/eino` source directly (`schema/message.go`) to confirm `schema.ToolCall.Extra` exists with a matching `map[string]any` type on both sides, rather than assuming. Happy to address any CI feedback.

### Checklist
- [x] Read CONTRIBUTING.md
- [x] Added tests covering the fix
- [ ] Ran `go test` locally (not possible in this environment - see note above)