### PR TITLE
[fix][evaluation] eval-set column filter only matched the primary eval set in multi-eval-set experiments

### DIFF
--- a/backend/modules/evaluation/application/wire.go
+++ b/backend/modules/evaluation/application/wire.go
@@ -93,6 +93,7 @@ var (
 		domainservice.EvaluationSetDomainServiceSet,
 		domainservice.TargetDomainServiceSet,
 		domainservice.NewExptResultService,
+		domainservice.ProvideExptItemRefRepos,
 		domainservice.NewEvaluationAnalysisService,
 		// Infrastructure Sets
 		infrahttp.NewHTTPClient,

--- a/backend/modules/evaluation/application/wire_gen.go
+++ b/backend/modules/evaluation/application/wire_gen.go
@@ -156,9 +156,10 @@ func InitExperimentApplication(ctx context.Context, idgen2 idgen.IIDGenerator, d
 	evaluationSetItemService := service.NewEvaluationSetItemServiceImpl(iDatasetRPCAdapter)
 	iEvaluationAnalysisService := service.NewEvaluationAnalysisService()
 	iFileProvider := foundation.NewFileRPCProvider(fileClient)
-	exptResultService := service.NewExptResultService(iExptItemResultRepo, iExptTurnResultRepo, iExptAnnotateRepo, iExptStatsRepo, iExperimentRepo, exptMetric, iLatestWriteTracker, idgen2, iExptTurnResultFilterRepo, serviceEvaluatorService, iEvalTargetService, iEvalTargetRepo, evaluationSetVersionService, iEvaluationSetService, evaluatorRecordService, evaluationSetItemService, exptEventPublisher, iTagRPCAdapter, iEvaluationAnalysisService, iFileProvider, iEvaluatorScoreCalculator)
 	iExptItemRefDAO := mysql.NewExptItemRefDAO(db2)
 	iExptItemRefRepo := experiment.NewExptItemRefRepo(iExptItemRefDAO)
+	v3 := service.ProvideExptItemRefRepos(iExptItemRefRepo)
+	exptResultService := service.NewExptResultService(iExptItemResultRepo, iExptTurnResultRepo, iExptAnnotateRepo, iExptStatsRepo, iExperimentRepo, exptMetric, iLatestWriteTracker, idgen2, iExptTurnResultFilterRepo, serviceEvaluatorService, iEvalTargetService, iEvalTargetRepo, evaluationSetVersionService, iEvaluationSetService, evaluatorRecordService, evaluationSetItemService, exptEventPublisher, iTagRPCAdapter, iEvaluationAnalysisService, iFileProvider, iEvaluatorScoreCalculator, v3...)
 	iQuotaDAO := dao.NewQuotaDAO(cmdable)
 	quotaRepo := experiment.NewQuotaService(iQuotaDAO, iLocker)
 	iExptTemplateDAO := mysql.NewExptTemplateDAO(db2)
@@ -175,11 +176,11 @@ func InitExperimentApplication(ctx context.Context, idgen2 idgen.IIDGenerator, d
 	}
 	resourceAccessAuthorizer := service.NewResourceAccessAuthorizer(iAuthProvider, sharedResourceConfigProvider)
 	iExptManager := service.NewExptManager(exptResultService, iExperimentRepo, iExptRunLogRepo, iExptStatsRepo, iExptItemResultRepo, iExptItemRefRepo, iExptTurnResultRepo, componentIConfiger, quotaRepo, iLocker, idempotentService, exptEventPublisher, auditClient, idgen2, exptMetric, iLatestWriteTracker, evaluationSetVersionService, iEvaluationSetService, iEvalTargetService, serviceEvaluatorService, benefitSvc, exptAggrResultService, iExptTemplateRepo, iExptTemplateManager, iNotifyRPCAdapter, iUserProvider, pipelineListAdapter, resourceAccessAuthorizer, sandboxAgentMetrics)
-	v3 := service.ProvideNoSandboxAgentNotifiers()
-	schedulerModeFactory := service.NewSchedulerModeFactory(iExptManager, iExptItemResultRepo, iExptStatsRepo, iExptTurnResultRepo, idgen2, evaluationSetItemService, iExperimentRepo, iExptItemRefRepo, idempotentService, componentIConfiger, exptEventPublisher, evaluatorRecordService, exptResultService, iExptTemplateManager, iExptRunLogRepo, iLocker, v3...)
+	v4 := service.ProvideNoSandboxAgentNotifiers()
+	schedulerModeFactory := service.NewSchedulerModeFactory(iExptManager, iExptItemResultRepo, iExptStatsRepo, iExptTurnResultRepo, idgen2, evaluationSetItemService, iExperimentRepo, iExptItemRefRepo, idempotentService, componentIConfiger, exptEventPublisher, evaluatorRecordService, exptResultService, iExptTemplateManager, iExptRunLogRepo, iLocker, v4...)
 	iItemCompletePublisher := service.ProvideNilItemCompletePublisher()
-	exptSchedulerEvent := service.NewExptSchedulerSvc(iExptManager, iExperimentRepo, iExptItemResultRepo, iExptTurnResultRepo, iEvaluatorRecordRepo, iExptStatsRepo, iExptRunLogRepo, idempotentService, componentIConfiger, quotaRepo, iLocker, exptEventPublisher, auditClient, exptMetric, exptResultService, idgen2, evaluationSetItemService, schedulerModeFactory, iEvalTargetService, iItemCompletePublisher, iExptItemRefRepo, sandboxAgentMetrics, v3...)
-	exptItemEvalEvent := service.NewExptRecordEvalService(iExptManager, componentIConfiger, exptEventPublisher, iExptItemResultRepo, iExptTurnResultRepo, iExptStatsRepo, iExperimentRepo, iExptItemRefRepo, quotaRepo, iLocker, idempotentService, auditClient, exptMetric, exptResultService, iEvalTargetService, evaluationSetItemService, evaluatorRecordService, serviceEvaluatorService, idgen2, benefitSvc, iEvalAsyncRepo, iItemCompletePublisher, sandboxAgentMetrics, v3...)
+	exptSchedulerEvent := service.NewExptSchedulerSvc(iExptManager, iExperimentRepo, iExptItemResultRepo, iExptTurnResultRepo, iEvaluatorRecordRepo, iExptStatsRepo, iExptRunLogRepo, idempotentService, componentIConfiger, quotaRepo, iLocker, exptEventPublisher, auditClient, exptMetric, exptResultService, idgen2, evaluationSetItemService, schedulerModeFactory, iEvalTargetService, iItemCompletePublisher, iExptItemRefRepo, sandboxAgentMetrics, v4...)
+	exptItemEvalEvent := service.NewExptRecordEvalService(iExptManager, componentIConfiger, exptEventPublisher, iExptItemResultRepo, iExptTurnResultRepo, iExptStatsRepo, iExperimentRepo, iExptItemRefRepo, quotaRepo, iLocker, idempotentService, auditClient, exptMetric, exptResultService, iEvalTargetService, evaluationSetItemService, evaluatorRecordService, serviceEvaluatorService, idgen2, benefitSvc, iEvalAsyncRepo, iItemCompletePublisher, sandboxAgentMetrics, v4...)
 	iExptAnnotateService := service.NewExptAnnotateService(db2, iExptAnnotateRepo, iExptTurnResultRepo, exptEventPublisher, evaluationSetItemService, iExperimentRepo, exptResultService, iExptTurnResultFilterRepo, iExptAggrResultRepo)
 	exptResultExportRecordDAO := mysql.NewExptResultExportRecordDAO(db2)
 	iExptResultExportRecordRepo := experiment.NewExptResultExportRecordRepo(exptResultExportRecordDAO, idgen2)
@@ -282,7 +283,10 @@ func InitEvaluatorApplication(ctx context.Context, idgen2 idgen.IIDGenerator, au
 	evaluationSetItemService := service.NewEvaluationSetItemServiceImpl(iDatasetRPCAdapter)
 	iTagRPCAdapter := tag.NewTagRPCProvider(tagClient)
 	iEvaluationAnalysisService := service.NewEvaluationAnalysisService()
-	exptResultService := service.NewExptResultService(iExptItemResultRepo, iExptTurnResultRepo, iExptAnnotateRepo, iExptStatsRepo, iExperimentRepo, exptMetric, iLatestWriteTracker, idgen2, iExptTurnResultFilterRepo, evaluatorService, iEvalTargetService, iEvalTargetRepo, evaluationSetVersionService, iEvaluationSetService, evaluatorRecordService, evaluationSetItemService, exptEventPublisher, iTagRPCAdapter, iEvaluationAnalysisService, iFileProvider, iEvaluatorScoreCalculator)
+	iExptItemRefDAO := mysql.NewExptItemRefDAO(db2)
+	iExptItemRefRepo := experiment.NewExptItemRefRepo(iExptItemRefDAO)
+	v3 := service.ProvideExptItemRefRepos(iExptItemRefRepo)
+	exptResultService := service.NewExptResultService(iExptItemResultRepo, iExptTurnResultRepo, iExptAnnotateRepo, iExptStatsRepo, iExperimentRepo, exptMetric, iLatestWriteTracker, idgen2, iExptTurnResultFilterRepo, evaluatorService, iEvalTargetService, iEvalTargetRepo, evaluationSetVersionService, iEvaluationSetService, evaluatorRecordService, evaluationSetItemService, exptEventPublisher, iTagRPCAdapter, iEvaluationAnalysisService, iFileProvider, iEvaluatorScoreCalculator, v3...)
 	evaluationEvaluatorService := NewEvaluatorHandlerImpl(idgen2, iConfiger, iAuthProvider, evaluatorService, evaluatorRecordService, evaluatorTemplateService, evaluatorExecMetrics, userInfoService, auditClient, benefitSvc, iFileProvider, v, exptResultService, iEvalAsyncRepo)
 	return evaluationEvaluatorService, nil
 }
@@ -337,7 +341,7 @@ func InitEvalTargetApplication(ctx context.Context, idgen2 idgen.IIDGenerator, d
 	return evalTargetService, nil
 }
 
-func InitEvalOpenAPIApplication(ctx context.Context, configFactory conf.IConfigLoaderFactory, rmqFactory mq.IFactory, cmdable redis.Cmdable, idgen2 idgen.IIDGenerator, db2 db.Provider, client promptmanageservice.Client, executeClient promptexecuteservice.Client, authClient authservice.Client, meter metrics.Meter, dataClient datasetservice.Client, userClient userservice.Client, llmClient llmruntimeservice.Client, tagClient tagservice.Client, limiterFactory limiter.IRateLimiterFactory, objectStorage fileserver.ObjectStorage, batchObjectStorage fileserver.BatchObjectStorage, auditClient audit.IAuditService, benefitService benefit.IBenefitService, ckProvider ck.Provider, plainLimiterFactory limiter.IPlainRateLimiterFactory, trajectoryAdapter rpc.ITrajectoryAdapter, fileClient fileservice.Client, taskClientFactory func() taskservice.Client, scheduleAdapter rpc.IExptScheduleAdapter) (IEvalOpenAPIApplication, error) {
+func InitEvalOpenAPIApplication(ctx context.Context, configFactory conf.IConfigLoaderFactory, rmqFactory mq.IFactory, cmdable redis.Cmdable, idgen2 idgen.IIDGenerator, db2 db.Provider, client promptmanageservice.Client, executeClient promptexecuteservice.Client, authClient authservice.Client, meter metrics.Meter, dataClient datasetservice.Client, userClient userservice.Client, llmClient llmruntimeservice.Client, tagClient tagservice.Client, limiterFactory limiter.IRateLimiterFactory, objectStorage fileserver.ObjectStorage, batchObjectStorage fileserver.BatchObjectStorage, auditClient audit.IAuditService, benefitService benefit.IBenefitService, ckProvider ck.Provider, plainLimiterFactory limiter.IPlainRateLimiterFactory, trajectoryAdapter rpc.ITrajectoryAdapter, fileClient fileservice.Client, taskClientFactory func() taskservice.Client, scheduleAdapter rpc.IExptScheduleAdapter) (evaluation.EvalOpenAPIService, error) {
 	iConfiger, err := conf2.NewConfiger(configFactory)
 	if err != nil {
 		return nil, err
@@ -424,9 +428,10 @@ func InitEvalOpenAPIApplication(ctx context.Context, configFactory conf.IConfigL
 	iExptTurnResultFilterRepo := experiment.NewExptTurnResultFilterRepo(iExptTurnResultFilterDAO, iExptTurnResultFilterKeyMappingDAO)
 	iEvaluationAnalysisService := service.NewEvaluationAnalysisService()
 	iFileProvider := foundation.NewFileRPCProvider(fileClient)
-	exptResultService := service.NewExptResultService(iExptItemResultRepo, iExptTurnResultRepo, iExptAnnotateRepo, iExptStatsRepo, iExperimentRepo, exptMetric, iLatestWriteTracker, idgen2, iExptTurnResultFilterRepo, evaluatorService, iEvalTargetService, iEvalTargetRepo, evaluationSetVersionService, iEvaluationSetService, evaluatorRecordService, evaluationSetItemService, exptEventPublisher, iTagRPCAdapter, iEvaluationAnalysisService, iFileProvider, iEvaluatorScoreCalculator)
 	iExptItemRefDAO := mysql.NewExptItemRefDAO(db2)
 	iExptItemRefRepo := experiment.NewExptItemRefRepo(iExptItemRefDAO)
+	v3 := service.ProvideExptItemRefRepos(iExptItemRefRepo)
+	exptResultService := service.NewExptResultService(iExptItemResultRepo, iExptTurnResultRepo, iExptAnnotateRepo, iExptStatsRepo, iExperimentRepo, exptMetric, iLatestWriteTracker, idgen2, iExptTurnResultFilterRepo, evaluatorService, iEvalTargetService, iEvalTargetRepo, evaluationSetVersionService, iEvaluationSetService, evaluatorRecordService, evaluationSetItemService, exptEventPublisher, iTagRPCAdapter, iEvaluationAnalysisService, iFileProvider, iEvaluatorScoreCalculator, v3...)
 	iQuotaDAO := dao.NewQuotaDAO(cmdable)
 	quotaRepo := experiment.NewQuotaService(iQuotaDAO, iLocker)
 	iExptTemplateDAO := mysql.NewExptTemplateDAO(db2)
@@ -442,11 +447,11 @@ func InitEvalOpenAPIApplication(ctx context.Context, configFactory conf.IConfigL
 	}
 	resourceAccessAuthorizer := service.NewResourceAccessAuthorizer(iAuthProvider, sharedResourceConfigProvider)
 	iExptManager := service.NewExptManager(exptResultService, iExperimentRepo, iExptRunLogRepo, iExptStatsRepo, iExptItemResultRepo, iExptItemRefRepo, iExptTurnResultRepo, iConfiger, quotaRepo, iLocker, idempotentService, exptEventPublisher, auditClient, idgen2, exptMetric, iLatestWriteTracker, evaluationSetVersionService, iEvaluationSetService, iEvalTargetService, evaluatorService, benefitService, exptAggrResultService, iExptTemplateRepo, iExptTemplateManager, iNotifyRPCAdapter, iUserProvider, pipelineListAdapter, resourceAccessAuthorizer, sandboxAgentMetrics)
-	v3 := service.ProvideNoSandboxAgentNotifiers()
-	schedulerModeFactory := service.NewSchedulerModeFactory(iExptManager, iExptItemResultRepo, iExptStatsRepo, iExptTurnResultRepo, idgen2, evaluationSetItemService, iExperimentRepo, iExptItemRefRepo, idempotentService, iConfiger, exptEventPublisher, evaluatorRecordService, exptResultService, iExptTemplateManager, iExptRunLogRepo, iLocker, v3...)
+	v4 := service.ProvideNoSandboxAgentNotifiers()
+	schedulerModeFactory := service.NewSchedulerModeFactory(iExptManager, iExptItemResultRepo, iExptStatsRepo, iExptTurnResultRepo, idgen2, evaluationSetItemService, iExperimentRepo, iExptItemRefRepo, idempotentService, iConfiger, exptEventPublisher, evaluatorRecordService, exptResultService, iExptTemplateManager, iExptRunLogRepo, iLocker, v4...)
 	iItemCompletePublisher := service.ProvideNilItemCompletePublisher()
-	exptSchedulerEvent := service.NewExptSchedulerSvc(iExptManager, iExperimentRepo, iExptItemResultRepo, iExptTurnResultRepo, iEvaluatorRecordRepo, iExptStatsRepo, iExptRunLogRepo, idempotentService, iConfiger, quotaRepo, iLocker, exptEventPublisher, auditClient, exptMetric, exptResultService, idgen2, evaluationSetItemService, schedulerModeFactory, iEvalTargetService, iItemCompletePublisher, iExptItemRefRepo, sandboxAgentMetrics, v3...)
-	exptItemEvalEvent := service.NewExptRecordEvalService(iExptManager, iConfiger, exptEventPublisher, iExptItemResultRepo, iExptTurnResultRepo, iExptStatsRepo, iExperimentRepo, iExptItemRefRepo, quotaRepo, iLocker, idempotentService, auditClient, exptMetric, exptResultService, iEvalTargetService, evaluationSetItemService, evaluatorRecordService, evaluatorService, idgen2, benefitService, iEvalAsyncRepo, iItemCompletePublisher, sandboxAgentMetrics, v3...)
+	exptSchedulerEvent := service.NewExptSchedulerSvc(iExptManager, iExperimentRepo, iExptItemResultRepo, iExptTurnResultRepo, iEvaluatorRecordRepo, iExptStatsRepo, iExptRunLogRepo, idempotentService, iConfiger, quotaRepo, iLocker, exptEventPublisher, auditClient, exptMetric, exptResultService, idgen2, evaluationSetItemService, schedulerModeFactory, iEvalTargetService, iItemCompletePublisher, iExptItemRefRepo, sandboxAgentMetrics, v4...)
+	exptItemEvalEvent := service.NewExptRecordEvalService(iExptManager, iConfiger, exptEventPublisher, iExptItemResultRepo, iExptTurnResultRepo, iExptStatsRepo, iExperimentRepo, iExptItemRefRepo, quotaRepo, iLocker, idempotentService, auditClient, exptMetric, exptResultService, iEvalTargetService, evaluationSetItemService, evaluatorRecordService, evaluatorService, idgen2, benefitService, iEvalAsyncRepo, iItemCompletePublisher, sandboxAgentMetrics, v4...)
 	iExptAnnotateService := service.NewExptAnnotateService(db2, iExptAnnotateRepo, iExptTurnResultRepo, exptEventPublisher, evaluationSetItemService, iExperimentRepo, exptResultService, iExptTurnResultFilterRepo, iExptAggrResultRepo)
 	exptResultExportRecordDAO := mysql.NewExptResultExportRecordDAO(db2)
 	iExptResultExportRecordRepo := experiment.NewExptResultExportRecordRepo(exptResultExportRecordDAO, idgen2)
@@ -463,8 +468,8 @@ func InitEvalOpenAPIApplication(ctx context.Context, configFactory conf.IConfigL
 	exptLifecycleEventHandler := service.NewExptLifecycleEventHandler(iExperimentRepo, iNotifyRPCAdapter, iUserProvider, webhookDispatcher)
 	iExperimentApplication := NewExperimentApplication(exptAggrResultService, exptResultService, iExptManager, exptSchedulerEvent, exptItemEvalEvent, idgen2, iConfiger, iAuthProvider, userInfoService, iEvalTargetService, evaluationSetItemService, iExptAnnotateService, iTagRPCAdapter, iExptResultExportService, iExptInsightAnalysisService, evaluatorService, iExptTemplateManager, iFileProvider, exptLifecycleEventHandler, sandboxSchedulerAdapter, sandboxAgentMetrics)
 	evaluatorCallbackDispatcher := service.NewEvaluatorCallbackDispatcher(noopWebhookSecretProvider)
-	v4 := NewEvalOpenAPIApplication(iEvalAsyncRepo, exptEventPublisher, iEvalTargetService, iEvalTargetRepo, iAuthProvider, iEvaluationSetService, evaluationSetVersionService, evaluationSetItemService, evaluationSetSchemaService, openAPIEvaluationMetrics, sandboxAgentMetrics, userInfoService, iExperimentApplication, iExptManager, exptResultService, exptAggrResultService, evaluatorService, evaluatorRecordService, iExptTemplateManager, iConfiger, sandboxSchedulerAdapter, iFileProvider, evaluatorCallbackDispatcher, resourceAccessAuthorizer)
-	return v4, nil
+	evalOpenAPIService := NewEvalOpenAPIApplication(iEvalAsyncRepo, exptEventPublisher, iEvalTargetService, iEvalTargetRepo, iAuthProvider, iEvaluationSetService, evaluationSetVersionService, evaluationSetItemService, evaluationSetSchemaService, openAPIEvaluationMetrics, sandboxAgentMetrics, userInfoService, iExperimentApplication, iExptManager, exptResultService, exptAggrResultService, evaluatorService, evaluatorRecordService, iExptTemplateManager, iConfiger, sandboxSchedulerAdapter, iFileProvider, evaluatorCallbackDispatcher, resourceAccessAuthorizer)
+	return evalOpenAPIService, nil
 }
 
 // wire.go:
@@ -478,7 +483,7 @@ var (
 	)
 
 	evaluatorSet = wire.NewSet(
-		NewEvaluatorHandlerImpl, service.EvaluatorDomainServiceSet, service.EvaluationSetDomainServiceSet, service.TargetDomainServiceSet, service.NewExptResultService, service.NewEvaluationAnalysisService, http.NewHTTPClient, foundation.FoundationRPCSet, tag.TagRPCSet, trajectory.TrajectoryRPCSet, userinfo.NewUserInfoServiceImpl, experiment.ExperimentRepoSet, metrics2.ExperimentMetricsSet, metrics3.EvalTargetMetricsSet, sandbox_agent.SandboxAgentMetricsSet, conf2.NewConfiger, flagSet, storage.StorageSet,
+		NewEvaluatorHandlerImpl, service.EvaluatorDomainServiceSet, service.EvaluationSetDomainServiceSet, service.TargetDomainServiceSet, service.NewExptResultService, service.ProvideExptItemRefRepos, service.NewEvaluationAnalysisService, http.NewHTTPClient, foundation.FoundationRPCSet, tag.TagRPCSet, trajectory.TrajectoryRPCSet, userinfo.NewUserInfoServiceImpl, experiment.ExperimentRepoSet, metrics2.ExperimentMetricsSet, metrics3.EvalTargetMetricsSet, sandbox_agent.SandboxAgentMetricsSet, conf2.NewConfiger, flagSet, storage.StorageSet,
 	)
 
 	evaluationSetSet = wire.NewSet(

--- a/backend/modules/evaluation/domain/entity/expt_result.go
+++ b/backend/modules/evaluation/domain/entity/expt_result.go
@@ -690,16 +690,6 @@ type ItemSnapshotVersionCond struct {
 	Cond *ItemSnapshotFilter `json:"cond,omitempty"`
 }
 
-func (c *ItemSnapshotVersionCond) HasCond() bool {
-	if c == nil || c.Cond == nil {
-		return false
-	}
-	return len(c.Cond.BoolMapFilters) > 0 ||
-		len(c.Cond.FloatMapFilters) > 0 ||
-		len(c.Cond.IntMapFilters) > 0 ||
-		len(c.Cond.StringMapFilters) > 0
-}
-
 type ExptTurnResultFilter struct {
 	TrunRunStateFilters []*TurnRunStateFilter
 	ScoreFilters        []*ScoreFilter

--- a/backend/modules/evaluation/domain/entity/expt_result.go
+++ b/backend/modules/evaluation/domain/entity/expt_result.go
@@ -671,6 +671,35 @@ type KeywordFilter struct {
 	Keyword               *string
 }
 
+// ItemSnapshotVersionCond 单个「评测集版本」维度的快照筛选条件。
+//
+// ★ 多评测集实验 (MultiSetConfig) 必须 per-set 组织：字段映射 (field_key -> string_map/int_map 的
+// subkey)、快照表分区列 sync_ck_date、评测集来源空间，三者都是按 (space_id, version_id) 存的，
+// 各评测集各一份、不保证一致。只用主集那一份去查，非主集的 item 在该版本分区下根本不存在，
+// 表现为「内容筛选只在第一个评测集上生效」。
+// 单评测集实验退化为 1 组，语义与改动前完全一致。
+type ItemSnapshotVersionCond struct {
+	EvalSetID        int64 `json:"eval_set_id"`
+	EvalSetVersionID int64 `json:"eval_set_version_id"`
+	// SourceSpaceID 该评测集来源空间 (跨空间共享)；0=同实验空间。
+	SourceSpaceID int64 `json:"source_space_id"`
+	// SyncCkDate 该版本快照表的分区列取值，由 mapping RPC 随 field mapping 一起返回。
+	// 快照表开了 force_index_by_date，缺它的查询会被直接拒绝，故为空的组不可查。
+	SyncCkDate string `json:"sync_ck_date"`
+	// Cond 已按**该版本**的 mapping 翻译成 subkey 的条件。
+	Cond *ItemSnapshotFilter `json:"cond,omitempty"`
+}
+
+func (c *ItemSnapshotVersionCond) HasCond() bool {
+	if c == nil || c.Cond == nil {
+		return false
+	}
+	return len(c.Cond.BoolMapFilters) > 0 ||
+		len(c.Cond.FloatMapFilters) > 0 ||
+		len(c.Cond.IntMapFilters) > 0 ||
+		len(c.Cond.StringMapFilters) > 0
+}
+
 type ExptTurnResultFilter struct {
 	TrunRunStateFilters []*TurnRunStateFilter
 	ScoreFilters        []*ScoreFilter
@@ -702,6 +731,17 @@ type ExptTurnResultFilterAccelerator struct {
 	KeywordSearch     *KeywordFilter `json:"keyword_search"`
 	Page              Page           `json:"page"`
 	EvalSetSyncCkDate string
+	// ItemSnapshotCondBySet 多评测集实验的 per-set 快照条件：每个评测集版本一组，组间是 OR
+	// (item 只属于一个评测集，取 item_id 并集即可)。非空时 DAO 优先用它，忽略单值的
+	// ItemSnapshotCond / EvalSetSyncCkDate / EvalSetSpaceID；后三者保留给尚未 per-set 化的
+	// 调用方兜底，取值为主集那一组。
+	ItemSnapshotCondBySet []*ItemSnapshotVersionCond `json:"item_snapshot_cond_by_set,omitempty"`
+	// KeywordItemSnapshotCondBySet 关键词搜索的 per-set 快照条件，语义同上。
+	KeywordItemSnapshotCondBySet []*ItemSnapshotVersionCond `json:"keyword_item_snapshot_cond_by_set,omitempty"`
+	// ItemSnapshotCondUnmatched 请求带了评测集列条件，但**没有任何**评测集版本能完整翻译出这些字段
+	// (字段不在任一 set 的 schema，或 mapping 缺失)。此时正确语义是「命中 0 条」而不是「不筛」——
+	// 老实现在翻译不到时 continue 丢条件，表现为筛选被静默忽略、返回全量数据。
+	ItemSnapshotCondUnmatched bool `json:"item_snapshot_cond_unmatched,omitempty"`
 	// IsOnlineExpt 是否在线实验，用于 QueryItemIDStates 拼接 SQL 时选择 join 的表名和条件
 	IsOnlineExpt bool `json:"is_online_expt"`
 }
@@ -727,6 +767,11 @@ func (e *ExptTurnResultFilterAccelerator) HasFilters() bool {
 		len(e.KeywordSearch.ItemSnapshotFilter.IntMapFilters) > 0 ||
 		len(e.KeywordSearch.ItemSnapshotFilter.StringMapFilters) > 0)) ||
 		len(e.KeywordSearch.EvalTargetDataFilters) > 0))
+	// per-set 快照条件 / 「无任何评测集可满足」标记同样构成筛选条件：
+	// 后者语义是命中 0 条，若这里返回 false 会退回全量列表，等于筛选被忽略。
+	hasFilters = hasFilters || len(e.ItemSnapshotCondBySet) > 0 ||
+		len(e.KeywordItemSnapshotCondBySet) > 0 ||
+		e.ItemSnapshotCondUnmatched
 
 	return hasFilters
 }

--- a/backend/modules/evaluation/domain/service/expt_crossspace_regression_test.go
+++ b/backend/modules/evaluation/domain/service/expt_crossspace_regression_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 	repoMocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/repo/mocks"
+	svcMocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/service/mocks"
 )
 
 // TestBackfillRefEvalSetSourceSpace_MixedSpaceMultiSet 钉住调度侧(重试链路)的混合空间多集回归。
@@ -65,6 +66,50 @@ func TestBackfillRefEvalSetSourceSpace_SingleSetFallback(t *testing.T) {
 	refs2 := []*entity.ExptItemRef{{ItemID: 1, EvalSetID: 10, EvalSetSourceSpaceID: 123}}
 	backfillRefEvalSetSourceSpace(refs2, nil)
 	assert.Equal(t, int64(123), refs2[0].EvalSetSourceSpaceID)
+}
+
+// TestResolveItemCompleteMeta_CrossSpaceEvalSet 钉住 item-complete 组装侧的跨空间回归。
+// 与上面两条同因: 从 DB 读回的 ref 不带来源空间, 必须先回填再按来源空间加载 item。
+// 漏回填 → 用调用方空间读跨空间评测集 → 601103001 → itemMeta 空 → sendItemComplete
+// 静默 skip publish, 整个实验一条 item-complete 都不发, 下游离线分析拿不到任何数据。
+func TestResolveItemCompleteMeta_CrossSpaceEvalSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	const (
+		consumerSpace = int64(9)
+		srcSpace      = int64(9001)
+		crossSet      = int64(71)
+		exptID        = int64(100)
+	)
+
+	expt := &entity.Experiment{
+		EvalSetSpaceID:    srcSpace,
+		EvalSetSourceType: entity.ExptEvalSetSourceType_MultiSetConfig,
+		EvalConf: &entity.EvaluationConfiguration{
+			EvalSetConfigs: []*entity.EvalSetConfig{{EvalSetID: crossSet, SourceSpaceID: srcSpace}},
+		},
+	}
+	event := &entity.ExptScheduleEvent{SpaceID: consumerSpace, ExptID: exptID, ExptRunID: 200}
+	items := []*entity.ExptEvalItem{{ItemID: 11}}
+
+	refRepo := repoMocks.NewMockIExptItemRefRepo(ctrl)
+	// 表无来源空间列(值只在 item_config blob 里), 读回的 ref 该字段恒为 0
+	refRepo.EXPECT().MGetByExptIDAndItemIDs(gomock.Any(), consumerSpace, exptID, []int64{11}).
+		Return([]*entity.ExptItemRef{{ItemID: 11, EvalSetID: crossSet, EvalSetVersionID: 81}}, nil)
+
+	setItemSvc := svcMocks.NewMockEvaluationSetItemService(ctrl)
+	setItemSvc.EXPECT().BatchGetEvaluationSetItems(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, p *entity.BatchGetEvaluationSetItemsParam) ([]*entity.EvaluationSetItem, error) {
+			assert.Equal(t, srcSpace, p.SpaceID, "须按评测集来源空间加载, 不能用调用方空间")
+			return []*entity.EvaluationSetItem{{ItemID: 11, ItemKey: "k11", EvaluationSetID: crossSet}}, nil
+		})
+
+	svc := &ExptSchedulerImpl{exptItemRefRepo: refRepo, evaluationSetItemService: setItemSvc}
+	meta, ver := svc.resolveItemCompleteMeta(context.Background(), event, items, expt)
+
+	assert.Equal(t, "k11", meta[11].ItemKey, "meta 补齐才会发 item-complete")
+	assert.Equal(t, int64(81), ver[11])
 }
 
 // TestCompleteItemRunOnUnretriableErr 钉住"失败且不重试"的兜底落库。

--- a/backend/modules/evaluation/domain/service/expt_result_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl.go
@@ -2979,8 +2979,10 @@ func (e ExptResultServiceImpl) mapItemSnapshotFilter(ctx context.Context, filter
 	condBySet := make([]*entity.ItemSnapshotVersionCond, 0, len(pairs))
 	keywordCondBySet := make([]*entity.ItemSnapshotVersionCond, 0, len(pairs))
 	var (
-		firstErr        error
-		mappingResolved bool
+		firstErr              error
+		mappingResolved       bool
+		translatedCond        bool
+		translatedKeywordCond bool
 	)
 	for idx, p := range pairs {
 		// ★ 跨空间共享: item snapshot field mapping 按 (space_id, version_id) 存在**评测集来源空间**下，
@@ -3026,6 +3028,24 @@ func (e ExptResultServiceImpl) mapItemSnapshotFilter(ctx context.Context, filter
 		// setCondFull=false 表示该集缺其中某个字段：条件不能只应用一半（会放宽成"少筛一个条件"），
 		// 该集直接不入组 → 贡献 0 条。
 		if hasCond && setCondFull {
+			translatedCond = true
+		}
+		if hasKeywordCond && setKeywordFull {
+			translatedKeywordCond = true
+		}
+		// 该组能否真的用于查快照表：离线必须有 version_id + 分区日期 sync_ck_date，
+		// 在线必须有 dataset_id。缺任何一样都不能拼成组 —— 拼了会得到 version_id='0'
+		// 之类的恒假谓词、静默返回 0 条。此时宁可让 per-set 列表为空，退回单值老路径
+		// (老路径有「从 etrf 反查 version」的兜底和显式报错)。
+		queryable := p.EvalSetID > 0
+		if !isOnline {
+			queryable = p.EvalSetVersionID > 0 && strings.TrimSpace(syncCkDate) != ""
+		}
+		if !queryable {
+			logs.CtxWarn(ctx, "item snapshot group not queryable, evalSetID: %v, versionID: %v, syncCkDate: %q", p.EvalSetID, p.EvalSetVersionID, syncCkDate)
+			continue
+		}
+		if hasCond && setCondFull {
 			condBySet = append(condBySet, &entity.ItemSnapshotVersionCond{
 				EvalSetID:        p.EvalSetID,
 				EvalSetVersionID: p.EvalSetVersionID,
@@ -3053,12 +3073,18 @@ func (e ExptResultServiceImpl) mapItemSnapshotFilter(ctx context.Context, filter
 
 	filter.ItemSnapshotCondBySet = condBySet
 	filter.KeywordItemSnapshotCondBySet = keywordCondBySet
-	// 带了条件却没有任何评测集能完整翻译出来 → 语义是命中 0 条。
-	// 老实现在这里把条件 continue 掉，退化成"不筛"，返回全量数据。
-	filter.ItemSnapshotCondUnmatched = (hasCond && len(condBySet) == 0) ||
-		(hasKeywordCond && len(keywordCondBySet) == 0)
+	// Unmatched 只表示「字段翻译不出来」：任何评测集都没有该 field_key 的 mapping，
+	// 语义是命中 0 条（老实现在这里 continue 丢条件，退化成"不筛"、返回全量数据）。
+	//
+	// 注意与「翻译出来了但该组不可查」区分：后者(version/分区日期缺失)不置 Unmatched，
+	// per-set 列表为空 → DAO 退回单值老路径，保住老数据的兜底能力，绝不静默返 0。
+	filter.ItemSnapshotCondUnmatched = (hasCond && !translatedCond) ||
+		(hasKeywordCond && !translatedKeywordCond)
 	if filter.ItemSnapshotCondUnmatched {
 		logs.CtxWarn(ctx, "item snapshot filter matched no eval set, exptID: %v, hasCond: %v, hasKeywordCond: %v", baseExpt.ID, hasCond, hasKeywordCond)
+	}
+	if !filter.ItemSnapshotCondUnmatched && hasCond && len(condBySet) == 0 {
+		logs.CtxWarn(ctx, "item snapshot per-set conds all unqueryable, fallback to single-value path, exptID: %v", baseExpt.ID)
 	}
 
 	return nil

--- a/backend/modules/evaluation/domain/service/expt_result_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl.go
@@ -58,8 +58,16 @@ func NewExptResultService(
 	analysisService IEvaluationAnalysisService,
 	fileProvider rpc.IFileProvider,
 	scoreCalculator IEvaluatorScoreCalculator,
+	// exptItemRefRepo ★ MultiSetConfig 实验按 item 回填 eval_set_id/eval_set_version_id 用。
+	// variadic 保持既有调用方（含商业化 wire）向后兼容。
+	exptItemRefRepo ...repo.IExptItemRefRepo,
 ) ExptResultService {
+	var itemRefRepo repo.IExptItemRefRepo
+	if len(exptItemRefRepo) > 0 {
+		itemRefRepo = exptItemRefRepo[0]
+	}
 	return &ExptResultServiceImpl{
+		exptItemRefRepo:             itemRefRepo,
 		ExptItemResultRepo:          exptItemResultRepo,
 		ExptTurnResultRepo:          exptTurnResultRepo,
 		ExptAnnotateRepo:            exptAnnotateRepo,
@@ -95,6 +103,9 @@ type ExptResultServiceImpl struct {
 	exptTurnResultFilterRepo repo.IExptTurnResultFilterRepo
 	ExptAnnotateRepo         repo.IExptAnnotateRepo
 	tagRPCAdapter            rpc.ITagRPCAdapter
+	// exptItemRefRepo ★ 多评测集实验 item -> (eval_set_id, eval_set_version_id) 的真值源；
+	// 可能为 nil（老调用方未注入），此时退化为按主集写入。
+	exptItemRefRepo repo.IExptItemRefRepo
 
 	evalTargetService           IEvalTargetService
 	evalTargetRepo              repo.IEvalTargetRepo
@@ -811,7 +822,7 @@ func (e ExptResultServiceImpl) ListTurnResult(ctx context.Context, param *entity
 			total = iTotal
 		} else {
 			logs.CtxInfo(ctx, "filter accelerator has filters, exptID: %v", baseExptID)
-			if err = e.mapItemSnapshotFilter(ctx, filterAccelerator, expt, expt.EvalSetVersionID); err != nil {
+			if err = e.mapItemSnapshotFilter(ctx, filterAccelerator, expt); err != nil {
 				logs.CtxError(ctx, "mapItemSnapshotFilter failed: %v", err)
 				errOccur = true
 			}
@@ -1308,6 +1319,11 @@ type PayloadBuilder struct {
 	LoadEvalTargetFullContent bool
 	// LoadEvalTargetOutputFieldKeys 非空时仅按需加载指定 output 字段的完整内容
 	LoadEvalTargetOutputFieldKeys []string
+
+	// ItemID2EvalSetRef ★ 多评测集实验 item -> 归属评测集(含版本) 的映射, 来源 expt_item_ref。
+	// 写 expt_turn_result_filter 时逐行按此回填 eval_set_id/eval_set_version_id;
+	// 为空则退化成全部按主集写(老行为)。
+	ItemID2EvalSetRef map[int64]*entity.ExptItemRef
 }
 
 func NewPayloadBuilder(ctx context.Context, param *entity.MGetExperimentResultParam, baselineExptID int64, baselineTurnResults []*entity.ExptTurnResult,
@@ -1705,7 +1721,7 @@ func (b *PayloadBuilder) BuildTurnResultFilter(ctx context.Context) ([]*entity.E
 	if exptDO.ExptType == entity.ExptType_Online {
 		evalSetVersionID = 0
 	}
-	err = b.fillExptTurnResultFilters(ctx, exptDO.StartAt, evalSetID, evalSetVersionID)
+	err = b.fillExptTurnResultFilters(ctx, exptDO.StartAt, evalSetID, evalSetVersionID, exptDO.ExptType == entity.ExptType_Online)
 	if err != nil {
 		return nil, err
 	}
@@ -1713,7 +1729,7 @@ func (b *PayloadBuilder) BuildTurnResultFilter(ctx context.Context) ([]*entity.E
 	return b.ExptTurnResultFilters, nil
 }
 
-func (b *PayloadBuilder) fillExptTurnResultFilters(ctx context.Context, createdDate *time.Time, evalSetID, evalSetVersionID int64) error {
+func (b *PayloadBuilder) fillExptTurnResultFilters(ctx context.Context, createdDate *time.Time, evalSetID, evalSetVersionID int64, isOnline bool) error {
 	exptResultBuilder := b.ExptResultBuilders[0]
 	b.ExptTurnResultFilters = make([]*entity.ExptTurnResultFilterEntity, 0)
 	itemID2ItemIdx := make(map[int64]*entity.ExptItemResult)
@@ -1737,6 +1753,18 @@ func (b *PayloadBuilder) fillExptTurnResultFilters(ctx context.Context, createdD
 			CreatedDate:       ptr.From(createdDate),
 			EvalSetID:         evalSetID,
 			EvalSetVersionID:  evalSetVersionID,
+		}
+		// ★ 多评测集实验: 逐行回填该 item 真实归属的评测集(含版本)。
+		// 老实现给所有行盖同一个主集 version, 导致 CK 侧按 version 关联快照表时
+		// 非主集 item 恒关联不上, 内容筛选只在第一个评测集上生效。
+		if ref := b.ItemID2EvalSetRef[exptTurnResult.ItemID]; ref != nil {
+			if ref.EvalSetID > 0 {
+				exptTurnResultFilter.EvalSetID = ref.EvalSetID
+			}
+			// 在线实验 eval_set_version_id 固定写 0, 不覆盖。
+			if !isOnline && ref.EvalSetVersionID > 0 {
+				exptTurnResultFilter.EvalSetVersionID = ref.EvalSetVersionID
+			}
 		}
 		exptTurnResultFilter.ExptID = b.BaselineExptID
 		exptTurnResultFilter.SpaceID = b.SpaceID
@@ -2875,6 +2903,10 @@ func (e ExptResultServiceImpl) UpsertExptTurnResultFilter(ctx context.Context, s
 	payloadBuilder := NewPayloadBuilder(ctx, param, exptID, allTurnResults, itemResults, e.ExperimentRepo,
 		e.ExptTurnResultRepo, e.ExptItemResultRepo, e.ExptAnnotateRepo, e.evalTargetRepo, e.evalTargetService, e.evaluatorRecordService, e.evaluationSetItemService, e.evaluationSetVersionService, e.evaluationSetService, e.analysisService, exptTurnResultFilterKeyMappingEvaluatorMap, exptTurnResultFilterKeyMappingAnnotationMap, make(map[int64]entity.ItemRunState), e.fileProvider, e.scoreCalculator)
 
+	// ★ 多评测集实验: 逐 item 取归属评测集(含版本), 供写 expt_turn_result_filter 时按行回填。
+	// 拿不到(老调用方未注入 repo / 查询失败)时只告警, 退化为按主集写, 不阻塞写入。
+	payloadBuilder.ItemID2EvalSetRef = e.loadItemEvalSetRefs(ctx, spaceID, exptID, itemIDs)
+
 	exptTurnResultFilters, err := payloadBuilder.BuildTurnResultFilter(ctx)
 	if err != nil {
 		return err
@@ -2887,158 +2919,204 @@ func (e ExptResultServiceImpl) UpsertExptTurnResultFilter(ctx context.Context, s
 	return nil
 }
 
-// 提取过滤器映射逻辑
-func (e ExptResultServiceImpl) mapItemSnapshotFilter(ctx context.Context, filter *entity.ExptTurnResultFilterAccelerator, baseExpt *entity.Experiment, baseExptEvalSetVersionID int64) error {
-	hasCond := filter.ItemSnapshotCond != nil && len(filter.ItemSnapshotCond.StringMapFilters) > 0
-	hasKeywordCond := filter.KeywordSearch != nil && filter.KeywordSearch.ItemSnapshotFilter != nil &&
-		len(filter.KeywordSearch.ItemSnapshotFilter.StringMapFilters) > 0
+// loadItemEvalSetRefs 取 item -> expt_item_ref 映射 (多评测集实验的评测集归属真值源)。
+// 失败/未注入 repo 时返回 nil, 调用方退化为按主集处理。
+func (e ExptResultServiceImpl) loadItemEvalSetRefs(ctx context.Context, spaceID, exptID int64, itemIDs []int64) map[int64]*entity.ExptItemRef {
+	if e.exptItemRefRepo == nil || len(itemIDs) == 0 {
+		return nil
+	}
+	refs, err := e.exptItemRefRepo.MGetByExptIDAndItemIDs(ctx, spaceID, exptID, itemIDs)
+	if err != nil {
+		logs.CtxWarn(ctx, "loadItemEvalSetRefs failed, exptID: %v, err: %v", exptID, err)
+		return nil
+	}
+	res := make(map[int64]*entity.ExptItemRef, len(refs))
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		res[ref.ItemID] = ref
+	}
+	return res
+}
+
+// mapItemSnapshotFilter 把「评测集列」筛选条件从 field_key 翻译成快照表 (dataset_item_snapshot /
+// dataset_item_draft) 上的 map subkey，并解析出查询必需的 sync_ck_date / 来源空间。
+//
+// ★ 多评测集 (MultiSetConfig) 关键点：mapping、sync_ck_date、来源空间三者都是按
+// (space_id, version_id) 存的，各评测集各一份。老实现只按主集 (baseExpt.EvalSetID/
+// EvalSetVersionID) 解析一次，非主集 item 在主集版本的分区下不存在 → 内容筛选只在第一个
+// 评测集上生效。这里改为遍历实验的全部 (set, version, sourceSpace)，每个集产出一组条件，
+// 由 DAO 侧分组查询后取 item_id 并集。单评测集实验只有 1 组，行为与改动前一致。
+func (e ExptResultServiceImpl) mapItemSnapshotFilter(ctx context.Context, filter *entity.ExptTurnResultFilterAccelerator, baseExpt *entity.Experiment) error {
+	rawCond := filter.ItemSnapshotCond
+	var rawKeywordCond *entity.ItemSnapshotFilter
+	if filter.KeywordSearch != nil {
+		rawKeywordCond = filter.KeywordSearch.ItemSnapshotFilter
+	}
+
+	hasCond := rawCond != nil && len(rawCond.StringMapFilters) > 0
+	hasKeywordCond := rawKeywordCond != nil && len(rawKeywordCond.StringMapFilters) > 0
 	if !hasCond && !hasKeywordCond {
 		return nil
 	}
 	// map 类条件（评测集 schema 字段）需要 field_key → string_map/int_map/... 的映射，
-	// 对 mapping 是硬依赖：查不到就无法翻译条件，必须报错。
-	// 独立列条件（item_key 等 dataset_item_snapshot 上的物理列）不来自 schema、不需要 mapping。
-	//
-	// 但 mapping RPC 还顺带返回 sync_ck_date（快照表的分区列，下游查 dis 表要用），
-	// 所以这里不是简单跳过：只有独立列条件时仍**尽力**调一次拿 sync_ck_date，
-	// 失败只告警不报错 —— 否则评测集没有 fieldMapping 记录时会返回
-	// "createdVersion fieldMapping not found"，整条筛选链路 errOccur 退化成全量扫描。
-	needMapping := (filter.ItemSnapshotCond != nil && len(filter.ItemSnapshotCond.StringMapFilters) > 0) ||
-		(filter.KeywordSearch != nil && filter.KeywordSearch.ItemSnapshotFilter != nil &&
-			len(filter.KeywordSearch.ItemSnapshotFilter.StringMapFilters) > 0)
-	itemSnapshotMappingsMap := make(map[string]*entity.ItemSnapshotFieldMapping)
-	// ★ 跨空间共享: item snapshot field mapping 按 (space_id, version_id) 存在**评测集来源空间**下，
-	// 用实验所在空间去查必然 not found，连带丢掉 sync_ck_date（快照表分区列，下游必需）。
-	// 用实验冻结的 EvalSetSpaceID（0=同空间）解析，与 expt_annotate_impl 读 item 同口径。
-	// 注意不能走 EvalSet.SharedInfo：本链路的实验来自 ExperimentRepo.MGetByID，只加载实验行 +
-	// 评估器 ref，EvalSet 为 nil。
-	evalSetSpaceID := resolveLoadSpaceID(baseExpt.SpaceID, baseExpt.EvalSetSpaceID)
-	req := &rpc.QueryItemSnapshotMappingRequest{
-		SpaceID:        evalSetSpaceID,
-		DatasetID:      baseExpt.EvalSetID,
-		IsDraftVersion: baseExpt.ExptType == entity.ExptType_Online,
-		VersionID:      gcond.If(baseExpt.ExptType == entity.ExptType_Online, ptr.Of(int64(0)), ptr.Of(baseExpt.EvalSetVersionID)),
-	}
-	itemSnapshotMappings, syncCkDate, err := e.evaluationSetService.QueryItemSnapshotMappings(ctx, req)
-	if err != nil {
-		if needMapping {
-			return err
-		}
-		logs.CtxWarn(ctx, "QueryItemSnapshotMappings failed, proceeding with column-only filters, err: %v", err)
-	} else {
-		filter.EvalSetSyncCkDate = syncCkDate
-		for _, item := range itemSnapshotMappings {
-			itemSnapshotMappingsMap[item.FieldKey] = item
-		}
-	}
-	itemSnapshotFilter := &entity.ItemSnapshotFilter{
-		BoolMapFilters:   make([]*entity.FieldFilter, 0, len(filter.ItemSnapshotCond.BoolMapFilters)),
-		FloatMapFilters:  make([]*entity.FieldFilter, 0, len(filter.ItemSnapshotCond.FloatMapFilters)),
-		IntMapFilters:    make([]*entity.FieldFilter, 0, len(filter.ItemSnapshotCond.IntMapFilters)),
-		StringMapFilters: make([]*entity.FieldFilter, 0, len(filter.ItemSnapshotCond.StringMapFilters)),
-	}
-	for _, item := range filter.ItemSnapshotCond.StringMapFilters {
-		if itemSnapshotMappingsMap[item.Key] == nil {
-			logs.CtxWarn(ctx, "MGetExperimentResult found itemSnapshotMappingsMap not found, key: %v", item.Key)
-			continue
-		}
-		itemSnapshotMapping := itemSnapshotMappingsMap[item.Key]
-		switch itemSnapshotMapping.MappingKey {
-		case "string_map":
-			itemSnapshotFilter.StringMapFilters = append(itemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: item.Op, Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				itemSnapshotFilter.StringMapFilters = append(itemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
-			}
-		case "float_map":
-			itemSnapshotFilter.FloatMapFilters = append(itemSnapshotFilter.FloatMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: item.Op, Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				itemSnapshotFilter.StringMapFilters = append(itemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
-			}
-		case "int_map":
-			itemSnapshotFilter.IntMapFilters = append(itemSnapshotFilter.IntMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: item.Op, Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				itemSnapshotFilter.StringMapFilters = append(itemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
-			}
-		case "bool_map":
-			itemSnapshotFilter.BoolMapFilters = append(itemSnapshotFilter.BoolMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: item.Op, Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				itemSnapshotFilter.StringMapFilters = append(itemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
-			}
-		}
-	}
-	filter.ItemSnapshotCond = itemSnapshotFilter
+	// 对 mapping 是硬依赖：所有评测集都查不到就无法翻译条件，必须报错（让上游走 errOccur
+	// 降级到保留分页的普通查询），而不是静默返回 0 条。
+	needMapping := hasCond || hasKeywordCond
 
-	// 处理keyword search
-	keywordItemSnapshotFilter := &entity.ItemSnapshotFilter{
-		BoolMapFilters:   make([]*entity.FieldFilter, 0, len(filter.KeywordSearch.ItemSnapshotFilter.BoolMapFilters)),
-		FloatMapFilters:  make([]*entity.FieldFilter, 0, len(filter.KeywordSearch.ItemSnapshotFilter.FloatMapFilters)),
-		IntMapFilters:    make([]*entity.FieldFilter, 0, len(filter.KeywordSearch.ItemSnapshotFilter.IntMapFilters)),
-		StringMapFilters: make([]*entity.FieldFilter, 0, len(filter.KeywordSearch.ItemSnapshotFilter.StringMapFilters)),
+	isOnline := baseExpt.ExptType == entity.ExptType_Online
+	pairs := collectEvalSetVersionPairs(baseExpt)
+	if len(pairs) == 0 {
+		// 边界：主集 id/version 都为 0 的老数据，保持原有单集调用形态。
+		pairs = []evalSetVersionPair{{
+			EvalSetID:        baseExpt.EvalSetID,
+			EvalSetVersionID: baseExpt.EvalSetVersionID,
+			SourceSpaceID:    baseExpt.EvalSetSpaceID,
+		}}
 	}
-	for _, item := range filter.KeywordSearch.ItemSnapshotFilter.StringMapFilters {
-		if itemSnapshotMappingsMap[item.Key] == nil {
-			logs.CtxWarn(ctx, "MGetExperimentResult found itemSnapshotMappingsMap not found, key: %v", item.Key)
+
+	condBySet := make([]*entity.ItemSnapshotVersionCond, 0, len(pairs))
+	keywordCondBySet := make([]*entity.ItemSnapshotVersionCond, 0, len(pairs))
+	var (
+		firstErr        error
+		mappingResolved bool
+	)
+	for idx, p := range pairs {
+		// ★ 跨空间共享: item snapshot field mapping 按 (space_id, version_id) 存在**评测集来源空间**下，
+		// 用实验所在空间去查必然 not found，连带丢掉 sync_ck_date（快照表分区列，下游必需）。
+		// 多评测集时来源空间按 set 各自冻结，不能统一用主集的。
+		// 注意不能走 EvalSet.SharedInfo：本链路的实验来自 ExperimentRepo.MGetByID，只加载实验行 +
+		// 评估器 ref，EvalSet 为 nil。
+		req := &rpc.QueryItemSnapshotMappingRequest{
+			SpaceID:        resolveLoadSpaceID(baseExpt.SpaceID, p.SourceSpaceID),
+			DatasetID:      p.EvalSetID,
+			IsDraftVersion: isOnline,
+			VersionID:      gcond.If(isOnline, ptr.Of(int64(0)), ptr.Of(p.EvalSetVersionID)),
+		}
+		itemSnapshotMappings, syncCkDate, err := e.evaluationSetService.QueryItemSnapshotMappings(ctx, req)
+		if err != nil {
+			// 单个评测集拉不到 mapping 只让该集贡献 0 条，其余集照常筛；全挂了才报错。
+			logs.CtxWarn(ctx, "QueryItemSnapshotMappings failed, evalSetID: %v, versionID: %v, err: %v", p.EvalSetID, p.EvalSetVersionID, err)
+			if firstErr == nil {
+				firstErr = err
+			}
 			continue
 		}
-		itemSnapshotMapping := itemSnapshotMappingsMap[item.Key]
-		switch itemSnapshotMapping.MappingKey {
-		case "string_map":
-			keywordItemSnapshotFilter.StringMapFilters = append(keywordItemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: "LIKE", Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				keywordItemSnapshotFilter.StringMapFilters = append(keywordItemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
+		mappingResolved = true
+		mappingMap := make(map[string]*entity.ItemSnapshotFieldMapping, len(itemSnapshotMappings))
+		for _, item := range itemSnapshotMappings {
+			mappingMap[item.FieldKey] = item
+		}
+
+		setCond, setCondFull := translateItemSnapshotCond(ctx, rawCond, mappingMap, isOnline, false)
+		setKeywordCond, setKeywordFull := translateItemSnapshotCond(ctx, rawKeywordCond, mappingMap, isOnline, true)
+
+		// 主集那一组回填单值字段，兼容尚未 per-set 化的下游（开源 DAO 的 JOIN 路径、老调用方）。
+		if idx == 0 {
+			filter.EvalSetSyncCkDate = syncCkDate
+			if hasCond {
+				filter.ItemSnapshotCond = setCond
 			}
-		case "float_map":
-			keywordItemSnapshotFilter.FloatMapFilters = append(keywordItemSnapshotFilter.FloatMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: "LIKE", Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				keywordItemSnapshotFilter.StringMapFilters = append(keywordItemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
-			}
-		case "int_map":
-			keywordItemSnapshotFilter.IntMapFilters = append(keywordItemSnapshotFilter.IntMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: "LIKE", Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				keywordItemSnapshotFilter.StringMapFilters = append(keywordItemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
-			}
-		case "bool_map":
-			keywordItemSnapshotFilter.BoolMapFilters = append(keywordItemSnapshotFilter.BoolMapFilters, &entity.FieldFilter{
-				Key: itemSnapshotMapping.MappingSubKey, Op: "LIKE", Values: item.Values,
-			})
-			if baseExpt.ExptType == entity.ExptType_Online && itemSnapshotMapping.RecordID > 0 {
-				keywordItemSnapshotFilter.StringMapFilters = append(keywordItemSnapshotFilter.StringMapFilters, &entity.FieldFilter{
-					Key: "record_" + itemSnapshotMapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(itemSnapshotMapping.RecordID, 10)},
-				})
+			if hasKeywordCond && filter.KeywordSearch != nil {
+				filter.KeywordSearch.ItemSnapshotFilter = setKeywordCond
 			}
 		}
+
+		// setCondFull=false 表示该集缺其中某个字段：条件不能只应用一半（会放宽成"少筛一个条件"），
+		// 该集直接不入组 → 贡献 0 条。
+		if hasCond && setCondFull {
+			condBySet = append(condBySet, &entity.ItemSnapshotVersionCond{
+				EvalSetID:        p.EvalSetID,
+				EvalSetVersionID: p.EvalSetVersionID,
+				SourceSpaceID:    p.SourceSpaceID,
+				SyncCkDate:       syncCkDate,
+				Cond:             setCond,
+			})
+		}
+		if hasKeywordCond && setKeywordFull {
+			keywordCondBySet = append(keywordCondBySet, &entity.ItemSnapshotVersionCond{
+				EvalSetID:        p.EvalSetID,
+				EvalSetVersionID: p.EvalSetVersionID,
+				SourceSpaceID:    p.SourceSpaceID,
+				SyncCkDate:       syncCkDate,
+				Cond:             setKeywordCond,
+			})
+		}
 	}
-	filter.KeywordSearch.ItemSnapshotFilter = keywordItemSnapshotFilter
+
+	if !mappingResolved && needMapping && firstErr != nil {
+		// 所有评测集都拉不到 mapping：报错让上游降级，别静默返回 0 条（用户无法区分
+		// 「筛选失败」和「真的没有匹配」）。
+		return firstErr
+	}
+
+	filter.ItemSnapshotCondBySet = condBySet
+	filter.KeywordItemSnapshotCondBySet = keywordCondBySet
+	// 带了条件却没有任何评测集能完整翻译出来 → 语义是命中 0 条。
+	// 老实现在这里把条件 continue 掉，退化成"不筛"，返回全量数据。
+	filter.ItemSnapshotCondUnmatched = (hasCond && len(condBySet) == 0) ||
+		(hasKeywordCond && len(keywordCondBySet) == 0)
+	if filter.ItemSnapshotCondUnmatched {
+		logs.CtxWarn(ctx, "item snapshot filter matched no eval set, exptID: %v, hasCond: %v, hasKeywordCond: %v", baseExpt.ID, hasCond, hasKeywordCond)
+	}
 
 	return nil
+}
+
+// translateItemSnapshotCond 用某个评测集版本的 field mapping，把 field_key 条件翻译成快照表上的
+// map subkey 条件。返回 full=false 表示存在该版本翻译不出来的 field_key（调用方据此让该集不参与筛选）。
+// keyword=true 时统一用 LIKE（全文搜索语义）。
+func translateItemSnapshotCond(ctx context.Context, src *entity.ItemSnapshotFilter, mappingMap map[string]*entity.ItemSnapshotFieldMapping, isOnline, keyword bool) (*entity.ItemSnapshotFilter, bool) {
+	dst := &entity.ItemSnapshotFilter{
+		BoolMapFilters:   make([]*entity.FieldFilter, 0),
+		FloatMapFilters:  make([]*entity.FieldFilter, 0),
+		IntMapFilters:    make([]*entity.FieldFilter, 0),
+		StringMapFilters: make([]*entity.FieldFilter, 0),
+	}
+	if src == nil {
+		return dst, true
+	}
+	dst.BoolMapFilters = make([]*entity.FieldFilter, 0, len(src.BoolMapFilters))
+	dst.FloatMapFilters = make([]*entity.FieldFilter, 0, len(src.FloatMapFilters))
+	dst.IntMapFilters = make([]*entity.FieldFilter, 0, len(src.IntMapFilters))
+	dst.StringMapFilters = make([]*entity.FieldFilter, 0, len(src.StringMapFilters))
+
+	full := true
+	for _, item := range src.StringMapFilters {
+		mapping := mappingMap[item.Key]
+		if mapping == nil {
+			logs.CtxWarn(ctx, "item snapshot field mapping not found, key: %v", item.Key)
+			full = false
+			continue
+		}
+		op := item.Op
+		if keyword {
+			op = "LIKE"
+		}
+		f := &entity.FieldFilter{Key: mapping.MappingSubKey, Op: op, Values: item.Values}
+		switch mapping.MappingKey {
+		case "string_map":
+			dst.StringMapFilters = append(dst.StringMapFilters, f)
+		case "float_map":
+			dst.FloatMapFilters = append(dst.FloatMapFilters, f)
+		case "int_map":
+			dst.IntMapFilters = append(dst.IntMapFilters, f)
+		case "bool_map":
+			dst.BoolMapFilters = append(dst.BoolMapFilters, f)
+		default:
+			logs.CtxWarn(ctx, "unsupported item snapshot mapping key: %v, field: %v", mapping.MappingKey, item.Key)
+			full = false
+			continue
+		}
+		// 在线实验的草稿表一行存多个 record，需要额外用 record_<subkey> 锁定当前 record。
+		if isOnline && mapping.RecordID > 0 {
+			dst.StringMapFilters = append(dst.StringMapFilters, &entity.FieldFilter{
+				Key: "record_" + mapping.MappingSubKey, Op: "=", Values: []any{strconv.FormatInt(mapping.RecordID, 10)},
+			})
+		}
+	}
+	return dst, full
 }
 
 // 提取MapCond映射逻辑

--- a/backend/modules/evaluation/domain/service/expt_result_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl_test.go
@@ -8631,3 +8631,83 @@ func TestPayloadBuilder_fillExptTurnResultFilters_OnlineKeepsZeroVersion(t *test
 	assert.Equal(t, int64(20), builder.ExptTurnResultFilters[0].EvalSetID)
 	assert.Equal(t, int64(0), builder.ExptTurnResultFilters[0].EvalSetVersionID)
 }
+
+// per-set 组「翻译出来了但不可查」（缺 version / 缺分区日期）时必须退回单值老路径，
+// 而不是拼出恒假谓词静默返回 0 条 —— 老路径有从 etrf 反查 version 的兜底。
+func TestExptResultServiceImpl_mapItemSnapshotFilter_UnqueryableGroupFallsBack(t *testing.T) {
+	newFilter := func() *entity.ExptTurnResultFilterAccelerator {
+		return &entity.ExptTurnResultFilterAccelerator{
+			ItemSnapshotCond: &entity.ItemSnapshotFilter{
+				StringMapFilters: []*entity.FieldFilter{{Key: "item_key", Op: "=", Values: []any{"v"}}},
+			},
+			KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
+		}
+	}
+	mapping := []*entity.ItemSnapshotFieldMapping{
+		{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+	}
+
+	t.Run("离线实验缺 sync_ck_date => 不入组且不置 unmatched", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc0 := svcMocks.NewMockIEvaluationSetService(ctrl)
+		svc0.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).Return(mapping, "", nil).Times(1)
+		svc := ExptResultServiceImpl{evaluationSetService: svc0}
+
+		filter := newFilter()
+		expt := &entity.Experiment{SpaceID: 1, EvalSetID: 10, EvalSetVersionID: 100, ExptType: entity.ExptType_Offline}
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, expt))
+
+		assert.Empty(t, filter.ItemSnapshotCondBySet)
+		// 关键：不能置 unmatched，否则 DAO 会短路成 0 条
+		assert.False(t, filter.ItemSnapshotCondUnmatched)
+		// 单值字段仍被填好，DAO 走老路径照样能查
+		require.Len(t, filter.ItemSnapshotCond.StringMapFilters, 1)
+		assert.Equal(t, "string_key_0", filter.ItemSnapshotCond.StringMapFilters[0].Key)
+	})
+
+	t.Run("离线实验 version=0 的老数据 => 不入组且不置 unmatched", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc0 := svcMocks.NewMockIEvaluationSetService(ctrl)
+		svc0.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).Return(mapping, "2026-08-30", nil).Times(1)
+		svc := ExptResultServiceImpl{evaluationSetService: svc0}
+
+		filter := newFilter()
+		expt := &entity.Experiment{SpaceID: 1, EvalSetID: 10, EvalSetVersionID: 0, ExptType: entity.ExptType_Offline}
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, expt))
+
+		assert.Empty(t, filter.ItemSnapshotCondBySet)
+		assert.False(t, filter.ItemSnapshotCondUnmatched)
+	})
+
+	t.Run("在线实验只要有 dataset_id 就可查，不需要 version/分区日期", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc0 := svcMocks.NewMockIEvaluationSetService(ctrl)
+		svc0.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).Return(mapping, "", nil).Times(1)
+		svc := ExptResultServiceImpl{evaluationSetService: svc0}
+
+		filter := newFilter()
+		expt := &entity.Experiment{SpaceID: 1, EvalSetID: 10, EvalSetVersionID: 0, ExptType: entity.ExptType_Online}
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, expt))
+
+		require.Len(t, filter.ItemSnapshotCondBySet, 1)
+		assert.Equal(t, int64(10), filter.ItemSnapshotCondBySet[0].EvalSetID)
+		assert.False(t, filter.ItemSnapshotCondUnmatched)
+	})
+
+	t.Run("字段翻译不出来才置 unmatched", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc0 := svcMocks.NewMockIEvaluationSetService(ctrl)
+		svc0.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			Return([]*entity.ItemSnapshotFieldMapping{{FieldKey: "other", MappingKey: "string_map", MappingSubKey: "string_key_0"}}, "2026-08-30", nil).Times(1)
+		svc := ExptResultServiceImpl{evaluationSetService: svc0}
+
+		filter := newFilter()
+		expt := &entity.Experiment{SpaceID: 1, EvalSetID: 10, EvalSetVersionID: 100, ExptType: entity.ExptType_Offline}
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, expt))
+		assert.True(t, filter.ItemSnapshotCondUnmatched)
+	})
+}

--- a/backend/modules/evaluation/domain/service/expt_result_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl_test.go
@@ -8711,3 +8711,172 @@ func TestExptResultServiceImpl_mapItemSnapshotFilter_UnqueryableGroupFallsBack(t
 		assert.True(t, filter.ItemSnapshotCondUnmatched)
 	})
 }
+
+// loadItemEvalSetRefs：未注入 repo / 空 itemIDs / 查询失败 / 正常映射四条分支。
+func TestExptResultServiceImpl_loadItemEvalSetRefs(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("未注入 repo 或 itemIDs 为空时返回 nil", func(t *testing.T) {
+		svc := ExptResultServiceImpl{}
+		assert.Nil(t, svc.loadItemEvalSetRefs(ctx, 1, 2, []int64{1}))
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		svc2 := ExptResultServiceImpl{exptItemRefRepo: repoMocks.NewMockIExptItemRefRepo(ctrl)}
+		assert.Nil(t, svc2.loadItemEvalSetRefs(ctx, 1, 2, nil))
+	})
+
+	// 查询失败只降级（退回按主集写），不能阻塞 etrf 写入
+	t.Run("查询失败返回 nil 不报错", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		refRepo := repoMocks.NewMockIExptItemRefRepo(ctrl)
+		refRepo.EXPECT().MGetByExptIDAndItemIDs(gomock.Any(), int64(1), int64(2), []int64{7}).
+			Return(nil, errors.New("db down")).Times(1)
+		svc := ExptResultServiceImpl{exptItemRefRepo: refRepo}
+		assert.Nil(t, svc.loadItemEvalSetRefs(ctx, 1, 2, []int64{7}))
+	})
+
+	t.Run("正常返回 itemID -> ref 映射并跳过 nil", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		refRepo := repoMocks.NewMockIExptItemRefRepo(ctrl)
+		refRepo.EXPECT().MGetByExptIDAndItemIDs(gomock.Any(), int64(1), int64(2), []int64{7, 8}).
+			Return([]*entity.ExptItemRef{
+				nil,
+				{ItemID: 7, EvalSetID: 10, EvalSetVersionID: 100},
+				{ItemID: 8, EvalSetID: 20, EvalSetVersionID: 200},
+			}, nil).Times(1)
+		svc := ExptResultServiceImpl{exptItemRefRepo: refRepo}
+		got := svc.loadItemEvalSetRefs(ctx, 1, 2, []int64{7, 8})
+		require.Len(t, got, 2)
+		assert.Equal(t, int64(100), got[7].EvalSetVersionID)
+		assert.Equal(t, int64(200), got[8].EvalSetVersionID)
+	})
+}
+
+// NewExptResultService 的 variadic exptItemRefRepo：传了就注入，不传保持 nil（老调用方兼容）。
+func TestNewExptResultService_VariadicItemRefRepo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	refRepo := repoMocks.NewMockIExptItemRefRepo(ctrl)
+
+	withRepo := NewExptResultService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, refRepo).(*ExptResultServiceImpl)
+	assert.NotNil(t, withRepo.exptItemRefRepo)
+
+	without := NewExptResultService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil).(*ExptResultServiceImpl)
+	assert.Nil(t, without.exptItemRefRepo)
+}
+
+// translateItemSnapshotCond：四类 mapping、不支持的 mapping key、在线实验 record_ 后缀、nil 入参。
+func TestTranslateItemSnapshotCond(t *testing.T) {
+	ctx := context.Background()
+	mapping := map[string]*entity.ItemSnapshotFieldMapping{
+		"s": {FieldKey: "s", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+		"f": {FieldKey: "f", MappingKey: "float_map", MappingSubKey: "float_key_0"},
+		"i": {FieldKey: "i", MappingKey: "int_map", MappingSubKey: "int_key_0"},
+		"b": {FieldKey: "b", MappingKey: "bool_map", MappingSubKey: "bool_key_0"},
+		"x": {FieldKey: "x", MappingKey: "unknown_map", MappingSubKey: "x_0"},
+	}
+
+	t.Run("nil 入参返回空条件且视为完整", func(t *testing.T) {
+		dst, full := translateItemSnapshotCond(ctx, nil, mapping, false, false)
+		require.NotNil(t, dst)
+		assert.True(t, full)
+		assert.Empty(t, dst.StringMapFilters)
+	})
+
+	t.Run("四类 mapping 分别落到对应桶", func(t *testing.T) {
+		src := &entity.ItemSnapshotFilter{StringMapFilters: []*entity.FieldFilter{
+			{Key: "s", Op: "=", Values: []any{"v"}},
+			{Key: "f", Op: ">", Values: []any{1.5}},
+			{Key: "i", Op: "=", Values: []any{2}},
+			{Key: "b", Op: "=", Values: []any{true}},
+		}}
+		dst, full := translateItemSnapshotCond(ctx, src, mapping, false, false)
+		assert.True(t, full)
+		require.Len(t, dst.StringMapFilters, 1)
+		assert.Equal(t, "string_key_0", dst.StringMapFilters[0].Key)
+		require.Len(t, dst.FloatMapFilters, 1)
+		assert.Equal(t, "float_key_0", dst.FloatMapFilters[0].Key)
+		require.Len(t, dst.IntMapFilters, 1)
+		assert.Equal(t, "int_key_0", dst.IntMapFilters[0].Key)
+		require.Len(t, dst.BoolMapFilters, 1)
+		assert.Equal(t, "bool_key_0", dst.BoolMapFilters[0].Key)
+	})
+
+	// 不认识的 mapping key 不能当"翻译成功"，否则该评测集会被当成条件已生效
+	t.Run("不支持的 mapping key => full=false", func(t *testing.T) {
+		src := &entity.ItemSnapshotFilter{StringMapFilters: []*entity.FieldFilter{
+			{Key: "x", Op: "=", Values: []any{"v"}},
+		}}
+		dst, full := translateItemSnapshotCond(ctx, src, mapping, false, false)
+		assert.False(t, full)
+		assert.Empty(t, dst.StringMapFilters)
+	})
+
+	t.Run("keyword=true 时统一改成 LIKE", func(t *testing.T) {
+		src := &entity.ItemSnapshotFilter{StringMapFilters: []*entity.FieldFilter{
+			{Key: "s", Op: "=", Values: []any{"v"}},
+		}}
+		dst, full := translateItemSnapshotCond(ctx, src, mapping, false, true)
+		assert.True(t, full)
+		assert.Equal(t, "LIKE", dst.StringMapFilters[0].Op)
+	})
+
+	// 在线实验草稿表一行存多个 record，需要额外用 record_<subkey> 锁定当前 record
+	t.Run("在线实验且有 RecordID 时补 record_ 条件", func(t *testing.T) {
+		online := map[string]*entity.ItemSnapshotFieldMapping{
+			"s": {FieldKey: "s", MappingKey: "string_map", MappingSubKey: "string_key_0", RecordID: 777},
+		}
+		src := &entity.ItemSnapshotFilter{StringMapFilters: []*entity.FieldFilter{
+			{Key: "s", Op: "=", Values: []any{"v"}},
+		}}
+		dst, full := translateItemSnapshotCond(ctx, src, online, true, false)
+		assert.True(t, full)
+		require.Len(t, dst.StringMapFilters, 2)
+		assert.Equal(t, "record_string_key_0", dst.StringMapFilters[1].Key)
+		assert.Equal(t, []any{"777"}, dst.StringMapFilters[1].Values)
+	})
+}
+
+// 主集 id/version 都为 0 的老数据：collectEvalSetVersionPairs 返回空，需退化成单集调用形态。
+func TestExptResultServiceImpl_mapItemSnapshotFilter_ZeroPairFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	evalSetSvc := svcMocks.NewMockIEvaluationSetService(ctrl)
+	evalSetSvc.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, req *rpc.QueryItemSnapshotMappingRequest) ([]*entity.ItemSnapshotFieldMapping, string, error) {
+			assert.Equal(t, int64(0), req.DatasetID)
+			return []*entity.ItemSnapshotFieldMapping{
+				{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+			}, "2026-08-30", nil
+		}).Times(1)
+	svc := ExptResultServiceImpl{evaluationSetService: evalSetSvc}
+
+	filter := &entity.ExptTurnResultFilterAccelerator{
+		ItemSnapshotCond: &entity.ItemSnapshotFilter{
+			StringMapFilters: []*entity.FieldFilter{{Key: "item_key", Op: "=", Values: []any{"v"}}},
+		},
+		KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
+	}
+	expt := &entity.Experiment{SpaceID: 1, EvalSetID: 0, EvalSetVersionID: 0, ExptType: entity.ExptType_Offline}
+	require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, expt))
+
+	// version=0 不可查 => 不入组、也不置 unmatched，退回单值老路径
+	assert.Empty(t, filter.ItemSnapshotCondBySet)
+	assert.False(t, filter.ItemSnapshotCondUnmatched)
+	assert.Equal(t, "2026-08-30", filter.EvalSetSyncCkDate)
+}
+
+// ProvideExptItemRefRepos 把 repo 包成 slice 供 NewExptResultService 的 variadic 形参注入。
+func TestProvideExptItemRefRepos(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	r := repoMocks.NewMockIExptItemRefRepo(ctrl)
+	got := ProvideExptItemRefRepos(r)
+	require.Len(t, got, 1)
+	assert.Equal(t, r, got[0])
+}

--- a/backend/modules/evaluation/domain/service/expt_result_impl_test.go
+++ b/backend/modules/evaluation/domain/service/expt_result_impl_test.go
@@ -5982,7 +5982,7 @@ func TestExptResultBuilder_FillExptTurnResultFilters_RecalculateWeightedScore(t 
 			},
 		}
 
-		err := builder.fillExptTurnResultFilters(ctx, nil, 0, 1)
+		err := builder.fillExptTurnResultFilters(ctx, nil, 0, 1, false)
 		assert.NoError(t, err)
 		assert.Len(t, builder.ExptTurnResultFilters, 1)
 		if assert.NotNil(t, builder.ExptTurnResultFilters[0].EvaluatorWeightedScore) {
@@ -6037,7 +6037,7 @@ func TestExptResultBuilder_FillExptTurnResultFilters_RecalculateWeightedScore(t 
 			},
 		}
 
-		err := builder.fillExptTurnResultFilters(ctx, nil, 0, 1)
+		err := builder.fillExptTurnResultFilters(ctx, nil, 0, 1, false)
 		assert.NoError(t, err)
 		assert.Len(t, builder.ExptTurnResultFilters, 1)
 		// 应该使用已有的加权分数
@@ -6088,7 +6088,7 @@ func TestExptResultBuilder_FillExptTurnResultFilters_RecalculateWeightedScore(t 
 			},
 		}
 
-		err := builder.fillExptTurnResultFilters(ctx, nil, 0, 1)
+		err := builder.fillExptTurnResultFilters(ctx, nil, 0, 1, false)
 		assert.NoError(t, err)
 		assert.Len(t, builder.ExptTurnResultFilters, 1)
 		if assert.NotNil(t, builder.ExptTurnResultFilters[0].EvaluatorWeightedScore) {
@@ -6138,7 +6138,7 @@ func TestExptResultBuilder_FillExptTurnResultFilters_TargetOutputNilGuard(t *tes
 		})
 
 		assert.NotPanics(t, func() {
-			assert.NoError(t, builder.fillExptTurnResultFilters(ctx, nil, 0, 1))
+			assert.NoError(t, builder.fillExptTurnResultFilters(ctx, nil, 0, 1, false))
 		})
 		assert.Len(t, builder.ExptTurnResultFilters, 1)
 		assert.Empty(t, builder.ExptTurnResultFilters[0].EvalTargetData)
@@ -6152,7 +6152,7 @@ func TestExptResultBuilder_FillExptTurnResultFilters_TargetOutputNilGuard(t *tes
 		} {
 			builder := newBuilder(output)
 			assert.NotPanics(t, func() {
-				assert.NoError(t, builder.fillExptTurnResultFilters(ctx, nil, 0, 1))
+				assert.NoError(t, builder.fillExptTurnResultFilters(ctx, nil, 0, 1, false))
 			}, name)
 			assert.Len(t, builder.ExptTurnResultFilters, 1, name)
 			assert.Empty(t, builder.ExptTurnResultFilters[0].EvalTargetData, name)
@@ -6181,7 +6181,7 @@ func TestExptResultBuilder_FillExptTurnResultFilters_TargetOutputNilGuard(t *tes
 			},
 		})
 
-		assert.NoError(t, builder.fillExptTurnResultFilters(ctx, nil, 0, 1))
+		assert.NoError(t, builder.fillExptTurnResultFilters(ctx, nil, 0, 1, false))
 		assert.Len(t, builder.ExptTurnResultFilters, 1)
 		got := builder.ExptTurnResultFilters[0]
 		assert.Equal(t, "hello", got.EvalTargetData["actual_output"])
@@ -8338,7 +8338,7 @@ func TestExptResultServiceImpl_mapItemSnapshotFilter_SpaceResolution(t *testing.
 			},
 			KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
 		}
-		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, baseExpt, baseExpt.EvalSetVersionID))
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, baseExpt))
 
 		require.Len(t, filter.ItemSnapshotCond.StringMapFilters, 1)
 		assert.Equal(t, "string_key_0", filter.ItemSnapshotCond.StringMapFilters[0].Key)
