### PR TITLE
[fix][backend] accept string-encoded intValue in OTLP/JSON ingestion

### DIFF
--- a/backend/modules/observability/lib/otel/otel_json_request.go
+++ b/backend/modules/observability/lib/otel/otel_json_request.go
@@ -270,7 +270,18 @@ func (anyV *AnyValue) UnmarshalJSON(data []byte) error {
 	case len(rawMap["intValue"]) > 0:
 		var v AnyValue_IntValue
 		if err := sonic.Unmarshal(rawMap["intValue"], &v.IntValue); err != nil {
-			return err
+			// OTLP/JSON (proto3 JSON mapping) encodes int64/uint64/fixed64/sfixed64 as string,
+			// e.g. {"intValue":"42"}. Standard OTel SDKs (Rust/Go/Python) emit this form, so fall
+			// back to parsing the string here instead of rejecting the whole request.
+			var s string
+			if strErr := sonic.Unmarshal(rawMap["intValue"], &s); strErr != nil {
+				return err
+			}
+			iv, parseErr := strconv.ParseInt(s, 10, 64)
+			if parseErr != nil {
+				return err
+			}
+			v.IntValue = iv
 		}
 		anyV.Value = &v
 	case len(rawMap["doubleValue"]) > 0:

--- a/backend/modules/observability/lib/otel/otel_json_request_test.go
+++ b/backend/modules/observability/lib/otel/otel_json_request_test.go
@@ -151,6 +151,24 @@ func TestAnyValue_UnmarshalJSON(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name:     "int value - string encoded (OTLP/JSON spec)",
+			jsonData: `{"intValue": "123"}`,
+			expected: &AnyValue{Value: &AnyValue_IntValue{IntValue: 123}},
+			wantErr:  false,
+		},
+		{
+			name:     "int value - string encoded negative",
+			jsonData: `{"intValue": "-42"}`,
+			expected: &AnyValue{Value: &AnyValue_IntValue{IntValue: -42}},
+			wantErr:  false,
+		},
+		{
+			name:     "int value - string encoded non-numeric",
+			jsonData: `{"intValue": "not-a-number"}`,
+			expected: nil,
+			wantErr:  true,
+		},
+		{
 			name:     "double value",
 			jsonData: `{"doubleValue": 123.45}`,
 			expected: &AnyValue{Value: &AnyValue_DoubleValue{DoubleValue: 123.45}},


### PR DESCRIPTION
OTLP/JSON (proto3 JSON mapping) encodes int64/uint64/fixed64/sfixed64 as string, e.g. {"intValue":"42"}. Standard OTel SDKs (Rust/Go/Python) emit this form. AnyValue.UnmarshalJSON only decoded intValue as a JSON number, so any span attribute carrying an int (thread.id, code.line.number, token counts) failed the whole request with 600904004 "json Unmarshal err".

Fall back to parsing the string form when numeric decode fails; keep the numeric path for the PB->JSON internal shape. Non-numeric strings still error. Add unit tests for the string-encoded, negative and invalid cases.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
