### PR TITLE
[fix][evaluation] retry item-complete mq send on failure via next sch…

### DIFF
--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl.go
@@ -461,11 +461,14 @@ func (e *ExptSchedulerImpl) recordEvalItemRunLogs(ctx context.Context, event *en
 		}
 
 		// item-complete(success) 发送点: 每个 item 一进来先发, 仅发成功行(fail/zombie 不发, 下游只消费成功行)。
-		// 发送作为旁路, 只读不写 result_state, 发失败在 sendItemComplete 内 CtxError + return(仅本 item), 不阻断落库/后续。
-		// 是否真正投递由 producer 依空间开关(item_complete_space_config) + 评测对象 enable_analysis 判定, 此处不重复判。
-		// 不追求消竞态: 下游侧 defer 投递已覆盖读侧就绪窗口, 本处只保障"成功行必发一次 MQ"。
+		// 发失败必须 return 中断本次调度: 此处在 RecordItemRunLogs 落库之前, item 落库状态仍为 complete,
+		// 下次调度会重新扫入 completeItems 再次驱动发送, 从而保障"成功行必发一次 MQ"(发失败靠下次调度补发)。
+		// 是否真正投递由 producer 依空间开关(item_complete_space_config) + 评测对象 enable_analysis 判定, 此处不重复判;
+		// 条件不满足时 producer 返回 nil(skip, 非失败), 不会触发 return。
 		if e.itemCompletePublisher != nil && item.State == entity.ItemRunState_Success {
-			e.sendItemComplete(ctx, event, expt, item, itemMeta[item.ItemID], itemVer[item.ItemID])
+			if err := e.sendItemComplete(ctx, event, expt, item, itemMeta[item.ItemID], itemVer[item.ItemID]); err != nil {
+				return err
+			}
 		}
 
 		var turnEvaluatorRefs []*entity.ExptTurnEvaluatorResultRef
@@ -596,16 +599,20 @@ func (e *ExptSchedulerImpl) resolveItemCompleteMeta(ctx context.Context, event *
 	return itemMeta, itemVer
 }
 