@@ -8362,7 +8362,7 @@ func TestExptResultServiceImpl_mapItemSnapshotFilter_SpaceResolution(t *testing.
 			},
 			KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
 		}
-		assert.Error(t, svc.mapItemSnapshotFilter(context.Background(), filter, baseExpt, baseExpt.EvalSetVersionID))
+		assert.Error(t, svc.mapItemSnapshotFilter(context.Background(), filter, baseExpt))
 	})
 
 	// ★ 跨空间共享：mapping 必须用评测集来源空间查，否则 not found + 丢分区键。
@@ -8389,7 +8389,7 @@ func TestExptResultServiceImpl_mapItemSnapshotFilter_SpaceResolution(t *testing.
 			},
 			KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
 		}
-		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, sharedExpt, sharedExpt.EvalSetVersionID))
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, sharedExpt))
 		assert.Equal(t, "2026-08-12", filter.EvalSetSyncCkDate)
 	})
 
@@ -8411,7 +8411,223 @@ func TestExptResultServiceImpl_mapItemSnapshotFilter_SpaceResolution(t *testing.
 			},
 			KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
 		}
-		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, baseExpt, baseExpt.EvalSetVersionID))
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, baseExpt))
 		assert.Equal(t, "2026-08-18", filter.EvalSetSyncCkDate)
 	})
