### PR TITLE
[feat][evaluation] add RunModeConfig.SkillsMode for sandbox agent skills

### DIFF
--- a/backend/kitex_gen/coze/loop/evaluation/domain/expt/expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/expt/expt.go
@@ -1338,6 +1338,9 @@ type RunModeConfig struct {
 	SuaPeTemplate *string `thrift:"sua_pe_template,9,optional" frugal:"9,optional,string" json:"sua_pe_template" form:"sua_pe_template" query:"sua_pe_template"`
 	// max_turns 实验级轮数上限 (题目级同名字段在 ItemRunConf, 题目级优先)。
 	MaxTurns *int32 `thrift:"max_turns,10,optional" frugal:"10,optional,i32" json:"max_turns" form:"max_turns" query:"max_turns"`
+	// skills_mode SandboxAgent 跑法的技能模式, 原样透传到 case-file experiment_info.skills_mode。
+	// 合法值 merge / disable_test_case; 校验在 OpenAPI convertor 做。
+	SkillsMode *string `thrift:"skills_mode,11,optional" frugal:"11,optional,string" json:"skills_mode" form:"skills_mode" query:"skills_mode"`
 }
 
 func NewRunModeConfig() *RunModeConfig {
@@ -1454,6 +1457,18 @@ func (p *RunModeConfig) GetMaxTurns() (v int32) {
 	}
 	return *p.MaxTurns
 }
+
+var RunModeConfig_SkillsMode_DEFAULT string
+
+func (p *RunModeConfig) GetSkillsMode() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetSkillsMode() {
+		return RunModeConfig_SkillsMode_DEFAULT
+	}
+	return *p.SkillsMode
+}
 func (p *RunModeConfig) SetRunMode(val *ExptRunMode) {
 	p.RunMode = val
 }
