### PR TITLE
fix(evaluation): 修复实验模板列表 ORDER BY SQL 注入

### DIFF
--- a/backend/modules/evaluation/infra/repo/experiment/mysql/expt_template.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/expt_template.go
@@ -258,7 +258,7 @@ func (d *exptTemplateDAOImpl) toConditions(f *entity.ExptTemplateListFilter, ord
 	ordered := false
 	for _, orderBy := range orders {
 		column := gptr.Indirect(orderBy.Field)
-		if len(column) == 0 {
+		if !exptTemplateSortColumns[column] {
 			continue
 		}
 
@@ -282,4 +282,22 @@ func (d *exptTemplateDAOImpl) toConditions(f *entity.ExptTemplateListFilter, ord
 	}
 
 	return conditions, true
+}
+
+// ORDER BY 的列名直接拼进 SQL，只放行 expt_template 的真实列，其余一律忽略
+var exptTemplateSortColumns = map[string]bool{
+	"id":                  true,
+	"space_id":            true,
+	"name":                true,
+	"description":         true,
+	"eval_set_id":         true,
+	"eval_set_version_id": true,
+	"target_id":           true,
+	"target_type":         true,
+	"target_version_id":   true,
+	"expt_type":           true,
+	"created_by":          true,
+	"updated_by":          true,
+	"created_at":          true,
+	"updated_at":          true,
 }

--- a/backend/modules/evaluation/infra/repo/experiment/mysql/expt_template_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/mysql/expt_template_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mysql
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/bytedance/gg/gptr"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/mysql/gorm_gen/model"
+)
+
+func TestExptTemplateDAOImpl_toConditions_OrderByColumnWhitelist(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		field     string
+		wantOrder string
+	}{
+		{
+			name:      "合法列按请求排序",
+			field:     "updated_at",
+			wantOrder: "ORDER BY updated_at desc",
+		},
+		{
+			name:      "注入 payload 被忽略，回落默认排序",
+			field:     "(SELECT UPDATEXML(1,CONCAT(0x7e,database(),0x7e),1))",
+			wantOrder: "ORDER BY created_at desc",
+		},
+		{
+			name:      "未知列被忽略，回落默认排序",
+			field:     "not_a_column",
+			wantOrder: "ORDER BY created_at desc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sqlDB, _, err := sqlmock.New()
+			assert.NoError(t, err)
+			defer func() { _ = sqlDB.Close() }()
+
+			gormDB, err := gorm.Open(mysql.New(mysql.Config{
+				Conn:                      sqlDB,
+				SkipInitializeWithVersion: true,
+			}), &gorm.Config{DryRun: true})
+			assert.NoError(t, err)
+
+			d := &exptTemplateDAOImpl{}
+			conds, ok := d.toConditions(nil, []*entity.OrderBy{{Field: gptr.Of(tt.field)}})
+			assert.True(t, ok)
+
+			tx := gormDB.Model(&model.ExptTemplate{})
+			for _, cond := range conds {
+				tx = cond(tx)
+			}
+			var templates []*model.ExptTemplate
+			tx.Find(&templates)
+
+			sql := tx.Statement.SQL.String()
+			assert.Contains(t, sql, tt.wantOrder)
+			assert.NotContains(t, sql, "UPDATEXML")
+		})
+	}
+}


### PR DESCRIPTION
ListExperimentTemplates 的 order_bys[].field 未经校验直接拼进 ORDER BY， 可构造报错注入读取库名/版本/用户。改为按 expt_template 真实列名白名单放行，
非法列忽略并回落默认排序，与同包 expt.go 的做法保持一致。

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