+}
+
+// 多评测集 (MultiSetConfig) 实验：评测集列筛选必须对**每个**评测集生效。
+//
+// 回归的缺陷：mapping / sync_ck_date / 来源空间都是按 (space_id, version_id) 存的，
+// 老实现只按主集解析一次，非主集 item 在主集版本的分区下查不到 → 筛选只在第一个评测集上生效。
+func TestExptResultServiceImpl_mapItemSnapshotFilter_MultiSet(t *testing.T) {
+	multiSetExpt := func() *entity.Experiment {
+		return &entity.Experiment{
+			SpaceID: 1, ExptType: entity.ExptType_Offline,
+			EvalSetID: 10, EvalSetVersionID: 100,
+			EvalSetSourceType: entity.ExptEvalSetSourceType_MultiSetConfig,
+			EvalConf: &entity.EvaluationConfiguration{
+				EvalSetConfigs: []*entity.EvalSetConfig{
+					{EvalSetID: 10, EvalSetVersionID: 100},
+					{EvalSetID: 20, EvalSetVersionID: 200, SourceSpaceID: 99},
+				},
+			},
+		}
+	}
+	newFilter := func() *entity.ExptTurnResultFilterAccelerator {
+		return &entity.ExptTurnResultFilterAccelerator{
+			ItemSnapshotCond: &entity.ItemSnapshotFilter{
+				StringMapFilters: []*entity.FieldFilter{{Key: "item_key", Op: "LIKE", Values: []any{"miniprogram"}}},
+			},
+			KeywordSearch: &entity.KeywordFilter{ItemSnapshotFilter: &entity.ItemSnapshotFilter{}},
+		}
+	}
+
+	t.Run("每个评测集各自解析 subkey / sync_ck_date / 来源空间", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockEvalSetSvc := svcMocks.NewMockIEvaluationSetService(ctrl)
+		mockEvalSetSvc.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *rpc.QueryItemSnapshotMappingRequest) ([]*entity.ItemSnapshotFieldMapping, string, error) {
+				switch req.DatasetID {
+				case 10:
+					assert.Equal(t, int64(1), req.SpaceID)
+					return []*entity.ItemSnapshotFieldMapping{
+						{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+					}, "2026-08-30", nil
+				case 20:
+					// 跨空间：第二个评测集要用它自己冻结的来源空间
+					assert.Equal(t, int64(99), req.SpaceID)
+					return []*entity.ItemSnapshotFieldMapping{
+						{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_3"},
+					}, "2026-08-31", nil
+				}
+				t.Fatalf("unexpected datasetID %d", req.DatasetID)
+				return nil, "", nil
+			}).Times(2)
+		svc := ExptResultServiceImpl{evaluationSetService: mockEvalSetSvc}
+
+		filter := newFilter()
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, multiSetExpt()))
+
+		require.Len(t, filter.ItemSnapshotCondBySet, 2)
+		assert.False(t, filter.ItemSnapshotCondUnmatched)
+
+		first := filter.ItemSnapshotCondBySet[0]
+		assert.Equal(t, int64(100), first.EvalSetVersionID)
+		assert.Equal(t, "2026-08-30", first.SyncCkDate)
+		assert.Equal(t, int64(0), first.SourceSpaceID)
+		require.Len(t, first.Cond.StringMapFilters, 1)
+		assert.Equal(t, "string_key_0", first.Cond.StringMapFilters[0].Key)
+
+		second := filter.ItemSnapshotCondBySet[1]
+		assert.Equal(t, int64(200), second.EvalSetVersionID)
+		assert.Equal(t, "2026-08-31", second.SyncCkDate)
+		assert.Equal(t, int64(99), second.SourceSpaceID)
+		require.Len(t, second.Cond.StringMapFilters, 1)
+		// 同名字段在第二个评测集里的 subkey 不同 —— 用主集那份会永远匹配不上
+		assert.Equal(t, "string_key_3", second.Cond.StringMapFilters[0].Key)
+
+		// 主集那组仍回填到单值字段，兼容未 per-set 化的下游
+		assert.Equal(t, "2026-08-30", filter.EvalSetSyncCkDate)
+		assert.Equal(t, "string_key_0", filter.ItemSnapshotCond.StringMapFilters[0].Key)
+	})
+
+	t.Run("某个评测集没有该字段则该集不参与筛选，其余集照常", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockEvalSetSvc := svcMocks.NewMockIEvaluationSetService(ctrl)
+		mockEvalSetSvc.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *rpc.QueryItemSnapshotMappingRequest) ([]*entity.ItemSnapshotFieldMapping, string, error) {
+				if req.DatasetID == 10 {
+					// 主集没有 item_key 这一列
+					return []*entity.ItemSnapshotFieldMapping{
+						{FieldKey: "other", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+					}, "2026-08-30", nil
+				}
+				return []*entity.ItemSnapshotFieldMapping{
+					{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_3"},
+				}, "2026-08-31", nil
+			}).Times(2)
+		svc := ExptResultServiceImpl{evaluationSetService: mockEvalSetSvc}
+
+		filter := newFilter()
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, multiSetExpt()))
+
+		require.Len(t, filter.ItemSnapshotCondBySet, 1)
+		assert.Equal(t, int64(200), filter.ItemSnapshotCondBySet[0].EvalSetVersionID)
+		assert.False(t, filter.ItemSnapshotCondUnmatched)
+	})
+
+	t.Run("所有评测集都没有该字段 => 命中 0 条，而不是退化成不筛", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockEvalSetSvc := svcMocks.NewMockIEvaluationSetService(ctrl)
+		mockEvalSetSvc.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			Return([]*entity.ItemSnapshotFieldMapping{
+				{FieldKey: "other", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+			}, "2026-08-30", nil).Times(2)
+		svc := ExptResultServiceImpl{evaluationSetService: mockEvalSetSvc}
+
+		filter := newFilter()
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, multiSetExpt()))
+
+		assert.Empty(t, filter.ItemSnapshotCondBySet)
+		assert.True(t, filter.ItemSnapshotCondUnmatched)
+		assert.True(t, filter.HasFilters())
+	})
+
+	t.Run("部分评测集 mapping 拉取失败只降级该集，全失败才报错", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockEvalSetSvc := svcMocks.NewMockIEvaluationSetService(ctrl)
+		mockEvalSetSvc.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, req *rpc.QueryItemSnapshotMappingRequest) ([]*entity.ItemSnapshotFieldMapping, string, error) {
+				if req.DatasetID == 10 {
+					return nil, "", errors.New("fieldMapping not found")
+				}
+				return []*entity.ItemSnapshotFieldMapping{
+					{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_3"},
+				}, "2026-08-31", nil
+			}).Times(2)
+		svc := ExptResultServiceImpl{evaluationSetService: mockEvalSetSvc}
+
+		filter := newFilter()
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, multiSetExpt()))
+		require.Len(t, filter.ItemSnapshotCondBySet, 1)
+		assert.Equal(t, int64(200), filter.ItemSnapshotCondBySet[0].EvalSetVersionID)
+
+		ctrl2 := gomock.NewController(t)
+		defer ctrl2.Finish()
+		allFail := svcMocks.NewMockIEvaluationSetService(ctrl2)
+		allFail.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			Return(nil, "", errors.New("fieldMapping not found")).Times(2)
+		svcAllFail := ExptResultServiceImpl{evaluationSetService: allFail}
+		assert.Error(t, svcAllFail.mapItemSnapshotFilter(context.Background(), newFilter(), multiSetExpt()))
+	})
+
+	t.Run("单评测集实验行为不变：只解析一次，只有一组", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockEvalSetSvc := svcMocks.NewMockIEvaluationSetService(ctrl)
+		mockEvalSetSvc.EXPECT().QueryItemSnapshotMappings(gomock.Any(), gomock.Any()).
+			Return([]*entity.ItemSnapshotFieldMapping{
+				{FieldKey: "item_key", MappingKey: "string_map", MappingSubKey: "string_key_0"},
+			}, "2026-08-30", nil).Times(1)
+		svc := ExptResultServiceImpl{evaluationSetService: mockEvalSetSvc}
+
+		singleSetExpt := &entity.Experiment{
+			SpaceID: 1, ExptType: entity.ExptType_Offline,
+			EvalSetID: 10, EvalSetVersionID: 100,
+		}
+		filter := newFilter()
+		require.NoError(t, svc.mapItemSnapshotFilter(context.Background(), filter, singleSetExpt))
+		require.Len(t, filter.ItemSnapshotCondBySet, 1)
+		assert.Equal(t, "string_key_0", filter.ItemSnapshotCond.StringMapFilters[0].Key)
+		assert.Equal(t, "2026-08-30", filter.EvalSetSyncCkDate)
+	})
+}
+
+// 写侧：多评测集实验的每一行必须落自己评测集的 eval_set_id / eval_set_version_id，
+// 而不是一律盖主集（盖主集会让 CK 侧按 version 关联快照表时非主集 item 恒关联不上）。
+func TestPayloadBuilder_fillExptTurnResultFilters_PerItemEvalSet(t *testing.T) {
+	builder := &PayloadBuilder{
+		BaselineExptID:       7,
+		SpaceID:              1,
+		BaseExptTurnResultDO: []*entity.ExptTurnResult{{ItemID: 1001, TurnID: 1}, {ItemID: 2002, TurnID: 1}},
+		BaseExptItemResultDO: []*entity.ExptItemResult{{ItemID: 1001, ItemIdx: 0}, {ItemID: 2002, ItemIdx: 1}},
+		ExptResultBuilders:   []*ExptResultBuilder{{}},
+		ItemID2EvalSetRef: map[int64]*entity.ExptItemRef{
+			2002: {ItemID: 2002, EvalSetID: 20, EvalSetVersionID: 200},
+		},
+	}
+	require.NoError(t, builder.fillExptTurnResultFilters(context.Background(), nil, 10, 100, false))
+	require.Len(t, builder.ExptTurnResultFilters, 2)
+
+	got := make(map[int64][2]int64, 2)
+	for _, f := range builder.ExptTurnResultFilters {
+		got[f.ItemID] = [2]int64{f.EvalSetID, f.EvalSetVersionID}
+	}
+	// 没有 ref 的 item 退化为主集（老数据兼容）
+	assert.Equal(t, [2]int64{10, 100}, got[1001])
+	// 有 ref 的 item 落自己评测集的版本
+	assert.Equal(t, [2]int64{20, 200}, got[2002])
+}
+
+// 在线实验 eval_set_version_id 固定写 0，不能被 ref 覆盖。
+func TestPayloadBuilder_fillExptTurnResultFilters_OnlineKeepsZeroVersion(t *testing.T) {
+	builder := &PayloadBuilder{
+		BaselineExptID:       7,
+		SpaceID:              1,
+		BaseExptTurnResultDO: []*entity.ExptTurnResult{{ItemID: 2002, TurnID: 1}},
+		BaseExptItemResultDO: []*entity.ExptItemResult{{ItemID: 2002, ItemIdx: 0}},
+		ExptResultBuilders:   []*ExptResultBuilder{{}},
+		ItemID2EvalSetRef: map[int64]*entity.ExptItemRef{
+			2002: {ItemID: 2002, EvalSetID: 20, EvalSetVersionID: 200},
+		},
+	}
+	require.NoError(t, builder.fillExptTurnResultFilters(context.Background(), nil, 10, 0, true))
+	require.Len(t, builder.ExptTurnResultFilters, 1)
+	assert.Equal(t, int64(20), builder.ExptTurnResultFilters[0].EvalSetID)
+	assert.Equal(t, int64(0), builder.ExptTurnResultFilters[0].EvalSetVersionID)
 }

