### PR TITLE
[fix][backend] convert retention days to ms for trajectory query in trajectory

### DIFF
--- a/backend/modules/observability/domain/trace/service/trace_export_service.go
+++ b/backend/modules/observability/domain/trace/service/trace_export_service.go
@@ -155,7 +155,7 @@ func (r *TraceExportServiceImpl) ExportTracesToDataset(ctx context.Context, req 
 		})
 
 		// 前端传入的是当前span时间，不能直接使用。改为和ListTrajectory逻辑一致。
-		finalStartTime := r.traceConfig.GetTraceDataMaxDurationDay(ctx, lo.ToPtr(string(req.PlatformType)))
+		finalStartTime := r.trajectoryStartTime(ctx, req.PlatformType)
 		trajectoryMap, err = r.traceService.GetTrajectories(ctx, req.WorkspaceID, traceIDs, finalStartTime,
 			time.Now().UnixMilli(), req.PlatformType)
 		if err != nil {
@@ -220,7 +220,7 @@ func (r *TraceExportServiceImpl) PreviewExportTracesToDataset(ctx context.Contex
 		})
 
 		// 前端传入的是当前span时间，不能直接使用。改为和ListTrajectory逻辑一致。
-		finalStartTime := r.traceConfig.GetTraceDataMaxDurationDay(ctx, lo.ToPtr(string(req.PlatformType)))
+		finalStartTime := r.trajectoryStartTime(ctx, req.PlatformType)
 		trajectoryMap, err = r.traceService.GetTrajectories(ctx, req.WorkspaceID, traceIDs, finalStartTime,
 			time.Now().UnixMilli(), req.PlatformType)
 		if err != nil {
@@ -552,6 +552,17 @@ func (r *TraceExportServiceImpl) hasTrajectory(fieldMappings []entity.FieldMappi
 		}
 	}
 	return false
+}
+
+// trajectoryStartTime 返回拉取 trajectory 的时间下界（ms）。
+// GetTraceDataMaxDurationDay 返回的是保留天数，必须换算成毫秒时间戳后再传给 GetTrajectories：
+// 直接把天数当时间戳会让 CK 的时间/分区条件退化成「1970 至今」，丢掉分区裁剪后整表扫直至超时。
+// 口径与 application 层 DateValidator 一致：今天零点往前推 N 天。
+func (r *TraceExportServiceImpl) trajectoryStartTime(ctx context.Context, platformType loop_span.PlatformType) int64 {
+	days := r.traceConfig.GetTraceDataMaxDurationDay(ctx, lo.ToPtr(string(platformType)))
+	now := time.Now()
+	startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	return startOfToday.Add(-time.Duration(days*24) * time.Hour).UnixMilli()
 }
 
 func (r *TraceExportServiceImpl) buildItem(ctx context.Context, span *loop_span.Span, i int, fieldMappings []entity.FieldMapping, workspaceID int64, dataset *entity.Dataset, trajectory *loop_span.Trajectory) *entity.DatasetItem {

--- a/backend/modules/observability/domain/trace/service/trace_export_service_test.go
+++ b/backend/modules/observability/domain/trace/service/trace_export_service_test.go
@@ -1208,7 +1208,7 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset(t *testing.T) {
 				repoMock.EXPECT().ListSpans(gomock.Any(), gomock.Any()).Return(&repo.ListSpansResult{
 					Spans: []*loop_span.Span{testSpan},
 				}, nil)
-				confMock.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(7 * 24 * 3600 * 1000))
+				confMock.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(7))
 				datasetProviderMock.EXPECT().ValidateDatasetItems(gomock.Any(), gomock.Any(), gomock.Any(), (*bool)(nil)).Return(
 					[]*entity.DatasetItem{}, []entity.ItemErrorGroup{}, nil)
 
@@ -2085,7 +2085,7 @@ func TestTraceExportServiceImpl_ExportTracesToDataset_Additional(t *testing.T) {
 				}, nil)
 
 				// Trajectory logic mocks
-				confMock.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(7 * 24 * 3600 * 1000))
+				confMock.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(int64(7))
 				traceServiceStub.getTrajectoriesFunc = func(ctx context.Context, workspaceID int64, traceIDs []string, startTime, endTime int64, platformType loop_span.PlatformType) (map[string]*loop_span.Trajectory, error) {
 					return map[string]*loop_span.Trajectory{
 						"trace-1": {
@@ -2333,6 +2333,38 @@ func TestTraceExportServiceImpl_PreviewExportTracesToDataset_Additional(t *testi
 				assert.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+func TestTraceExportServiceImpl_trajectoryStartTime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		days int64
+	}{
+		{name: "default 7 days", days: 7},
+		{name: "inner_cozeloop 90 days", days: 90},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			confMock := confmocks.NewMockITraceConfig(ctrl)
+			confMock.EXPECT().GetTraceDataMaxDurationDay(gomock.Any(), gomock.Any()).Return(tt.days)
+
+			r := &TraceExportServiceImpl{traceConfig: confMock}
+			got := r.trajectoryStartTime(context.Background(), loop_span.PlatformCozeLoop)
+
+			now := time.Now()
+			startOfToday := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+			assert.Equal(t, startOfToday.Add(-time.Duration(tt.days*24)*time.Hour).UnixMilli(), got)
+			// 回归保护：配置返回的是天数，不能直接当毫秒时间戳用，否则 CK 时间条件退化成「1970 至今」。
+			assert.NotEqual(t, tt.days, got)
+			assert.Greater(t, got, time.Date(2020, 1, 1, 0, 0, 0, 0, time.Local).UnixMilli())
 		})
 	}
 }


### PR DESCRIPTION
…ce export

GetTraceDataMaxDurationDay returns a number of days, but ExportTracesToDataset and PreviewExportTracesToDataset passed it straight into GetTrajectories as a millisecond timestamp. With 90 days configured the lower bound became 90ms, so the generated ClickHouse query degraded to `start_date >= '1970-01-01'`, lost partition pruning and timed out (Code 159) — failing every trace export whose field mappings include a trajectory field.

Convert days to a millisecond timestamp with the same semantics as the application-layer DateValidator (midnight today minus N days). The existing tests mocked the config as milliseconds, which is what hid the bug; they now return days, and a dedicated test pins the conversion.

#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title
<!--
The description of the title will be attached in Release Notes,
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \[\<type\>\]\[\<scope\>\] \<description\>. For example: \[fix\]\[backend\] flaky fix
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Add documentation if the current PR requires user awareness at the usage level.
- [ ] This PR is written in English. PRs not in English will not be reviewed.

#### (Optional) Translate the PR title into Chinese

#### (Optional) More detailed description for this PR(en: English/zh: Chinese)
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
