### PR TITLE
[fix][evaluation] normalize dataset keys in outputs and events

### DIFF
--- a/backend/modules/evaluation/application/standard_eval_output.go
+++ b/backend/modules/evaluation/application/standard_eval_output.go
@@ -19,6 +19,7 @@ import (
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/component/rpc"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/pkg/errno"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/pkg/utils"
 	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
 	"github.com/coze-dev/coze-loop/backend/pkg/json"
 	"github.com/coze-dev/coze-loop/backend/pkg/logs"
@@ -449,6 +450,9 @@ func buildItemStandardEvalOutput(ctx context.Context, item *entity.ItemResult, o
 	if res.Eval, err = mergeStandardEvalOutputField(std.Eval, fields, "eval"); err != nil {
 		return nil, err
 	}
+	if err := normalizeStandardEvalDatasetKeys(res.Eval); err != nil {
+		return nil, err
+	}
 	if res.Extra, err = mergeStandardEvalOutputField(std.Extra, fields, "extra"); err != nil {
 		return nil, err
 	}
@@ -495,6 +499,45 @@ func mergeStandardEvalOutputField(platformVal any, fields map[string]*entity.Con
 	}
 	merged := deepMergeStandardEvalOutput(normalizeToJSONValue(platformVal), objVal)
 	return inlineJSONContent(merged)
+}
+
+// normalizeStandardEvalDatasetKeys runs after merging all reported output formats.
+func normalizeStandardEvalDatasetKeys(content *expt.StandardEvalOutputContent) error {
+	if content == nil || content.GetContentOmitted() || content.FullContent != nil || !json.Valid([]byte(content.GetText())) {
+		return nil
+	}
+	var eval map[string]any
+	decoder := json.NewDecoder(strings.NewReader(content.GetText()))
+	decoder.UseNumber()
+	if err := decoder.Decode(&eval); err != nil {
+		return nil
+	}
+	taskConfig, _ := eval["task_config"].(map[string]any)
+	items, _ := taskConfig["items"].([]any)
+	changed := false
+	for _, item := range items {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		key, ok := entry["dataset_key"].(string)
+		if !ok {
+			continue
+		}
+		if normalized := utils.NormalizeDatasetKey(key); normalized != key {
+			entry["dataset_key"] = normalized
+			changed = true
+		}
+	}
+	if !changed {
+		return nil
+	}
+	text, err := json.MarshalString(eval)
+	if err != nil {
+		return err
+	}
+	content.Text = gptr.Of(text)
+	return nil
 }
 
 func isItemStandardEvalOutputContentReady(item *entity.ItemResult) bool {
@@ -698,13 +741,13 @@ func datasetKeyFromItem(item *entity.ItemResult) string {
 		return ""
 	}
 	if item.Ext != nil && item.Ext["dataset_key"] != "" {
-		return item.Ext["dataset_key"]
+		return utils.NormalizeDatasetKey(item.Ext["dataset_key"])
 	}
 	for _, payload := range standardPayloads(item, 0) {
 		if payload == nil || payload.EvalSet == nil || payload.EvalSet.DatasetKey == "" {
 			continue
 		}
-		return payload.EvalSet.DatasetKey
+		return utils.NormalizeDatasetKey(payload.EvalSet.DatasetKey)
 	}
 	return ""
 }

--- a/backend/modules/evaluation/application/standard_eval_output_dataset_key_test.go
+++ b/backend/modules/evaluation/application/standard_eval_output_dataset_key_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytedance/gg/gptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	exptpb "github.com/coze-dev/coze-loop/backend/kitex_gen/coze/loop/evaluation/expt"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/consts"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/pkg/json"
+)
+
+func standardEvalTaskConfigItems(t *testing.T, content *exptpb.StandardEvalOutputContent) []map[string]any {
+	t.Helper()
+	var eval struct {
+		TaskConfig struct {
+			Items []map[string]any `json:"items"`
+		} `json:"task_config"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(content.GetText()), &eval))
+	return eval.TaskConfig.Items
+}
+
+func TestBuildItemStandardEvalOutput_NormalizesPlatformDatasetKey(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		extKey     string
+		payloadKey string
+		want       string
+	}{
+		{name: "ext takes precedence", extKey: "dataset_new_runtime", payloadKey: "other_schema_v0_1", want: "dataset"},
+		{name: "payload fallback", payloadKey: "dataset_schema_v0_1", want: "dataset"},
+		{name: "stacked suffixes", extKey: "dataset_new_runtime_schema_v0_1", want: "dataset"},
+		{name: "suffix in name", extKey: "dataset_new_runtime_part_schema_v0_1_data", want: "dataset_new_runtime_part_schema_v0_1_data"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			item := makeStandardEvalOutputReportResult(20, 30, 10, 1, 100).ItemResults[0]
+			item.Ext["dataset_key"] = tt.extKey
+			payload := item.TurnResults[0].ExperimentResults[0].Payload
+			payload.EvalSet.DatasetKey = tt.payloadKey
+
+			got, err := buildItemStandardEvalOutput(context.Background(), item, standardEvalOutputBuildOptions{ExptID: 20})
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.GetDatasetKey())
+			items := standardEvalTaskConfigItems(t, got.GetEval())
+			require.Len(t, items, 1)
+			assert.Equal(t, tt.want, items[0]["dataset_key"])
+			assert.Equal(t, "case-1", items[0]["item_key"])
+			assert.Equal(t, tt.extKey, item.Ext["dataset_key"])
+			assert.Equal(t, tt.payloadKey, payload.EvalSet.DatasetKey)
+		})
+	}
+}
+
+func TestBuildItemStandardEvalOutput_NormalizesReportedDatasetKeys(t *testing.T) {
+	const reported = `{"task_config":{"items":[{"dataset_key":"dataset_new_runtime_schema_v0_1","item_key":"case_new_runtime"},{"dataset_key":"other_schema_v0_1_new_runtime","item_key":"other"},{"dataset_key":"name_new_runtime_part","item_key":"third"}],"mode":"reported"},"detail":{"eval_result":{"score":0.99}}}`
+	for _, tt := range []struct {
+		name   string
+		fields map[string]string
+	}{
+		{
+			name: "prefixed field overrides bare field",
+			fields: map[string]string{
+				"eval":        `{"task_config":{"items":[{"dataset_key":"ignored_schema_v0_1"}]}}`,
+				"FORNAX_eval": reported,
+			},
+		},
+		{name: "bare eval field", fields: map[string]string{"eval": reported}},
+		{
+			name: "legacy standard fields",
+			fields: map[string]string{
+				"source": `{"type":"fornax"}`,
+				"rounds": `[]`,
+				"output": `{}`,
+				"eval":   reported,
+			},
+		},
+		{
+			name: "whole standard output",
+			fields: map[string]string{
+				consts.EvalTargetOutputFieldKeyActualOutput: `{"detail_id":"detail","source":"fornax","rounds":[],"output":{},"eval":` + reported + `}`,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			item := makeStandardEvalOutputReportResult(20, 30, 10, 1, 100).ItemResults[0]
+			item.Ext["dataset_key"] = "dataset_new_runtime"
+			for field, value := range tt.fields {
+				injectFornaxField(item, field, value)
+			}
+			fields := item.TurnResults[0].ExperimentResults[0].Payload.TargetOutput.EvalTargetRecord.EvalTargetOutputData.OutputFields
+			before, err := json.MarshalString(fields)
+			require.NoError(t, err)
+
+			got, err := buildItemStandardEvalOutput(context.Background(), item, standardEvalOutputBuildOptions{ExptID: 20})
+			require.NoError(t, err)
+			assert.Equal(t, "dataset", got.GetDatasetKey())
+			items := standardEvalTaskConfigItems(t, got.GetEval())
+			require.Len(t, items, 3)
+			assert.Equal(t, "dataset", items[0]["dataset_key"])
+			assert.Equal(t, "other", items[1]["dataset_key"])
+			assert.Equal(t, "name_new_runtime_part", items[2]["dataset_key"])
+			assert.Equal(t, "case_new_runtime", items[0]["item_key"])
+			var eval map[string]any
+			require.NoError(t, json.Unmarshal([]byte(got.GetEval().GetText()), &eval))
+			assert.Equal(t, "reported", eval["task_config"].(map[string]any)["mode"])
+			assert.Equal(t, 0.99, eval["detail"].(map[string]any)["eval_result"].(map[string]any)["score"])
+			after, err := json.MarshalString(fields)
+			require.NoError(t, err)
+			assert.JSONEq(t, before, after)
+		})
+	}
+}
+
+func TestBuildItemStandardEvalOutput_DatasetKeyNormalizationPreservesOpaqueEval(t *testing.T) {
+	const preview = `{"task_config":{"items":[{"dataset_key":"dataset_new_runtime"}]}}`
+	for _, tt := range []struct {
+		name    string
+		content *entity.Content
+	}{
+		{
+			name: "omitted content",
+			content: &entity.Content{
+				Text:             gptr.Of(preview),
+				ContentOmitted:   gptr.Of(true),
+				FullContent:      &entity.ObjectStorage{URI: gptr.Of("eval:record:field:key")},
+				FullContentBytes: gptr.Of(int32(4096)),
+			},
+		},
+		{
+			name: "full content reference",
+			content: &entity.Content{
+				Text:        gptr.Of(preview),
+				FullContent: &entity.ObjectStorage{URI: gptr.Of("eval:record:field:key")},
+			},
+		},
+		{name: "non JSON content", content: &entity.Content{Text: gptr.Of("dataset_new_runtime")}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			item := makeStandardEvalOutputReportResult(20, 30, 10, 1, 100).ItemResults[0]
+			fields := item.TurnResults[0].ExperimentResults[0].Payload.TargetOutput.EvalTargetRecord.EvalTargetOutputData.OutputFields
+			fields["FORNAX_eval"] = tt.content
+
+			got, err := buildItemStandardEvalOutput(context.Background(), item, standardEvalOutputBuildOptions{ExptID: 20})
+			require.NoError(t, err)
+			assert.Equal(t, contentToStandardEvalOutputContent(tt.content), got.GetEval())
+		})
+	}
+}
+
+func TestNormalizeStandardEvalDatasetKeys_PreservesOtherValues(t *testing.T) {
+	content := &exptpb.StandardEvalOutputContent{
+		Text: gptr.Of(`{"task_config":{"items":[{"dataset_key":"dataset_new_runtime","item_key":"item_schema_v0_1","external_id":9223372036854775807},null,"dataset_new_runtime",{"dataset_key":123}]},"detail":{"dataset_key":"detail_new_runtime"}}`),
+	}
+	require.NoError(t, normalizeStandardEvalDatasetKeys(content))
+	assert.Contains(t, content.GetText(), "9223372036854775807")
+	assert.JSONEq(t, `{"task_config":{"items":[{"dataset_key":"dataset","item_key":"item_schema_v0_1","external_id":9223372036854775807},null,"dataset_new_runtime",{"dataset_key":123}]},"detail":{"dataset_key":"detail_new_runtime"}}`, content.GetText())
+}

--- a/backend/modules/evaluation/application/standard_eval_output_test.go
+++ b/backend/modules/evaluation/application/standard_eval_output_test.go
@@ -66,7 +66,9 @@ func TestExperimentApplication_MGetExperimentStandardEvalOutputs(t *testing.T) {
 			assert.True(t, *param.LoadEvaluatorFullContent)
 			require.NotNil(t, param.LoadEvalTargetFullContent)
 			assert.True(t, *param.LoadEvalTargetFullContent)
-			return makeStandardEvalOutputReportResult(exptID, exptRunID, itemID, turnID, targetRecordID), nil
+			result := makeStandardEvalOutputReportResult(exptID, exptRunID, itemID, turnID, targetRecordID)
+			result.ItemResults[0].Ext["dataset_key"] = "dataset-1_new_runtime_schema_v0_1"
+			return result, nil
 		},
 	)
 
@@ -96,6 +98,9 @@ func TestExperimentApplication_MGetExperimentStandardEvalOutputs(t *testing.T) {
 	var eval map[string]any
 	require.NoError(t, json.Unmarshal([]byte(got.GetEval().GetText()), &eval))
 	assert.Contains(t, eval, "task_config")
+	items := standardEvalTaskConfigItems(t, got.GetEval())
+	require.Len(t, items, 1)
+	assert.Equal(t, "dataset-1", items[0]["dataset_key"])
 	assert.Contains(t, eval, "detail")
 	assert.NotContains(t, eval, "rounds") // 平台兜底只补 detail
 
@@ -128,6 +133,7 @@ func TestExperimentApplication_MGetExperimentStandardEvalOutputs(t *testing.T) {
 
 func TestBuildItemStandardEvalOutput_ProcessingOnlyReturnsMetadata(t *testing.T) {
 	item := makeStandardEvalOutputReportResult(20, 30, 10, 1, 100).ItemResults[0]
+	item.Ext["dataset_key"] = "dataset-1_new_runtime"
 	item.SystemInfo.RunState = entity.ItemRunState_Processing
 
 	got, err := buildItemStandardEvalOutput(context.Background(), item, standardEvalOutputBuildOptions{ExptID: 20})
@@ -287,7 +293,10 @@ func TestExperimentApplication_ListExperimentStandardEvalOutputs(t *testing.T) {
 			assert.True(t, *param.LoadEvaluatorFullContent)
 			require.NotNil(t, param.LoadEvalTargetFullContent)
 			assert.True(t, *param.LoadEvalTargetFullContent)
-			return makeStandardEvalOutputReportResult(2, 3, 4, 5, 6), nil
+			result := makeStandardEvalOutputReportResult(2, 3, 4, 5, 6)
+			result.ItemResults[0].Ext["dataset_key"] = "dataset-1_schema_v0_1"
+			injectFornaxField(result.ItemResults[0], "FORNAX_eval", `{"task_config":{"items":[{"dataset_key":"dataset-1_new_runtime"}]}}`)
+			return result, nil
 		},
 	)
 
@@ -302,6 +311,10 @@ func TestExperimentApplication_ListExperimentStandardEvalOutputs(t *testing.T) {
 	require.NotNil(t, resp.Total)
 	assert.Equal(t, int64(1), *resp.Total)
 	got := resp.Items[0]
+	assert.Equal(t, "dataset-1", got.GetDatasetKey())
+	items := standardEvalTaskConfigItems(t, got.GetEval())
+	require.Len(t, items, 1)
+	assert.Equal(t, "dataset-1", items[0]["dataset_key"])
 	assert.Equal(t, standardEvalOutputExptCreateUnix, got.GetExperimentCreateTime())
 	assert.Equal(t, standardEvalOutputCreatedBy, got.GetCreatedBy())
 	assert.Equal(t, standardEvalOutputItemEndUnix, got.GetItemEndTime())

--- a/backend/modules/evaluation/domain/service/expt_run_item_dataset_key_test.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_dataset_key_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
+)
+
+func TestBuildItemCompleteEvent_NormalizesDatasetKey(t *testing.T) {
+	for _, sourceType := range []entity.ExptEvalSetSourceType{
+		entity.ExptEvalSetSourceType_SingleSet,
+		entity.ExptEvalSetSourceType_MultiSetConfig,
+	} {
+		for _, tt := range []struct {
+			key  string
+			want string
+		}{
+			{key: "dataset_new_runtime", want: "dataset"},
+			{key: "dataset_schema_v0_1", want: "dataset"},
+			{key: "dataset_schema_v0_1_new_runtime_schema_v0_1", want: "dataset"},
+			{key: "dataset_new_runtime_part", want: "dataset_new_runtime_part"},
+		} {
+			t.Run(fmt.Sprintf("%d/%s", sourceType, tt.key), func(t *testing.T) {
+				evalSet := &entity.EvaluationSet{
+					ID:                   700,
+					DatasetKey:           tt.key,
+					EvaluationSetVersion: &entity.EvaluationSetVersion{ID: 800, Version: "0.0.1"},
+				}
+				experiment := &entity.Experiment{
+					EvalSetSourceType:  sourceType,
+					ExperimentGroupKey: "group-key",
+					EvalSet:            evalSet,
+				}
+				if sourceType == entity.ExptEvalSetSourceType_MultiSetConfig {
+					experiment.EvalSet = &entity.EvaluationSet{ID: 900, DatasetKey: "primary_new_runtime"}
+					experiment.EvalSetDetails = []*entity.ExptEvalSetDetail{{EvalSetID: 700, EvalSet: evalSet}}
+				}
+				evalSetItem := &entity.EvaluationSetItem{SpaceID: 1, EvaluationSetID: 700, ItemKey: "item_new_runtime"}
+				ctx := &entity.ExptItemEvalCtx{
+					Event:            &entity.ExptItemEvalEvent{SpaceID: 1, ExptID: 100, ExptRunID: 200, EvalSetItemID: 300},
+					Expt:             experiment,
+					EvalSetItem:      evalSetItem,
+					EvalSetVersionID: 800,
+				}
+				fromItem := buildItemCompleteEvent(ctx)
+				fromScheduler := buildItemCompleteEventFromScheduler(1, 100, 200, experiment,
+					&entity.ExptEvalItem{ItemID: 300}, evalSetItem, 800)
+
+				assert.Equal(t, tt.want, fromItem.DatasetKey)
+				assert.Equal(t, fromItem, fromScheduler)
+				assert.Equal(t, "item_new_runtime", fromItem.ItemKey)
+				assert.Equal(t, "group-key", fromItem.ExperimentGroupKey)
+				assert.Equal(t, "700", fromItem.DatasetID)
+				assert.Equal(t, "800", fromItem.DatasetVersionID)
+				assert.Equal(t, tt.key, evalSet.DatasetKey)
+			})
+		}
+	}
+}

--- a/backend/modules/evaluation/domain/service/expt_run_item_impl.go
+++ b/backend/modules/evaluation/domain/service/expt_run_item_impl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/entity"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/domain/repo"
 	"github.com/coze-dev/coze-loop/backend/modules/evaluation/pkg/errno"
+	"github.com/coze-dev/coze-loop/backend/modules/evaluation/pkg/utils"
 	"github.com/coze-dev/coze-loop/backend/pkg/consts"
 	"github.com/coze-dev/coze-loop/backend/pkg/errorx"
 	"github.com/coze-dev/coze-loop/backend/pkg/json"
@@ -572,7 +573,7 @@ func buildItemCompleteEvent(eiec *entity.ExptItemEvalCtx) *component.ItemComplet
 
 	// version_name / dataset_key: 按 item 归属集从内存查找（GetDetail 已批量拉全所有集详情）。
 	if es := findEvalSetForItem(eiec.Expt, datasetID); es != nil {
-		ev.DatasetKey = es.DatasetKey
+		ev.DatasetKey = utils.NormalizeDatasetKey(es.DatasetKey)
 		if ver := es.EvaluationSetVersion; ver != nil {
 			if ev.DatasetVersionID == "" {
 				ev.DatasetVersionID = strconv.FormatInt(ver.ID, 10)

--- a/backend/modules/evaluation/pkg/utils/dataset_key.go
+++ b/backend/modules/evaluation/pkg/utils/dataset_key.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import "strings"
+
+// NormalizeDatasetKey removes runtime and schema suffixes from dataset identities.
+// Removing all trailing suffixes keeps normalization idempotent across output paths.
+func NormalizeDatasetKey(key string) string {
+	for {
+		normalized := strings.TrimSuffix(key, "_new_runtime")
+		normalized = strings.TrimSuffix(normalized, "_schema_v0_1")
+		if normalized == key {
+			return key
+		}
+		key = normalized
+	}
+}

--- a/backend/modules/evaluation/pkg/utils/dataset_key_test.go
+++ b/backend/modules/evaluation/pkg/utils/dataset_key_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import "testing"
+
+func TestNormalizeDatasetKey(t *testing.T) {
+	for _, tt := range []struct {
+		key  string
+		want string
+	}{
+		{key: "", want: ""},
+		{key: "dataset", want: "dataset"},
+		{key: "dataset_new_runtime", want: "dataset"},
+		{key: "dataset_schema_v0_1", want: "dataset"},
+		{key: "dataset_new_runtime_schema_v0_1", want: "dataset"},
+		{key: "dataset_schema_v0_1_new_runtime", want: "dataset"},
+		{key: "dataset_new_runtime_new_runtime_schema_v0_1_schema_v0_1", want: "dataset"},
+		{key: "_new_runtime_schema_v0_1", want: ""},
+		{key: "dataset_new_runtime_part", want: "dataset_new_runtime_part"},
+		{key: "dataset_schema_v0_1_part", want: "dataset_schema_v0_1_part"},
+		{key: "dataset_schema_v0_10", want: "dataset_schema_v0_10"},
+		{key: "dataset_new_runtime ", want: "dataset_new_runtime "},
+		{key: " dataset_new_runtime", want: " dataset"},
+	} {
+		t.Run(tt.key, func(t *testing.T) {
+			got := NormalizeDatasetKey(tt.key)
+			if got != tt.want {
+				t.Errorf("NormalizeDatasetKey(%q) = %q, want %q", tt.key, got, tt.want)
+			}
+			if repeated := NormalizeDatasetKey(got); repeated != got {
+				t.Errorf("normalizing %q again changed it to %q", got, repeated)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title
- [x] The title matches `[<type>][<scope>] <description>`.
- [x] The title clearly describes the behavior change.
- [x] Contract documentation is updated in the companion Runtime MR.
- [x] This PR is written in English.

#### More detailed description
Dataset keys ending in `_new_runtime` or `_schema_v0_1` remained in standard evaluation outputs and item-complete events while Runtime traces used normalized keys. This change applies one idempotent normalization rule to MGet/List top-level keys, `eval.task_config.items[].dataset_key` after merging reported output, and MQ completion events.

Regression coverage includes platform output, `FORNAX_eval`, legacy payload formats, repeated suffixes, and single/multiple evaluation sets.

Validation: full Go tests for application, domain/service, and pkg/utils passed; golangci-lint v2.2.1 reported 0 issues; independent review found no blocking issues.

Companion Runtime change: https://code.byted.org/flowdevops/fornax_agent_eval_runtime/merge_requests/95