--- a/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_scheduler_event_impl.go
@@ -551,6 +551,8 @@ func (e *ExptSchedulerImpl) resolveItemCompleteMeta(ctx context.Context, event *
 			logs.CtxWarn(ctx, "[ExptEval] item complete resolve refs fail, skip publish batch, expt_id: %v, err: %v", event.ExptID, err)
 			return itemMeta, itemVer
 		}
+		// 跨空间共享: DB 读回的 ref 未带来源空间, 从实验冻结信息回填后再按来源空间加载 item。
+		backfillRefEvalSetSourceSpace(refs, expt)
 		refByItem := make(map[int64]*entity.ExptItemRef, len(refs))
 		for _, ref := range refs {
 			if ref != nil {

--- a/backend/modules/evaluation/domain/service/wire.go
+++ b/backend/modules/evaluation/domain/service/wire.go
@@ -11,6 +11,7 @@ import (
 	mtr "github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component/metrics"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component/rpc"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/repo"
 	evaluatormtr "github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/metrics/evaluator"
 	rmqproducer "github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/mq/rocket/producer"
 	evaluatorrepo "github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/evaluator"
@@ -43,6 +44,9 @@ var ExperimentDomainServiceSet = wire.NewSet(
 	// 商业版 fork 通过自己的 wire set 覆盖为真实的 Lark send。
 	NewSandboxAgentNotifier,
 	ProvideNoSandboxAgentNotifiers,
+	// ExptResultService 的 exptItemRefRepo 是 variadic(为兼容既有调用方), wire 需要显式的
+	// slice provider 才能注入。
+	ProvideExptItemRefRepos,
 	// Infrastructure Sets
 	taskrpc.TaskRPCSet,
 	pipeline.PipelineRPCSet,
@@ -64,6 +68,12 @@ func ProvideNoSandboxAgentNotifiers() []ISandboxAgentNotifier {
 
 func ProvideNilItemCompletePublisher() component.IItemCompletePublisher {
 	return nil
+}
+
+// ProvideExptItemRefRepos 把 IExptItemRefRepo 包成 slice, 供 NewExptResultService 的
+// variadic 形参注入 (多评测集实验按 item 回填评测集归属用)。
+func ProvideExptItemRefRepos(r repo.IExptItemRefRepo) []repo.IExptItemRefRepo {
+	return []repo.IExptItemRefRepo{r}
 }
 
 // EvaluatorDomainServiceSet 提供所有 Evaluator 相关的 Domain Service

--- a/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter.go
+++ b/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter.go
@@ -59,6 +59,14 @@ type KeywordMapCond struct {
 	Keyword               *string
 }
 
+// ItemSnapshotVersionCond 单个评测集版本的快照筛选条件（多评测集实验 per-set 一组）。
+type ItemSnapshotVersionCond struct {
+	EvalSetID        string
+	EvalSetVersionID string
+	SyncCkDate       string
+	Cond             *ItemSnapshotFilter
+}
+
 type ExptTurnResultFilterQueryCond struct {
 	// 主表字段
 	SpaceID                 *string
@@ -77,6 +85,13 @@ type ExptTurnResultFilterQueryCond struct {
 	// 联表
 	ItemSnapshotCond  *ItemSnapshotFilter
 	EvalSetSyncCkDate string
+	// ItemSnapshotCondBySet 多评测集实验的 per-set 快照条件：每组 = 一个评测集版本 + 该版本自己的
+	// map subkey 条件。非空时优先于 ItemSnapshotCond，拼成
+	// `AND ((dis.version_id = v1 AND <c1>) OR (dis.version_id = v2 AND <c2>) ...)`，
+	// 保证非主集的 item 也能被筛到（老实现只按主集一份 mapping 翻译，非主集恒不命中）。
+	ItemSnapshotCondBySet []*ItemSnapshotVersionCond
+	// ItemSnapshotCondUnmatched 带了评测集列条件但没有任何评测集能翻译出来 → 命中 0 条。
+	ItemSnapshotCondUnmatched bool
 	// IsOnlineExpt 是否在线实验，在线实验时 join 使用 dataset_item_draft + etrf.eval_set_id = dis.dataset_id，离线使用 dataset_item_snapshot + etrf.eval_set_version_id = dis.version_id
 	IsOnlineExpt bool
 
@@ -452,10 +467,56 @@ func (d *exptTurnResultFilterDAOImpl) buildMapFieldConditions(cond *ExptTurnResu
 // buildItemSnapshotConditions 构建 dis 表（dataset_item_draft/snapshot）的 map 字段条件
 // 在线实验的 record 条件通过独立 FieldFilter 传入，如 Key="record_string_key_0", Op="=", Values=["7581751092564738049"]
 func (d *exptTurnResultFilterDAOImpl) buildItemSnapshotConditions(cond *ExptTurnResultFilterQueryCond, whereSQL *string, args *[]interface{}) {
+	if cond == nil {
+		return
+	}
+	// 带了评测集列条件但没有任何评测集版本能翻译出来 → 命中 0 条，而不是退化成不筛。
+	if cond.ItemSnapshotCondUnmatched {
+		*whereSQL += " AND 1=0"
+		return
+	}
+	// ★ 多评测集：按评测集版本分组 OR，每组用**该版本自己**的 map subkey。
+	// 单评测集时只有一组，等价于原来的单份条件。
+	if len(cond.ItemSnapshotCondBySet) > 0 {
+		groups := make([]string, 0, len(cond.ItemSnapshotCondBySet))
+		groupArgs := make([]interface{}, 0, len(cond.ItemSnapshotCondBySet)*2)
+		for _, set := range cond.ItemSnapshotCondBySet {
+			if set == nil || !d.hasItemSnapshotFilters(set.Cond) {
+				continue
+			}
+			inner := ""
+			innerArgs := make([]interface{}, 0, 4)
+			d.appendItemSnapshotFilters(set.Cond, &inner, &innerArgs)
+			if inner == "" {
+				continue
+			}
+			group := "(1=1"
+			if set.EvalSetVersionID != "" {
+				group += " AND dis.version_id = ?"
+				groupArgs = append(groupArgs, set.EvalSetVersionID)
+			}
+			groupArgs = append(groupArgs, innerArgs...)
+			groups = append(groups, group+inner+")")
+		}
+		if len(groups) == 0 {
+			*whereSQL += " AND 1=0"
+			return
+		}
+		*whereSQL += " AND (" + strings.Join(groups, " OR ") + ")"
+		*args = append(*args, groupArgs...)
+		return
+	}
 	if cond.ItemSnapshotCond == nil || !d.hasItemSnapshotFilters(cond.ItemSnapshotCond) {
 		return
 	}
-	f := cond.ItemSnapshotCond
+	d.appendItemSnapshotFilters(cond.ItemSnapshotCond, whereSQL, args)
+}
+
+// appendItemSnapshotFilters 把一组已翻译好的 map 条件拼进 SQL（形如 " AND dis.string_map['k'] = ?"）。
+func (d *exptTurnResultFilterDAOImpl) appendItemSnapshotFilters(f *ItemSnapshotFilter, whereSQL *string, args *[]interface{}) {
+	if f == nil {
+		return
+	}
 	for _, ff := range f.StringMapFilters {
 		d.appendItemSnapshotMapCond(whereSQL, args, "string_map", ff)
 	}
@@ -598,12 +659,28 @@ func (d *exptTurnResultFilterDAOImpl) hasItemSnapshotFilters(f *ItemSnapshotFilt
 		len(f.IntMapFilters) > 0 || len(f.StringMapFilters) > 0
 }
 
+// needJoinItemSnapshot 是否需要联快照表：单份条件或 per-set 任一组有条件都要 join。
+func (d *exptTurnResultFilterDAOImpl) needJoinItemSnapshot(cond *ExptTurnResultFilterQueryCond) bool {
+	if cond == nil {
+		return false
+	}
+	if d.hasItemSnapshotFilters(cond.ItemSnapshotCond) {
+		return true
+	}
+	for _, set := range cond.ItemSnapshotCondBySet {
+		if set != nil && d.hasItemSnapshotFilters(set.Cond) {
+			return true
+		}
+	}
+	return false
+}
+
 // buildBaseSQL 构建基础SQL语句
 // 当 ItemSnapshotCond 非空时，需 join 数据集 item 表：在线实验用 dataset_item_draft + etrf.eval_set_id = dis.dataset_id，离线用 dataset_item_snapshot + etrf.eval_set_version_id = dis.version_id
 func (d *exptTurnResultFilterDAOImpl) buildBaseSQL(ctx context.Context, cond *ExptTurnResultFilterQueryCond, whereSQL, keywordCond string, args *[]interface{}) string {
 	dbName := getClickHouseDatabaseName()
 	sql := "SELECT  etrf.item_id, etrf.status FROM " + dbName + ".expt_turn_result_filter etrf"
-	if cond != nil && cond.ItemSnapshotCond != nil && d.hasItemSnapshotFilters(cond.ItemSnapshotCond) {
+	if d.needJoinItemSnapshot(cond) {
 		itemTable := "dataset_item_snapshot"
 		joinCond := "etrf.eval_set_version_id = dis.version_id"
 		if cond.IsOnlineExpt {

--- a/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter.go
+++ b/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter.go
@@ -687,6 +687,12 @@ func (d *exptTurnResultFilterDAOImpl) buildBaseSQL(ctx context.Context, cond *Ex
 			itemTable = "dataset_item_draft"
 			joinCond = "etrf.eval_set_id = dis.dataset_id"
 		}
+		// ★ 多评测集：存量实验的 etrf 行全部盖着主集 eval_set_version_id（写侧缺陷），
+		// 拿它 join 会把快照表限死在主集版本，非主集 item 关联不上。per-set 条件已经在
+		// 每个分组里带了自己的 dis.version_id，这里只按 item_id 关联即可。
+		if len(cond.ItemSnapshotCondBySet) > 0 {
+			joinCond = "1=1"
+		}
 		sql += " INNER JOIN " + dbName + "." + itemTable + " dis ON " + joinCond + " AND etrf.item_id = dis.item_id"
 	}
 	sql += " FINAL WHERE 1=1"

--- a/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter_test.go
@@ -983,3 +983,109 @@ func TestExptTurnResultFilterDAOImpl_buildItemSnapshotConditions_PerSet(t *testi
 		assert.Equal(t, []interface{}{"v"}, args)
 	})
 }
+
+// per-set 相关的边界分支：nil cond / nil 组 / 组内条件为空 / 全组为空 / join 条件切换。
+func TestExptTurnResultFilterDAOImpl_PerSetEdgeCases(t *testing.T) {
+	d := &exptTurnResultFilterDAOImpl{}
+
+	t.Run("cond 为 nil 直接返回", func(t *testing.T) {
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(nil, &whereSQL, &args)
+		assert.Empty(t, whereSQL)
+		assert.Empty(t, args)
+	})
+
+	t.Run("nil 组与空条件组都被跳过；全为空时拼恒假条件", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{
+				nil,
+				{EvalSetVersionID: "100", Cond: nil},
+				{EvalSetVersionID: "200", Cond: &ItemSnapshotFilter{}},
+			},
+		}
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(cond, &whereSQL, &args)
+		assert.Equal(t, " AND 1=0", whereSQL)
+		assert.Empty(t, args)
+	})
+
+	t.Run("组内条件全部被 appendItemSnapshotMapCond 丢掉时也是恒假", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{
+				// 不支持的 Op，appendItemSnapshotMapCond 会直接 return，inner 为空
+				{EvalSetVersionID: "100", Cond: &ItemSnapshotFilter{
+					StringMapFilters: []*FieldFilter{{Key: "string_key_0", Op: "REGEXP", Values: []any{"v"}}},
+				}},
+			},
+		}
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(cond, &whereSQL, &args)
+		assert.Equal(t, " AND 1=0", whereSQL)
+	})
+
+	t.Run("组不带 version 时不拼 version 谓词", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{
+				{EvalSetVersionID: "", Cond: &ItemSnapshotFilter{
+					StringMapFilters: []*FieldFilter{{Key: "string_key_0", Op: "=", Values: []any{"v"}}},
+				}},
+			},
+		}
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(cond, &whereSQL, &args)
+		assert.NotContains(t, whereSQL, "dis.version_id")
+		assert.Equal(t, []interface{}{"v"}, args)
+	})
+
+	t.Run("appendItemSnapshotFilters 对 nil 直接返回", func(t *testing.T) {
+		whereSQL := ""
+		args := []interface{}{}
+		d.appendItemSnapshotFilters(nil, &whereSQL, &args)
+		assert.Empty(t, whereSQL)
+	})
+
+	t.Run("needJoinItemSnapshot: nil / 无条件 / per-set 有条件", func(t *testing.T) {
+		assert.False(t, d.needJoinItemSnapshot(nil))
+		assert.False(t, d.needJoinItemSnapshot(&ExptTurnResultFilterQueryCond{}))
+		assert.False(t, d.needJoinItemSnapshot(&ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{nil, {Cond: &ItemSnapshotFilter{}}},
+		}))
+		assert.True(t, d.needJoinItemSnapshot(&ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{{Cond: &ItemSnapshotFilter{
+				IntMapFilters: []*FieldFilter{{Key: "int_key_0", Op: "=", Values: []any{1}}},
+			}}},
+		}))
+	})
+
+	// ★ 存量多评测集实验的 etrf 行盖着主集 version，按它 join 会把快照表限死在主集版本，
+	// 所以有 per-set 条件时 join 只按 item_id 关联。
+	t.Run("有 per-set 条件时 join 不再按 etrf 的 version 关联", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{
+				{EvalSetVersionID: "100", Cond: &ItemSnapshotFilter{
+					StringMapFilters: []*FieldFilter{{Key: "string_key_0", Op: "=", Values: []any{"v"}}},
+				}},
+			},
+		}
+		args := []interface{}{}
+		sql := d.buildBaseSQL(context.Background(), cond, "", "", &args)
+		assert.Contains(t, sql, "INNER JOIN")
+		assert.Contains(t, sql, "dis ON 1=1 AND etrf.item_id = dis.item_id")
+		assert.NotContains(t, sql, "etrf.eval_set_version_id = dis.version_id")
+	})
+
+	t.Run("无 per-set 条件时 join 保持原样", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCond: &ItemSnapshotFilter{
+				StringMapFilters: []*FieldFilter{{Key: "string_key_0", Op: "=", Values: []any{"v"}}},
+			},
+		}
+		args := []interface{}{}
+		sql := d.buildBaseSQL(context.Background(), cond, "", "", &args)
+		assert.Contains(t, sql, "etrf.eval_set_version_id = dis.version_id")
+	})
+}