-// sendItemComplete 组装并发送单行 item-complete(success) 事件。发送失败打 CtxError 告警但不阻断(靠下游 defer/幂等兜底)。
-func (e *ExptSchedulerImpl) sendItemComplete(ctx context.Context, event *entity.ExptScheduleEvent, expt *entity.Experiment, item *entity.ExptEvalItem, evalSetItem *entity.EvaluationSetItem, evalSetVersionID int64) {
+// sendItemComplete 组装并发送单行 item-complete(success) 事件。
+// 发送失败返回 error, 由调用方中断本次调度、靠下次调度重扫 completeItems 补发; 元数据缺失属组装侧问题, 跳过不阻断。
+func (e *ExptSchedulerImpl) sendItemComplete(ctx context.Context, event *entity.ExptScheduleEvent, expt *entity.Experiment, item *entity.ExptEvalItem, evalSetItem *entity.EvaluationSetItem, evalSetVersionID int64) error {
+	// 元数据缺失(resolveItemCompleteMeta 已 CtxWarn)无法靠重试恢复, 跳过不阻断本次调度。
 	if evalSetItem == nil {
 		logs.CtxWarn(ctx, "[ExptEval] item complete meta missing, skip publish, expt_id: %v, item_id: %v", event.ExptID, item.ItemID)
-		return
+		return nil
 	}
 	completeEvent := buildItemCompleteEventFromScheduler(event.SpaceID, event.ExptID, event.ExptRunID, expt, item, evalSetItem, evalSetVersionID)
 	if err := e.itemCompletePublisher.PublishItemComplete(ctx, completeEvent); err != nil {
 		logs.CtxError(ctx, "[ExptEval] publish item complete event failed, expt_id: %v, item_id: %v, err: %v", event.ExptID, item.ItemID, err)
+		return err
 	}
+	return nil
 }
 
 func (e *ExptSchedulerImpl) handleToSubmits(ctx context.Context, event *entity.ExptScheduleEvent, toSubmits []*entity.ExptEvalItem) error {

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl_test.go
@@ -2269,7 +2269,7 @@ func Test_findEvalSetForItem(t *testing.T) {
 	assert.Nil(t, findEvalSetForItem(multi, 72))                 // 多集未命中, 不回退主集
 }
 
-// Test_sendItemComplete_nilMeta 覆盖 evalSetItem==nil 时 sendItemComplete 直接跳过、不 publish。
+// Test_sendItemComplete_nilMeta 覆盖 evalSetItem==nil 时 sendItemComplete 直接跳过、不 publish、返回 nil(不阻断调度)。
 func Test_sendItemComplete_nilMeta(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -2277,11 +2277,12 @@ func Test_sendItemComplete_nilMeta(t *testing.T) {
 	svc := &ExptSchedulerImpl{itemCompletePublisher: stub}
 	event := &entity.ExptScheduleEvent{ExptID: 1, ExptRunID: 2, SpaceID: 3}
 	item := &entity.ExptEvalItem{ItemID: 10, State: entity.ItemRunState_Success}
-	svc.sendItemComplete(context.Background(), event, &entity.Experiment{}, item, nil /*evalSetItem*/, 100)
-	assert.Empty(t, stub.events) // meta nil, 跳过, 未 publish
+	err := svc.sendItemComplete(context.Background(), event, &entity.Experiment{}, item, nil /*evalSetItem*/, 100)
+	assert.NoError(t, err)       // meta nil 属组装侧问题, 跳过不阻断, 返回 nil
+	assert.Empty(t, stub.events) // 未 publish
 }
 
-// Test_sendItemComplete_publish 覆盖 publish 成功 / 失败(CtxError 不阻断) 两条路径。
+// Test_sendItemComplete_publish 覆盖 publish 成功(返回 nil) / 失败(返回 error, 由调用方中断本次调度靠下次调度补发) 两条路径。
 func Test_sendItemComplete_publish(t *testing.T) {
 	event := &entity.ExptScheduleEvent{ExptID: 1, ExptRunID: 2, SpaceID: 3}
 	item := &entity.ExptEvalItem{ItemID: 10, State: entity.ItemRunState_Success}
@@ -2290,17 +2291,17 @@ func Test_sendItemComplete_publish(t *testing.T) {
 	t.Run("publish ok", func(t *testing.T) {
 		stub := &stubItemCompletePublisher{}
 		svc := &ExptSchedulerImpl{itemCompletePublisher: stub}
-		svc.sendItemComplete(context.Background(), event, &entity.Experiment{}, item, evalSetItem, 80)
+		err := svc.sendItemComplete(context.Background(), event, &entity.Experiment{}, item, evalSetItem, 80)
+		assert.NoError(t, err)        // 发送成功返回 nil
 		assert.Len(t, stub.events, 1) // 组装并发送一次
 	})
 
-	t.Run("publish fail not blocking", func(t *testing.T) {
+	t.Run("publish fail returns error", func(t *testing.T) {
 		stub := &stubItemCompletePublisher{err: assert.AnError}
 		svc := &ExptSchedulerImpl{itemCompletePublisher: stub}
-		// 失败仅 CtxError, 不 panic / 不阻断
-		assert.NotPanics(t, func() {
-			svc.sendItemComplete(context.Background(), event, &entity.Experiment{}, item, evalSetItem, 80)
-		})
+		// 发失败返回 error, 由调用方中断本次调度, 下次调度重扫 completeItems 补发
+		err := svc.sendItemComplete(context.Background(), event, &entity.Experiment{}, item, evalSetItem, 80)
+		assert.Error(t, err)
 		assert.Len(t, stub.events, 1) // 仍尝试发送一次
 	})
 }

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl_test.go
@@ -2306,6 +2306,61 @@ func Test_sendItemComplete_publish(t *testing.T) {
 	})
 }
 
+// Test_recordEvalItemRunLogs_publishFailInterrupts 锁定本次 fix 的核心不变量:
+// item-complete(success) 发送失败时, recordEvalItemRunLogs 循环必须在落库之前 return err 中断本次调度,
+// 使 item 停留在 complete(未推进到 Resulted), 下次调度重扫 completeItems 补发。
+// 因此断言发失败时 RecordItemRunLogs(落库/推进状态) 调用 0 次; 对照发成功时正常落库 1 次。
+// 防回归: 未来若把 return err 改成 continue、或调换"先发送后落库"顺序, 本用例会失败。
+func Test_recordEvalItemRunLogs_publishFailInterrupts(t *testing.T) {
+	// 单集实验, resolveItemCompleteMeta 走主集路径, 需 evaluationSetItemService 返回该 item 的 meta(非 nil), 才会真正触发发送。
+	newSvc := func(ctrl *gomock.Controller, pubErr error) (*ExptSchedulerImpl, *svcmocks.MockExptResultService, *entitymocks.MockExptSchedulerMode) {
+		setItemSvc := svcmocks.NewMockEvaluationSetItemService(ctrl)
+		setItemSvc.EXPECT().BatchGetEvaluationSetItems(gomock.Any(), gomock.Any()).
+			Return([]*entity.EvaluationSetItem{{ItemID: 10, ItemKey: "k10", EvaluationSetID: 70}}, nil)
+		resultSvc := svcmocks.NewMockExptResultService(ctrl)
+		publisher := eventmocks.NewMockExptEventPublisher(ctrl)
+		mode := entitymocks.NewMockExptSchedulerMode(ctrl)
+		return &ExptSchedulerImpl{
+			itemCompletePublisher:    &stubItemCompletePublisher{err: pubErr},
+			evaluationSetItemService: setItemSvc,
+			exptItemRefRepo:          mock_repo.NewMockIExptItemRefRepo(ctrl),
+			ResultSvc:                resultSvc,
+			Publisher:                publisher,
+		}, resultSvc, mode
+	}
+
+	expt := &entity.Experiment{EvalSet: &entity.EvaluationSet{ID: 70, EvaluationSetVersion: &entity.EvaluationSetVersion{ID: 80}}}
+	event := &entity.ExptScheduleEvent{SpaceID: 9, ExptID: 100, ExptRunID: 200}
+	items := []*entity.ExptEvalItem{{ItemID: 10, State: entity.ItemRunState_Success}}
+
+	t.Run("publish fail -> 落库前中断, RecordItemRunLogs 0 次", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc, resultSvc, mode := newSvc(ctrl, assert.AnError)
+		resultSvc.EXPECT().RecordItemRunLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		mode.EXPECT().PublishResult(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		err := svc.recordEvalItemRunLogs(context.Background(), event, items, mode, expt)
+		assert.Error(t, err) // 发失败 error 上抛, 调用方据此中断本次调度
+	})
+
+	t.Run("publish ok -> 正常落库, RecordItemRunLogs 1 次", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc, resultSvc, mode := newSvc(ctrl, nil)
+		resultSvc.EXPECT().RecordItemRunLogs(gomock.Any(), int64(100), int64(200), int64(10), int64(9), gomock.Any()).
+			Return(nil, nil).Times(1)
+		mode.EXPECT().PublishResult(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		// 循环结束后的批量收尾
+		resultSvc.EXPECT().UpsertExptTurnResultFilter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+		svc.Publisher.(*eventmocks.MockExptEventPublisher).EXPECT().
+			PublishExptTurnResultFilterEvent(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+		err := svc.recordEvalItemRunLogs(context.Background(), event, items, mode, expt)
+		assert.NoError(t, err)
+	})
+}
+
 // TestExptSchedulerImpl_terminateZombieEvalTargetRecords_CrossSpace 覆盖 zombie 兜底销毁沙箱时
 // 传入 TerminateAsyncRecordsAndDestroySandbox 的 spaceID 解析：
 //   - Expt.TargetSpaceID > 0 → 用来源空间 (跨空间共享评测对象), 避免 DAO SpaceID.Eq 过滤把 record 过滤空


### PR DESCRIPTION
…edule

链路B recordEvalItemRunLogs 发送 item-complete(success) 时, 原实现发失败仅 CtxError 旁路吞掉, 违背"单题发失败靠下次调度补发"的预期。

改动:
- sendItemComplete 由 void 改为返回 error: publish 失败返回 err; 元数据缺失(重试也恢复不了)返回 nil 跳过; 成功返回 nil。
- 调用点 Success 分支收到 err 即 return 中断本次调度。
- return 落在 RecordItemRunLogs 落库之前, 失败 item 的 result_state 仍为 Logged, 下次调度按 result_state=Logged 重扫入 complete 再次驱动发送; 已走完 RecordItemRunLogs 的 item 已置 Resulted, 不会重发。故重发范围仅 "失败点及其之后", 无"已发再发"的重复。
- 两条件(空间开关 item_complete_space_config + 评测对象 enable_analysis) 由 producer 判定, 不满足时返回 nil(skip 非失败), 不触发 return。

UT: Test_sendItemComplete_nilMeta / publish_ok 断言 NoError,
    publish_fail_returns_error 断言 Error。

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
