### PR TITLE
fix(file): use path.Join instead of filepath.Join for object storage keys (#629)

### DIFF
--- a/backend/modules/foundation/domain/file/service/server.go
+++ b/backend/modules/foundation/domain/file/service/server.go
@@ -13,6 +13,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -50,7 +51,7 @@ func (fs fileService) UploadLoopFile(ctx context.Context, fileHeader *multipart.
 	if fileName == "" {
 		return "", errorx.NewByCode(errno.CommonInvalidParamCode)
 	}
-	fileName = filepath.Join(spaceID, "/", fileName)
+	fileName = path.Join(spaceID, fileName)
 
 	f, err := fileHeader.Open()
 	if err != nil {
@@ -131,7 +132,7 @@ func (fs fileService) UploadFileForServer(ctx context.Context, mimeType string, 
 	}
 
 	// Build full path with workspace ID
-	fullPath := filepath.Join(spaceID, "/", fileName)
+	fullPath := path.Join(spaceID, fileName)
 
 	// Detect content type from file data
 	fileContentType := http.DetectContentType(body)


### PR DESCRIPTION
### Summary

Fixes #629.

`UploadLoopFile` and `UploadFileForServer` were using `filepath.Join` to construct object-storage keys. On Windows platforms, this injected backslashes (`\`) into S3/object storage keys instead of the standard portable forward slashes (`/`).

This PR:
- Replaces `filepath.Join` with URL/slash-oriented `path.Join` for object-storage key formatting in `backend/modules/foundation/domain/file/service/server.go`.
- Ensures key path format is consistent across Windows, macOS, and Linux.