--- a/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/ck/expt_turn_result_filter_test.go
@@ -921,3 +921,65 @@ func TestExptTurnResultFilterDAOImpl_buildMapFieldConditions_EvalTargetMetricsFi
 		})
 	}
 }
+
+// 多评测集：per-set 条件按 dis.version_id 分组 OR，各组用自己的 map subkey。
+func TestExptTurnResultFilterDAOImpl_buildItemSnapshotConditions_PerSet(t *testing.T) {
+	d := &exptTurnResultFilterDAOImpl{}
+
+	t.Run("多组按 version 分组 OR", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCondBySet: []*ItemSnapshotVersionCond{
+				{
+					EvalSetVersionID: "100",
+					Cond: &ItemSnapshotFilter{StringMapFilters: []*FieldFilter{
+						{Key: "string_key_0", Op: "LIKE", Values: []any{"mini"}},
+					}},
+				},
+				{
+					EvalSetVersionID: "200",
+					Cond: &ItemSnapshotFilter{StringMapFilters: []*FieldFilter{
+						{Key: "string_key_3", Op: "LIKE", Values: []any{"mini"}},
+					}},
+				},
+			},
+		}
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(cond, &whereSQL, &args)
+
+		assert.Contains(t, whereSQL, "dis.version_id = ?")
+		assert.Contains(t, whereSQL, "dis.string_map['string_key_0'] LIKE ?")
+		assert.Contains(t, whereSQL, "dis.string_map['string_key_3'] LIKE ?")
+		assert.Contains(t, whereSQL, " OR ")
+		// 每组 2 个参数：version + value
+		assert.Len(t, args, 4)
+		assert.Equal(t, "100", args[0])
+		assert.Equal(t, "200", args[2])
+		// per-set 非空时必须联表
+		assert.True(t, d.needJoinItemSnapshot(cond))
+	})
+
+	// 字段不在任何评测集里 => 命中 0 条，不能退化成不带条件的全量查询。
+	t.Run("unmatched 生成恒假条件", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{ItemSnapshotCondUnmatched: true}
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(cond, &whereSQL, &args)
+		assert.Equal(t, " AND 1=0", whereSQL)
+		assert.Empty(t, args)
+	})
+
+	// 单份条件（单评测集 / 老调用方）行为不变。
+	t.Run("单份条件保持原样", func(t *testing.T) {
+		cond := &ExptTurnResultFilterQueryCond{
+			ItemSnapshotCond: &ItemSnapshotFilter{StringMapFilters: []*FieldFilter{
+				{Key: "string_key_0", Op: "=", Values: []any{"v"}},
+			}},
+		}
+		whereSQL := ""
+		args := []interface{}{}
+		d.buildItemSnapshotConditions(cond, &whereSQL, &args)
+		assert.Equal(t, " AND dis.string_map['string_key_0'] = ?", whereSQL)
+		assert.Equal(t, []interface{}{"v"}, args)
+	})
+}