@@ -1481,6 +1496,9 @@ func (p *RunModeConfig) SetSuaPeTemplate(val *string) {
 func (p *RunModeConfig) SetMaxTurns(val *int32) {
 	p.MaxTurns = val
 }
+func (p *RunModeConfig) SetSkillsMode(val *string) {
+	p.SkillsMode = val
+}
 
 var fieldIDToName_RunModeConfig = map[int16]string{
 	1:  "run_mode",
@@ -1492,6 +1510,7 @@ var fieldIDToName_RunModeConfig = map[int16]string{
 	8:  "sua_behavioral_constraints",
 	9:  "sua_pe_template",
 	10: "max_turns",
+	11: "skills_mode",
 }
 
 func (p *RunModeConfig) IsSetRunMode() bool {
@@ -1528,6 +1547,10 @@ func (p *RunModeConfig) IsSetSuaPeTemplate() bool {
 
 func (p *RunModeConfig) IsSetMaxTurns() bool {
 	return p.MaxTurns != nil
+}
+
+func (p *RunModeConfig) IsSetSkillsMode() bool {
+	return p.SkillsMode != nil
 }
 
 func (p *RunModeConfig) Read(iprot thrift.TProtocol) (err error) {
@@ -1615,6 +1638,14 @@ func (p *RunModeConfig) Read(iprot thrift.TProtocol) (err error) {
 		case 10:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField10(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 11:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField11(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -1750,6 +1781,17 @@ func (p *RunModeConfig) ReadField10(iprot thrift.TProtocol) error {
 	p.MaxTurns = _field
 	return nil
 }
+func (p *RunModeConfig) ReadField11(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.SkillsMode = _field
+	return nil
+}
 
 func (p *RunModeConfig) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -1791,6 +1833,10 @@ func (p *RunModeConfig) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField10(oprot); err != nil {
 			fieldId = 10
+			goto WriteFieldError
+		}
+		if err = p.writeField11(oprot); err != nil {
+			fieldId = 11
 			goto WriteFieldError
 		}
 	}
@@ -1973,6 +2019,24 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 10 end error: ", p), err)
 }
+func (p *RunModeConfig) writeField11(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSkillsMode() {
+		if err = oprot.WriteFieldBegin("skills_mode", thrift.STRING, 11); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.SkillsMode); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 end error: ", p), err)
+}
 
 func (p *RunModeConfig) String() string {
 	if p == nil {
@@ -2013,6 +2077,9 @@ func (p *RunModeConfig) DeepEqual(ano *RunModeConfig) bool {
 		return false
 	}
 	if !p.Field10DeepEqual(ano.MaxTurns) {
+		return false
+	}
+	if !p.Field11DeepEqual(ano.SkillsMode) {
 		return false
 	}
 	return true
@@ -2122,6 +2189,18 @@ func (p *RunModeConfig) Field10DeepEqual(src *int32) bool {
 		return false
 	}
 	if *p.MaxTurns != *src {
+		return false
+	}
+	return true
+}
+func (p *RunModeConfig) Field11DeepEqual(src *string) bool {
+
+	if p.SkillsMode == src {
+		return true
+	} else if p.SkillsMode == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.SkillsMode, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/domain/expt/k-expt.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain/expt/k-expt.go
@@ -186,6 +186,20 @@ func (p *RunModeConfig) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 11:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField11(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -334,6 +348,20 @@ func (p *RunModeConfig) FastReadField10(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *RunModeConfig) FastReadField11(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.SkillsMode = _field
+	return offset, nil
+}
+
 func (p *RunModeConfig) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -350,6 +378,7 @@ func (p *RunModeConfig) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
 		offset += p.fastWriteField9(buf[offset:], w)
+		offset += p.fastWriteField11(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
 	return offset
@@ -367,6 +396,7 @@ func (p *RunModeConfig) BLength() int {
 		l += p.field8Length()
 		l += p.field9Length()
 		l += p.field10Length()
+		l += p.field11Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -453,6 +483,15 @@ func (p *RunModeConfig) fastWriteField10(buf []byte, w thrift.NocopyWriter) int 
 	return offset
 }
 
+func (p *RunModeConfig) fastWriteField11(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetSkillsMode() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 11)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.SkillsMode)
+	}
+	return offset
+}
+
 func (p *RunModeConfig) field1Length() int {
 	l := 0
 	if p.IsSetRunMode() {
@@ -534,6 +573,15 @@ func (p *RunModeConfig) field10Length() int {
 	return l
 }
 
+func (p *RunModeConfig) field11Length() int {
+	l := 0
+	if p.IsSetSkillsMode() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.SkillsMode)
+	}
+	return l
+}
+
 func (p *RunModeConfig) DeepCopy(s interface{}) error {
 	src, ok := s.(*RunModeConfig)
 	if !ok {
@@ -598,6 +646,14 @@ func (p *RunModeConfig) DeepCopy(s interface{}) error {
 	if src.MaxTurns != nil {
 		tmp := *src.MaxTurns
 		p.MaxTurns = &tmp
+	}
+
+	if src.SkillsMode != nil {
+		var tmp string
+		if *src.SkillsMode != "" {
+			tmp = kutils.StringDeepCopy(*src.SkillsMode)
+		}
+		p.SkillsMode = &tmp
 	}
 
 	return nil

--- a/backend/kitex_gen/coze/loop/evaluation/domain_openapi/experiment/experiment.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain_openapi/experiment/experiment.go
@@ -3057,6 +3057,9 @@ type RunModeConfig struct {
 	SuaPeTemplate *string `thrift:"sua_pe_template,9,optional" frugal:"9,optional,string" json:"sua_pe_template" form:"sua_pe_template" query:"sua_pe_template"`
 	// max_turns 实验级轮数上限 (题目级同名字段在 ItemRunConf, 题目级优先)。
 	MaxTurns *int32 `thrift:"max_turns,10,optional" frugal:"10,optional,i32" json:"max_turns" form:"max_turns" query:"max_turns"`
+	// skills_mode SandboxAgent 跑法的技能模式, 原样透传到 case-file experiment_info.skills_mode。
+	// 合法值 merge / disable_test_case; 非法值在 convertor 报 CommonInvalidParamCode。
+	SkillsMode *string `thrift:"skills_mode,11,optional" frugal:"11,optional,string" json:"skills_mode" form:"skills_mode" query:"skills_mode"`
 }
 
 func NewRunModeConfig() *RunModeConfig {
@@ -3173,6 +3176,18 @@ func (p *RunModeConfig) GetMaxTurns() (v int32) {
 	}
 	return *p.MaxTurns
 }
+
+var RunModeConfig_SkillsMode_DEFAULT string
+
+func (p *RunModeConfig) GetSkillsMode() (v string) {
+	if p == nil {
+		return
+	}
+	if !p.IsSetSkillsMode() {
+		return RunModeConfig_SkillsMode_DEFAULT
+	}
+	return *p.SkillsMode
+}
 func (p *RunModeConfig) SetRunMode(val *ExptRunMode) {
 	p.RunMode = val
 }
@@ -3200,6 +3215,9 @@ func (p *RunModeConfig) SetSuaPeTemplate(val *string) {
 func (p *RunModeConfig) SetMaxTurns(val *int32) {
 	p.MaxTurns = val
 }
+func (p *RunModeConfig) SetSkillsMode(val *string) {
+	p.SkillsMode = val
+}
 
 var fieldIDToName_RunModeConfig = map[int16]string{
 	1:  "run_mode",
@@ -3211,6 +3229,7 @@ var fieldIDToName_RunModeConfig = map[int16]string{
 	8:  "sua_behavioral_constraints",
 	9:  "sua_pe_template",
 	10: "max_turns",
+	11: "skills_mode",
 }
 
 func (p *RunModeConfig) IsSetRunMode() bool {
@@ -3247,6 +3266,10 @@ func (p *RunModeConfig) IsSetSuaPeTemplate() bool {
 
 func (p *RunModeConfig) IsSetMaxTurns() bool {
 	return p.MaxTurns != nil
+}
+
+func (p *RunModeConfig) IsSetSkillsMode() bool {
+	return p.SkillsMode != nil
 }
 
 func (p *RunModeConfig) Read(iprot thrift.TProtocol) (err error) {
@@ -3334,6 +3357,14 @@ func (p *RunModeConfig) Read(iprot thrift.TProtocol) (err error) {
 		case 10:
 			if fieldTypeId == thrift.I32 {
 				if err = p.ReadField10(iprot); err != nil {
+					goto ReadFieldError
+				}
+			} else if err = iprot.Skip(fieldTypeId); err != nil {
+				goto SkipFieldError
+			}
+		case 11:
+			if fieldTypeId == thrift.STRING {
+				if err = p.ReadField11(iprot); err != nil {
 					goto ReadFieldError
 				}
 			} else if err = iprot.Skip(fieldTypeId); err != nil {
@@ -3467,6 +3498,17 @@ func (p *RunModeConfig) ReadField10(iprot thrift.TProtocol) error {
 	p.MaxTurns = _field
 	return nil
 }
+func (p *RunModeConfig) ReadField11(iprot thrift.TProtocol) error {
+
+	var _field *string
+	if v, err := iprot.ReadString(); err != nil {
+		return err
+	} else {
+		_field = &v
+	}
+	p.SkillsMode = _field
+	return nil
+}
 
 func (p *RunModeConfig) Write(oprot thrift.TProtocol) (err error) {
 	var fieldId int16
@@ -3508,6 +3550,10 @@ func (p *RunModeConfig) Write(oprot thrift.TProtocol) (err error) {
 		}
 		if err = p.writeField10(oprot); err != nil {
 			fieldId = 10
+			goto WriteFieldError
+		}
+		if err = p.writeField11(oprot); err != nil {
+			fieldId = 11
 			goto WriteFieldError
 		}
 	}
@@ -3690,6 +3736,24 @@ WriteFieldBeginError:
 WriteFieldEndError:
 	return thrift.PrependError(fmt.Sprintf("%T write field 10 end error: ", p), err)
 }
+func (p *RunModeConfig) writeField11(oprot thrift.TProtocol) (err error) {
+	if p.IsSetSkillsMode() {
+		if err = oprot.WriteFieldBegin("skills_mode", thrift.STRING, 11); err != nil {
+			goto WriteFieldBeginError
+		}
+		if err := oprot.WriteString(*p.SkillsMode); err != nil {
+			return err
+		}
+		if err = oprot.WriteFieldEnd(); err != nil {
+			goto WriteFieldEndError
+		}
+	}
+	return nil
+WriteFieldBeginError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 begin error: ", p), err)
+WriteFieldEndError:
+	return thrift.PrependError(fmt.Sprintf("%T write field 11 end error: ", p), err)
+}
 
 func (p *RunModeConfig) String() string {
 	if p == nil {
@@ -3730,6 +3794,9 @@ func (p *RunModeConfig) DeepEqual(ano *RunModeConfig) bool {
 		return false
 	}
 	if !p.Field10DeepEqual(ano.MaxTurns) {
+		return false
+	}
+	if !p.Field11DeepEqual(ano.SkillsMode) {
 		return false
 	}
 	return true
@@ -3839,6 +3906,18 @@ func (p *RunModeConfig) Field10DeepEqual(src *int32) bool {
 		return false
 	}
 	if *p.MaxTurns != *src {
+		return false
+	}
+	return true
+}
+func (p *RunModeConfig) Field11DeepEqual(src *string) bool {
+
+	if p.SkillsMode == src {
+		return true
+	} else if p.SkillsMode == nil || src == nil {
+		return false
+	}
+	if strings.Compare(*p.SkillsMode, *src) != 0 {
 		return false
 	}
 	return true

--- a/backend/kitex_gen/coze/loop/evaluation/domain_openapi/experiment/k-experiment.go
+++ b/backend/kitex_gen/coze/loop/evaluation/domain_openapi/experiment/k-experiment.go
@@ -2196,6 +2196,20 @@ func (p *RunModeConfig) FastRead(buf []byte) (int, error) {
 					goto SkipFieldError
 				}
 			}
+		case 11:
+			if fieldTypeId == thrift.STRING {
+				l, err = p.FastReadField11(buf[offset:])
+				offset += l
+				if err != nil {
+					goto ReadFieldError
+				}
+			} else {
+				l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
+				offset += l
+				if err != nil {
+					goto SkipFieldError
+				}
+			}
 		default:
 			l, err = thrift.Binary.Skip(buf[offset:], fieldTypeId)
 			offset += l
@@ -2340,6 +2354,20 @@ func (p *RunModeConfig) FastReadField10(buf []byte) (int, error) {
 	return offset, nil
 }
 
+func (p *RunModeConfig) FastReadField11(buf []byte) (int, error) {
+	offset := 0
+
+	var _field *string
+	if v, l, err := thrift.Binary.ReadString(buf[offset:]); err != nil {
+		return offset, err
+	} else {
+		offset += l
+		_field = &v
+	}
+	p.SkillsMode = _field
+	return offset, nil
+}
+
 func (p *RunModeConfig) FastWrite(buf []byte) int {
 	return p.FastWriteNocopy(buf, nil)
 }
@@ -2356,6 +2384,7 @@ func (p *RunModeConfig) FastWriteNocopy(buf []byte, w thrift.NocopyWriter) int {
 		offset += p.fastWriteField7(buf[offset:], w)
 		offset += p.fastWriteField8(buf[offset:], w)
 		offset += p.fastWriteField9(buf[offset:], w)
+		offset += p.fastWriteField11(buf[offset:], w)
 	}
 	offset += thrift.Binary.WriteFieldStop(buf[offset:])
 	return offset
@@ -2373,6 +2402,7 @@ func (p *RunModeConfig) BLength() int {
 		l += p.field8Length()
 		l += p.field9Length()
 		l += p.field10Length()
+		l += p.field11Length()
 	}
 	l += thrift.Binary.FieldStopLength()
 	return l
@@ -2459,6 +2489,15 @@ func (p *RunModeConfig) fastWriteField10(buf []byte, w thrift.NocopyWriter) int 
 	return offset
 }
 
+func (p *RunModeConfig) fastWriteField11(buf []byte, w thrift.NocopyWriter) int {
+	offset := 0
+	if p.IsSetSkillsMode() {
+		offset += thrift.Binary.WriteFieldBegin(buf[offset:], thrift.STRING, 11)
+		offset += thrift.Binary.WriteStringNocopy(buf[offset:], w, *p.SkillsMode)
+	}
+	return offset
+}
+
 func (p *RunModeConfig) field1Length() int {
 	l := 0
 	if p.IsSetRunMode() {
@@ -2540,6 +2579,15 @@ func (p *RunModeConfig) field10Length() int {
 	return l
 }
 
+func (p *RunModeConfig) field11Length() int {
+	l := 0
+	if p.IsSetSkillsMode() {
+		l += thrift.Binary.FieldBeginLength()
+		l += thrift.Binary.StringLengthNocopy(*p.SkillsMode)
+	}
+	return l
+}
+
 func (p *RunModeConfig) DeepCopy(s interface{}) error {
 	src, ok := s.(*RunModeConfig)
 	if !ok {
@@ -2604,6 +2652,14 @@ func (p *RunModeConfig) DeepCopy(s interface{}) error {
 	if src.MaxTurns != nil {
 		tmp := *src.MaxTurns
 		p.MaxTurns = &tmp
+	}
+
+	if src.SkillsMode != nil {
+		var tmp string
+		if *src.SkillsMode != "" {
+			tmp = kutils.StringDeepCopy(*src.SkillsMode)
+		}
+		p.SkillsMode = &tmp
 	}
 
 	return nil

--- a/backend/modules/evaluation/application/convertor/experiment/expt.go
+++ b/backend/modules/evaluation/application/convertor/experiment/expt.go
@@ -1401,6 +1401,7 @@ func runModeConfigDTO2DO(dto *domain_expt.RunModeConfig) *entity.RunModeConfig {
 		SuaBehavioralConstraints: dto.GetSuaBehavioralConstraints(),
 		SuaPETemplate:            dto.GetSuaPeTemplate(),
 		MaxTurns:                 int(dto.GetMaxTurns()),
+		SkillsMode:               dto.GetSkillsMode(),
 	}
 	if dto.IsSetRunMode() {
 		do.RunMode = suaRunModeDTO2DO(dto.GetRunMode())
@@ -1494,6 +1495,9 @@ func runModeConfigDO2DTO(do *entity.RunModeConfig) *domain_expt.RunModeConfig {
 	}
 	if do.MaxTurns != 0 {
 		dto.MaxTurns = gptr.Of(int32(do.MaxTurns))
+	}
+	if do.SkillsMode != "" {
+		dto.SkillsMode = gptr.Of(do.SkillsMode)
 	}
 	return dto
 }

--- a/backend/modules/evaluation/application/convertor/experiment/openapi.go
+++ b/backend/modules/evaluation/application/convertor/experiment/openapi.go
@@ -3114,7 +3114,32 @@ func OpenAPIRunModeConfigDTO2Domain(c *openapiExperiment.RunModeConfig) (*domain
 		}
 		out.SuaMode = gptr.Of(sm)
 	}
+	// skills_mode 与 run_mode/sua_mode 同为受控枚举: 白名单外的非空值直接报错, 不静默透传
+	// (原样落到 case-file 会让 runtime 收到无法识别的模式)。空/未设置放行, 表示不透传该字段。
+	if c.SkillsMode != nil && *c.SkillsMode != "" {
+		if !isValidSkillsMode(*c.SkillsMode) {
+			return nil, errorx.NewByCode(errno.CommonInvalidParamCode, errorx.WithExtraMsg(fmt.Sprintf(
+				"invalid skills_mode %q (supported: %s, %s)", *c.SkillsMode,
+				skillsModeMerge, skillsModeDisableTestCase)))
+		}
+		out.SkillsMode = c.SkillsMode
+	}
 	return out, nil
+}
+
+// skills_mode 全量枚举 (SandboxAgent 跑法的技能模式)。case-file experiment_info.skills_mode 原样带这两个值之一。
+const (
+	skillsModeMerge           = "merge"
+	skillsModeDisableTestCase = "disable_test_case"
+)
+
+func isValidSkillsMode(s string) bool {
+	switch s {
+	case skillsModeMerge, skillsModeDisableTestCase:
+		return true
+	default:
+		return false
+	}
 }
 
 // openAPIRunModeToDomain 将 OpenAPI ExptRunMode 字符串枚举转为内部 int 枚举; 未识别返回 false。
@@ -3176,6 +3201,8 @@ func RunModeConfigDomain2OpenAPI(c *domainExpt.RunModeConfig) *openapiExperiment
 		SuaPersona:               c.SuaPersona,
 		SuaBehavioralConstraints: c.SuaBehavioralConstraints,
 		SuaPeTemplate:            c.SuaPeTemplate,
+		// skills_mode 是受控枚举, 但存量落库的值都经过入口白名单校验, 回显原样带出即可。
+		SkillsMode: c.SkillsMode,
 	}
 	if c.RunMode != nil {
 		if rm, ok := domainRunModeToOpenAPI(*c.RunMode); ok {

--- a/backend/modules/evaluation/application/convertor/experiment/skills_mode_test.go
+++ b/backend/modules/evaluation/application/convertor/experiment/skills_mode_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package experiment
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytedance/gg/gptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	domain_expt "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain/expt"
+	openapiExperiment "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/domain_openapi/experiment"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+)
+
+// skills_mode 是 SandboxAgent 跑法的技能模式 (merge / disable_test_case), 与 run_mode/sua_mode
+// 同为受控枚举。入口 OpenAPIRunModeConfigDTO2Domain 做白名单校验: 合法值透传到 entity,
+// 非法值报错 (不能静默透传 —— 会落到 case-file 让 runtime 收到无法识别的模式)。
+// 本文件钉住「白名单放行/拒绝 + DO↔DTO 往返闭合 + 读侧回显」三段。
+func TestOpenAPIRunModeConfigDTO2Domain_SkillsModeWhitelist(t *testing.T) {
+	t.Parallel()
+
+	t.Run("合法值 merge 透传", func(t *testing.T) {
+		t.Parallel()
+		dom, err := OpenAPIRunModeConfigDTO2Domain(&openapiExperiment.RunModeConfig{
+			SkillsMode: gptr.Of("merge"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, dom)
+		assert.Equal(t, "merge", dom.GetSkillsMode())
+	})
+
+	t.Run("合法值 disable_test_case 透传", func(t *testing.T) {
+		t.Parallel()
+		dom, err := OpenAPIRunModeConfigDTO2Domain(&openapiExperiment.RunModeConfig{
+			SkillsMode: gptr.Of("disable_test_case"),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, dom)
+		assert.Equal(t, "disable_test_case", dom.GetSkillsMode())
+	})
+
+	t.Run("未设置(nil) 放行, 不产出 skills_mode", func(t *testing.T) {
+		t.Parallel()
+		dom, err := OpenAPIRunModeConfigDTO2Domain(&openapiExperiment.RunModeConfig{})
+		require.NoError(t, err)
+		require.NotNil(t, dom)
+		assert.False(t, dom.IsSetSkillsMode(), "未配 skills_mode 不该被透传")
+	})
+
+	t.Run("空串 放行, 不产出 skills_mode", func(t *testing.T) {
+		t.Parallel()
+		dom, err := OpenAPIRunModeConfigDTO2Domain(&openapiExperiment.RunModeConfig{
+			SkillsMode: gptr.Of(""),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, dom)
+		assert.False(t, dom.IsSetSkillsMode(), "空串等同未配, 不该被透传")
+	})
+
+	t.Run("非法值 报错且含字段名", func(t *testing.T) {
+		t.Parallel()
+		_, err := OpenAPIRunModeConfigDTO2Domain(&openapiExperiment.RunModeConfig{
+			SkillsMode: gptr.Of("bogus"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "skills_mode", "错误信息应点出出错的字段名")
+	})
+}
+
+// DO↔DTO 往返: 入口合法值经 runModeConfigDTO2DO 落 entity, 再 runModeConfigDO2DTO 回 DTO,
+// 必须闭合 —— 否则"照抄详情页配置重新提交"会丢失 skills_mode。
+func TestRunModeConfig_SkillsModeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, v := range []string{"merge", "disable_test_case"} {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			t.Parallel()
+			dom, err := OpenAPIRunModeConfigDTO2Domain(&openapiExperiment.RunModeConfig{
+				SkillsMode: gptr.Of(v),
+			})
+			require.NoError(t, err)
+
+			do := runModeConfigDTO2DO(dom)
+			require.NotNil(t, do)
+			assert.Equal(t, v, do.SkillsMode, "DTO→DO skills_mode 丢失")
+
+			back := runModeConfigDO2DTO(do)
+			require.NotNil(t, back)
+			assert.Equal(t, v, back.GetSkillsMode(), "DO→DTO 回显与落库值不一致")
+		})
+	}
+
+	// 非空守卫: entity.SkillsMode 为空时, DTO 不得回显 (否则详情页凭空多出 skills_mode 键)。
+	t.Run("空值不回显", func(t *testing.T) {
+		t.Parallel()
+		back := runModeConfigDO2DTO(&entity.RunModeConfig{RunMode: entity.RunModeSingleTurn})
+		require.NotNil(t, back)
+		assert.False(t, back.IsSetSkillsMode(), "未配 skills_mode 不该回显")
+	})
+}
+
+// 读侧 Domain2OpenAPI 回显: 合法值带出, 非法(存量脏数据)值留空不猜。
+func TestRunModeConfigDomain2OpenAPI_SkillsModeEcho(t *testing.T) {
+	t.Parallel()
+
+	t.Run("合法值回显", func(t *testing.T) {
+		t.Parallel()
+		got := RunModeConfigDomain2OpenAPI(&domain_expt.RunModeConfig{
+			SkillsMode: gptr.Of("disable_test_case"),
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "disable_test_case", gptr.Indirect(got.SkillsMode))
+	})
+
+	t.Run("未设值 nil 出 nil", func(t *testing.T) {
+		t.Parallel()
+		got := RunModeConfigDomain2OpenAPI(&domain_expt.RunModeConfig{})
+		require.NotNil(t, got)
+		assert.Nil(t, got.SkillsMode)
+	})
+
+	// 存量脏数据(校验加入前已落库的非法值): 回显路径不校验, 原样带出 ——
+	// 校验只在入口做, 回显若再校验会把存量值静默吞掉, 详情页看不到实际落库内容。
+	t.Run("存量脏值原样带出, 不校验不吞", func(t *testing.T) {
+		t.Parallel()
+		got := RunModeConfigDomain2OpenAPI(&domain_expt.RunModeConfig{
+			SkillsMode: gptr.Of("legacy-bogus"),
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "legacy-bogus", gptr.Indirect(got.SkillsMode))
+	})
+}
+
+// 兜底: isValidSkillsMode 的全表, 防止有人新增枚举忘了同步白名单。
+func TestIsValidSkillsMode(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isValidSkillsMode("merge"))
+	assert.True(t, isValidSkillsMode("disable_test_case"))
+	assert.False(t, isValidSkillsMode(""))
+	assert.False(t, isValidSkillsMode("MERGE"))
+	assert.False(t, isValidSkillsMode("bogus"))
+	assert.False(t, isValidSkillsMode(strings.Repeat("x", 100)))
+}

--- a/backend/modules/evaluation/domain/entity/expt.go
+++ b/backend/modules/evaluation/domain/entity/expt.go
@@ -507,6 +507,9 @@ type RunModeConfig struct {
 	SuaPETemplate string `json:"sua_pe_template,omitempty"`
 	// MaxTurns 实验级轮数上限 (题目级同名字段在 ItemRunConf, 题目级优先)。
 	MaxTurns int `json:"max_turns,omitempty"`
+	// SkillsMode SandboxAgent 跑法的技能模式 (merge / disable_test_case)。入口 convertor 校白名单,
+	// 空即不透传; 原样落到 case-file experiment_info.skills_mode。
+	SkillsMode string `json:"skills_mode,omitempty"`
 }
 
 // ItemRunConf 题目级多轮/SUA 运行配置, 冻结进 expt_item_ref.item_config (ItemTargetConf.RunConf)。

--- a/idl/thrift/coze/loop/evaluation/domain/expt.thrift
+++ b/idl/thrift/coze/loop/evaluation/domain/expt.thrift
@@ -115,6 +115,9 @@ struct RunModeConfig {
     9: optional string sua_pe_template (go.tag = 'json:"sua_pe_template"')
     // max_turns 实验级轮数上限 (题目级同名字段在 ItemRunConf, 题目级优先)。
     10: optional i32 max_turns (go.tag = 'json:"max_turns"')
+    // skills_mode SandboxAgent 跑法的技能模式, 原样透传到 case-file experiment_info.skills_mode。
+    // 合法值 merge / disable_test_case; 校验在 OpenAPI convertor 做。
+    11: optional string skills_mode (go.tag = 'json:"skills_mode"')
 }
 
 typedef string Visibility(ts.enum="true")

--- a/idl/thrift/coze/loop/evaluation/domain_openapi/experiment.thrift
+++ b/idl/thrift/coze/loop/evaluation/domain_openapi/experiment.thrift
@@ -174,6 +174,9 @@ struct RunModeConfig {
     9: optional string sua_pe_template (go.tag = 'json:"sua_pe_template"')
     // max_turns 实验级轮数上限 (题目级同名字段在 ItemRunConf, 题目级优先)。
     10: optional i32 max_turns (go.tag = 'json:"max_turns"')
+    // skills_mode SandboxAgent 跑法的技能模式, 原样透传到 case-file experiment_info.skills_mode。
+    // 合法值 merge / disable_test_case; 非法值在 convertor 报 CommonInvalidParamCode。
+    11: optional string skills_mode (go.tag = 'json:"skills_mode"')
 }
 
 // per-set 运行期增量信息 (纯读模型; Get 全填含详情, List 只填 id/count)


### PR DESCRIPTION
## Background

Add `skills_mode` to `RunModeConfig`, declaring how a sandbox-agent experiment combines test-case-level and experiment-level Agent Skills (`merge` / `disable_test_case`). Forward-compatible (optional field).

This is the OSS half of a two-repo change. The commercial fork (`cozeloop-commercial`) emits this field to the case-file `experiment_info.skills_mode`, and carries the test-case-level `skills` list to `dataset_item.skills` (aligned with runtime `testcase.TestCase.Skills`). See companion commercial MR.

## Changes

- `idl/thrift/.../domain/expt.thrift` + `domain_openapi/experiment.thrift`: add `skills_mode` field to `RunModeConfig`
- `backend/.../domain/entity/expt.go`: `RunModeConfig.SkillsMode`
- `backend/.../application/convertor/experiment/{expt,openapi}.go`: wire the field through convertors
- `backend/kitex_gen/...`: regenerated via `code_gen.sh`

## Verification

- `cd backend && go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)