--- a/backend/modules/evaluation/infra/repo/experiment/expt_turn_result_filter_repo_impl.go
+++ b/backend/modules/evaluation/infra/repo/experiment/expt_turn_result_filter_repo_impl.go
@@ -77,6 +77,31 @@ func fieldFiltersEntityToCK(src []*entity.FieldFilter) []*ck.FieldFilter {
 	return res
 }
 
+// itemSnapshotCondsEntityToCK 把 per-set 快照条件转成 DAO 层结构（评测集/版本 id 在 CK 里是 String 列）。
+func itemSnapshotCondsEntityToCK(src []*entity.ItemSnapshotVersionCond) []*ck.ItemSnapshotVersionCond {
+	if len(src) == 0 {
+		return nil
+	}
+	res := make([]*ck.ItemSnapshotVersionCond, 0, len(src))
+	for _, s := range src {
+		if s == nil || s.Cond == nil {
+			continue
+		}
+		res = append(res, &ck.ItemSnapshotVersionCond{
+			EvalSetID:        strconv.FormatInt(s.EvalSetID, 10),
+			EvalSetVersionID: strconv.FormatInt(s.EvalSetVersionID, 10),
+			SyncCkDate:       s.SyncCkDate,
+			Cond: &ck.ItemSnapshotFilter{
+				BoolMapFilters:   fieldFiltersEntityToCK(s.Cond.BoolMapFilters),
+				FloatMapFilters:  fieldFiltersEntityToCK(s.Cond.FloatMapFilters),
+				IntMapFilters:    fieldFiltersEntityToCK(s.Cond.IntMapFilters),
+				StringMapFilters: fieldFiltersEntityToCK(s.Cond.StringMapFilters),
+			},
+		})
+	}
+	return res
+}
+
 // QueryItemIDStates 实现 IExptTurnResultFilterRepo 接口的 QueryItemIDStates 方法
 func (e *ExptTurnResultFilterRepoImpl) QueryItemIDStates(ctx context.Context, filter *entity.ExptTurnResultFilterAccelerator) (map[int64]entity.ItemRunState, int64, error) {
 	cond := &ck.ExptTurnResultFilterQueryCond{}
@@ -123,6 +148,9 @@ func (e *ExptTurnResultFilterRepoImpl) QueryItemIDStates(ctx context.Context, fi
 			StringMapFilters: fieldFiltersEntityToCK(filter.ItemSnapshotCond.StringMapFilters),
 		}
 	}
+	// ★ 多评测集：per-set 条件透传，DAO 侧按 dis.version_id 分组 OR。
+	cond.ItemSnapshotCondBySet = itemSnapshotCondsEntityToCK(filter.ItemSnapshotCondBySet)
+	cond.ItemSnapshotCondUnmatched = filter.ItemSnapshotCondUnmatched
 	if filter.KeywordSearch != nil {
 		cond.KeywordSearch = &ck.KeywordMapCond{
 			ItemSnapshotFilter: &ck.ItemSnapshotFilter{

--- a/backend/modules/evaluation/infra/repo/experiment/expt_turn_result_filter_repo_impl_test.go
+++ b/backend/modules/evaluation/infra/repo/experiment/expt_turn_result_filter_repo_impl_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/ck"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/ck/gorm_gen/model"
 	ckmocks "github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/ck/mocks"
 	diffmodel "github.com/coze-dev/coze-loop/backend/modules/evaluation/infra/repo/experiment/ck/model"
@@ -17,6 +18,7 @@ import (
 	"github.com/coze-dev/coze-loop/backend/pkg/lang/ptr"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -389,4 +391,88 @@ func TestExptTurnResultFilterRepoImpl_GetByExptIDItemIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+// itemSnapshotCondsEntityToCK：多评测集 per-set 条件透传到 DAO 层的转换。
+func TestItemSnapshotCondsEntityToCK(t *testing.T) {
+	t.Run("空输入返回 nil", func(t *testing.T) {
+		assert.Nil(t, itemSnapshotCondsEntityToCK(nil))
+		assert.Nil(t, itemSnapshotCondsEntityToCK([]*entity.ItemSnapshotVersionCond{}))
+	})
+
+	t.Run("跳过 nil 项与 Cond 为 nil 的项", func(t *testing.T) {
+		got := itemSnapshotCondsEntityToCK([]*entity.ItemSnapshotVersionCond{
+			nil,
+			{EvalSetID: 1, EvalSetVersionID: 2},
+		})
+		assert.Empty(t, got)
+	})
+
+	t.Run("id 转字符串，四类 map 条件全部透传", func(t *testing.T) {
+		got := itemSnapshotCondsEntityToCK([]*entity.ItemSnapshotVersionCond{
+			{
+				EvalSetID: 10, EvalSetVersionID: 100, SyncCkDate: "2026-08-30",
+				Cond: &entity.ItemSnapshotFilter{
+					StringMapFilters: []*entity.FieldFilter{{Key: "string_key_0", Op: "LIKE", Values: []any{"v"}}},
+					IntMapFilters:    []*entity.FieldFilter{{Key: "int_key_0", Op: "=", Values: []any{1}}},
+					FloatMapFilters:  []*entity.FieldFilter{{Key: "float_key_0", Op: ">", Values: []any{1.5}}},
+					BoolMapFilters:   []*entity.FieldFilter{{Key: "bool_key_0", Op: "=", Values: []any{true}}},
+				},
+			},
+			{
+				EvalSetID: 20, EvalSetVersionID: 200, SyncCkDate: "2026-08-31",
+				Cond: &entity.ItemSnapshotFilter{
+					StringMapFilters: []*entity.FieldFilter{{Key: "string_key_3", Op: "=", Values: []any{"w"}}},
+				},
+			},
+		})
+		require.Len(t, got, 2)
+
+		assert.Equal(t, "10", got[0].EvalSetID)
+		assert.Equal(t, "100", got[0].EvalSetVersionID)
+		assert.Equal(t, "2026-08-30", got[0].SyncCkDate)
+		require.NotNil(t, got[0].Cond)
+		assert.Equal(t, "string_key_0", got[0].Cond.StringMapFilters[0].Key)
+		assert.Equal(t, "int_key_0", got[0].Cond.IntMapFilters[0].Key)
+		assert.Equal(t, "float_key_0", got[0].Cond.FloatMapFilters[0].Key)
+		assert.Equal(t, "bool_key_0", got[0].Cond.BoolMapFilters[0].Key)
+
+		assert.Equal(t, "20", got[1].EvalSetID)
+		assert.Equal(t, "200", got[1].EvalSetVersionID)
+		assert.Equal(t, "string_key_3", got[1].Cond.StringMapFilters[0].Key)
+	})
+}
+
+// QueryItemIDStates 透传 per-set 条件与 unmatched 标记到 DAO 层。
+func TestExptTurnResultFilterRepoImpl_QueryItemIDStates_PerSetPassthrough(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dao := ckmocks.NewMockIExptTurnResultFilterDAO(ctrl)
+	r := NewExptTurnResultFilterRepo(dao, mysqlmocks.NewMockIExptTurnResultFilterKeyMappingDAO(ctrl))
+
+	dao.EXPECT().QueryItemIDStates(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, cond *ck.ExptTurnResultFilterQueryCond) (map[string]int32, int64, error) {
+			require.Len(t, cond.ItemSnapshotCondBySet, 2)
+			assert.Equal(t, "100", cond.ItemSnapshotCondBySet[0].EvalSetVersionID)
+			assert.Equal(t, "200", cond.ItemSnapshotCondBySet[1].EvalSetVersionID)
+			assert.True(t, cond.ItemSnapshotCondUnmatched)
+			return map[string]int32{"1": 2}, 1, nil
+		}).Times(1)
+
+	states, total, err := r.QueryItemIDStates(context.Background(), &entity.ExptTurnResultFilterAccelerator{
+		SpaceID: 1, ExptID: 2,
+		ItemSnapshotCondBySet: []*entity.ItemSnapshotVersionCond{
+			{EvalSetID: 10, EvalSetVersionID: 100, SyncCkDate: "d1", Cond: &entity.ItemSnapshotFilter{
+				StringMapFilters: []*entity.FieldFilter{{Key: "string_key_0", Op: "=", Values: []any{"v"}}},
+			}},
+			{EvalSetID: 20, EvalSetVersionID: 200, SyncCkDate: "d2", Cond: &entity.ItemSnapshotFilter{
+				StringMapFilters: []*entity.FieldFilter{{Key: "string_key_3", Op: "=", Values: []any{"v"}}},
+			}},
+		},
+		ItemSnapshotCondUnmatched: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, map[int64]entity.ItemRunState{1: entity.ItemRunState(2)}, states)
 }


### PR DESCRIPTION
Problem
For an experiment configured with multiple evaluation sets (eval_set_source_type = MultiSetConfig), filtering experiment results by an evaluation-set column — and keyword search over those columns — only ever matched items belonging to the primary evaluation set. Items from every other evaluation set were silently excluded.
Reproduced on an experiment with 10 evaluation sets and 900 items (primary set: 180 items). A filter condition that matches every item returned total = 180, exactly the primary set's item count, instead of 900.
Root cause
Translating an eval-set column filter into a query on dataset_item_snapshot needs three things, and all three are stored per (space_id, version_id), so they differ per evaluation set:
the field_key → string_map / int_map / … sub-key mapping,
sync_ck_date, the snapshot table's partition column,
the evaluation set's source space (for shared eval sets).
mapItemSnapshotFilter resolved all three exactly once, from the experiment's primary EvalSetID / EvalSetVersionID. Items of any other evaluation set live under a different version and partition, so they could never match the resulting predicate.
Two secondary defects on the same path:
When a field_key had no mapping for the resolved version, the condition was silently dropped (continue). That turns "nothing matches" into "no filter at all", i.e. the caller gets the full, unfiltered result set back.
expt_turn_result_filter rows were all stamped with the primary eval_set_id / eval_set_version_id, even though expt_item_ref already records each item's real owning evaluation set.
Fix
Read path — takes effect for existing experiments, no data backfill required:
ExptTurnResultFilterAccelerator now carries per-eval-set conditions (ItemSnapshotCondBySet, KeywordItemSnapshotCondBySet) plus an ItemSnapshotCondUnmatched flag. The former single-value fields are kept and filled from the primary set so that callers which have not been updated keep working.
mapItemSnapshotFilter iterates every (eval set, version, source space) of the experiment — reusing the existing collectEvalSetVersionPairs — and resolves mapping plus partition date per set. A set that cannot translate all requested fields contributes no items, rather than applying a subset of the conditions and thereby loosening the filter. An error is returned only when no set could be resolved at all, so the caller can fall back to the paginated plain query instead of silently reporting zero rows.
The ClickHouse DAO groups the translated conditions by dis.version_id and ORs the groups; ItemSnapshotCondUnmatched becomes a false predicate so that "no eval set can satisfy this field" yields zero rows instead of everything.
Write path — applies to new experiments:
fillExptTurnResultFilters fills eval_set_id / eval_set_version_id per row from expt_item_ref instead of always using the primary set. Online experiments keep version 0 as before.
ExptResultService accepts IExptItemRefRepo as a variadic parameter so existing callers stay source-compatible; a wire provider supplies it.
Single-eval-set experiments resolve to exactly one group, so their behaviour is unchanged.
Tests
mapItemSnapshotFilter: per-set mapping with distinct sub-keys, partition dates and source spaces; one set missing the column (that set alone drops out); no set matching (zero rows, not "unfiltered"); mapping lookup failing for one set only (that set degrades, the rest still filter); single-eval-set regression.
Write path: per-item fill from expt_item_ref; online experiments keep version 0.
DAO: per-set grouped SQL and bound arguments, false predicate on unmatched, single-condition path byte-for-byte unchanged.
Verification
End-to-end on the 10-set experiment described above, every non-primary filter now returns that set's real hit count (e.g. a value matching one 50-item set returns 50; a prefix spanning two sets returns the sum of both), the primary-set case is unchanged, and a value present in no set returns 0.