### PR TITLE
[fix][model] read default parameter values from config

### DIFF
--- a/backend/modules/llm/domain/entity/manage.go
+++ b/backend/modules/llm/domain/entity/manage.go
@@ -358,7 +358,7 @@ type ParamSchema struct {
 	Type         ParamType      `json:"type" yaml:"type" mapstructure:"type"`
 	Min          string         `json:"min" yaml:"min" mapstructure:"min"`
 	Max          string         `json:"max" yaml:"max" mapstructure:"max"`
-	DefaultValue string         `json:"default_value" yaml:"default_value" mapstructure:"default_value"`
+	DefaultValue string         `json:"default_value" yaml:"default_val" mapstructure:"default_val"`
 	Options      []*ParamOption `json:"options" yaml:"options" mapstructure:"options"`
 	Properties   []*ParamSchema `json:"properties" mapstructrue:"properties"`
 	JsonPath     string         `json:"json_path" mapstructrue:"json_path"`

--- a/backend/modules/llm/domain/entity/manage.go
+++ b/backend/modules/llm/domain/entity/manage.go
@@ -359,6 +359,7 @@ type ParamSchema struct {
 	Min          string         `json:"min" yaml:"min" mapstructure:"min"`
 	Max          string         `json:"max" yaml:"max" mapstructure:"max"`
 	DefaultValue string         `json:"default_value" yaml:"default_value" mapstructure:"default_value"`
+	DefaultVal   *string        `json:"-" yaml:"-" mapstructure:"default_val"` // normalized into DefaultValue by the config loader
 	Options      []*ParamOption `json:"options" yaml:"options" mapstructure:"options"`
 	Properties   []*ParamSchema `json:"properties" mapstructrue:"properties"`
 	JsonPath     string         `json:"json_path" mapstructrue:"json_path"`

--- a/backend/modules/llm/domain/entity/manage.go
+++ b/backend/modules/llm/domain/entity/manage.go
@@ -358,7 +358,7 @@ type ParamSchema struct {
 	Type         ParamType      `json:"type" yaml:"type" mapstructure:"type"`
 	Min          string         `json:"min" yaml:"min" mapstructure:"min"`
 	Max          string         `json:"max" yaml:"max" mapstructure:"max"`
-	DefaultValue string         `json:"default_value" yaml:"default_val" mapstructure:"default_val"`
+	DefaultValue string         `json:"default_value" yaml:"default_value" mapstructure:"default_value"`
 	Options      []*ParamOption `json:"options" yaml:"options" mapstructure:"options"`
 	Properties   []*ParamSchema `json:"properties" mapstructrue:"properties"`
 	JsonPath     string         `json:"json_path" mapstructrue:"json_path"`

--- a/backend/modules/llm/infra/config/manage.go
+++ b/backend/modules/llm/infra/config/manage.go
@@ -18,21 +18,6 @@ type ManageImpl struct {
 	loader conf.IConfigLoader
 }
 
-type modelConfigAliases struct {
-	ID          int64               `mapstructure:"id"`
-	ParamConfig *paramConfigAliases `mapstructure:"param_config"`
-}
-
-type paramConfigAliases struct {
-	ParamSchemas []*paramSchemaAliases `mapstructure:"param_schemas"`
-}
-
-type paramSchemaAliases struct {
-	Name       string                `mapstructure:"name"`
-	DefaultVal *string               `mapstructure:"default_val"`
-	Properties []*paramSchemaAliases `mapstructure:"properties"`
-}
-
 func NewManage(ctx context.Context, factory conf.IConfigLoaderFactory) (llm_conf.IConfigManage, error) {
 	loader, err := factory.NewConfigLoader("model_config.yaml")
 	if err != nil {
@@ -85,49 +70,26 @@ func (m *ManageImpl) readConfig(ctx context.Context) ([]*entity.Model, error) {
 	}
 
 	// default_value was the original decoder key, while every shipped model
-	// config uses default_val. Read the shipped spelling separately so both
-	// existing custom configs and the bundled configs remain supported.
-	var aliases []*modelConfigAliases
-	if err := m.loader.UnmarshalKey(ctx, "models", &aliases); err != nil {
-		return nil, err
-	}
-	modelsByID := make(map[int64]*entity.Model, len(models))
+	// config uses default_val. Normalize the alias from the same decoded
+	// snapshot so both spellings remain supported during live config reloads.
 	for _, model := range models {
-		if model != nil {
-			modelsByID[model.ID] = model
-		}
-	}
-	for _, alias := range aliases {
-		if alias == nil || alias.ParamConfig == nil {
-			continue
-		}
-		model := modelsByID[alias.ID]
 		if model == nil || model.ParamConfig == nil {
 			continue
 		}
-		applyParamSchemaAliases(model.ParamConfig.ParamSchemas, alias.ParamConfig.ParamSchemas)
+		normalizeParamSchemaDefaultValues(model.ParamConfig.ParamSchemas)
 	}
 	return models, nil
 }
 
-func applyParamSchemaAliases(schemas []*entity.ParamSchema, aliases []*paramSchemaAliases) {
-	schemasByName := make(map[string]*entity.ParamSchema, len(schemas))
+func normalizeParamSchemaDefaultValues(schemas []*entity.ParamSchema) {
 	for _, schema := range schemas {
-		if schema != nil {
-			schemasByName[schema.Name] = schema
-		}
-	}
-	for _, alias := range aliases {
-		if alias == nil {
-			continue
-		}
-		schema := schemasByName[alias.Name]
 		if schema == nil {
 			continue
 		}
-		if alias.DefaultVal != nil {
-			schema.DefaultValue = *alias.DefaultVal
+		if schema.DefaultVal != nil {
+			schema.DefaultValue = *schema.DefaultVal
+			schema.DefaultVal = nil
 		}
-		applyParamSchemaAliases(schema.Properties, alias.Properties)
+		normalizeParamSchemaDefaultValues(schema.Properties)
 	}
 }

--- a/backend/modules/llm/infra/config/manage.go
+++ b/backend/modules/llm/infra/config/manage.go
@@ -19,6 +19,7 @@ type ManageImpl struct {
 }
 
 type modelConfigAliases struct {
+	ID          int64               `mapstructure:"id"`
 	ParamConfig *paramConfigAliases `mapstructure:"param_config"`
 }
 
@@ -27,6 +28,7 @@ type paramConfigAliases struct {
 }
 
 type paramSchemaAliases struct {
+	Name       string                `mapstructure:"name"`
 	DefaultVal *string               `mapstructure:"default_val"`
 	Properties []*paramSchemaAliases `mapstructure:"properties"`
 }
@@ -89,23 +91,43 @@ func (m *ManageImpl) readConfig(ctx context.Context) ([]*entity.Model, error) {
 	if err := m.loader.UnmarshalKey(ctx, "models", &aliases); err != nil {
 		return nil, err
 	}
-	for i, alias := range aliases {
-		if i >= len(models) || alias == nil || alias.ParamConfig == nil || models[i] == nil || models[i].ParamConfig == nil {
+	modelsByID := make(map[int64]*entity.Model, len(models))
+	for _, model := range models {
+		if model != nil {
+			modelsByID[model.ID] = model
+		}
+	}
+	for _, alias := range aliases {
+		if alias == nil || alias.ParamConfig == nil {
 			continue
 		}
-		applyParamSchemaAliases(models[i].ParamConfig.ParamSchemas, alias.ParamConfig.ParamSchemas)
+		model := modelsByID[alias.ID]
+		if model == nil || model.ParamConfig == nil {
+			continue
+		}
+		applyParamSchemaAliases(model.ParamConfig.ParamSchemas, alias.ParamConfig.ParamSchemas)
 	}
 	return models, nil
 }
 
 func applyParamSchemaAliases(schemas []*entity.ParamSchema, aliases []*paramSchemaAliases) {
-	for i, alias := range aliases {
-		if i >= len(schemas) || alias == nil || schemas[i] == nil {
+	schemasByName := make(map[string]*entity.ParamSchema, len(schemas))
+	for _, schema := range schemas {
+		if schema != nil {
+			schemasByName[schema.Name] = schema
+		}
+	}
+	for _, alias := range aliases {
+		if alias == nil {
+			continue
+		}
+		schema := schemasByName[alias.Name]
+		if schema == nil {
 			continue
 		}
 		if alias.DefaultVal != nil {
-			schemas[i].DefaultValue = *alias.DefaultVal
+			schema.DefaultValue = *alias.DefaultVal
 		}
-		applyParamSchemaAliases(schemas[i].Properties, alias.Properties)
+		applyParamSchemaAliases(schema.Properties, alias.Properties)
 	}
 }

--- a/backend/modules/llm/infra/config/manage.go
+++ b/backend/modules/llm/infra/config/manage.go
@@ -18,6 +18,19 @@ type ManageImpl struct {
 	loader conf.IConfigLoader
 }
 
+type modelConfigAliases struct {
+	ParamConfig *paramConfigAliases `mapstructure:"param_config"`
+}
+
+type paramConfigAliases struct {
+	ParamSchemas []*paramSchemaAliases `mapstructure:"param_schemas"`
+}
+
+type paramSchemaAliases struct {
+	DefaultVal *string               `mapstructure:"default_val"`
+	Properties []*paramSchemaAliases `mapstructure:"properties"`
+}
+
 func NewManage(ctx context.Context, factory conf.IConfigLoaderFactory) (llm_conf.IConfigManage, error) {
 	loader, err := factory.NewConfigLoader("model_config.yaml")
 	if err != nil {
@@ -68,5 +81,31 @@ func (m *ManageImpl) readConfig(ctx context.Context) ([]*entity.Model, error) {
 	if err := m.loader.UnmarshalKey(ctx, "models", &models); err != nil {
 		return nil, err
 	}
+
+	// default_value was the original decoder key, while every shipped model
+	// config uses default_val. Read the shipped spelling separately so both
+	// existing custom configs and the bundled configs remain supported.
+	var aliases []*modelConfigAliases
+	if err := m.loader.UnmarshalKey(ctx, "models", &aliases); err != nil {
+		return nil, err
+	}
+	for i, alias := range aliases {
+		if i >= len(models) || alias == nil || alias.ParamConfig == nil || models[i] == nil || models[i].ParamConfig == nil {
+			continue
+		}
+		applyParamSchemaAliases(models[i].ParamConfig.ParamSchemas, alias.ParamConfig.ParamSchemas)
+	}
 	return models, nil
+}
+
+func applyParamSchemaAliases(schemas []*entity.ParamSchema, aliases []*paramSchemaAliases) {
+	for i, alias := range aliases {
+		if i >= len(schemas) || alias == nil || schemas[i] == nil {
+			continue
+		}
+		if alias.DefaultVal != nil {
+			schemas[i].DefaultValue = *alias.DefaultVal
+		}
+		applyParamSchemaAliases(schemas[i].Properties, alias.Properties)
+	}
 }

--- a/backend/modules/llm/infra/config/manage_test.go
+++ b/backend/modules/llm/infra/config/manage_test.go
@@ -22,6 +22,19 @@ func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
       param_schemas:
         - name: temperature
           default_val: "0.7"
+  - id: 2
+    param_config:
+      param_schemas:
+        - name: temperature
+          default_value: "0.8"
+  - id: 3
+    param_config:
+      param_schemas:
+        - name: response_format
+          properties:
+            - name: type
+              default_value: legacy
+              default_val: canonical
 `
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "model_config.yaml"), []byte(config), 0o600))
 
@@ -30,7 +43,15 @@ func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	model, err := manage.GetModel(context.Background(), 1)
+	shippedConfigModel, err := manage.GetModel(context.Background(), 1)
 	require.NoError(t, err)
-	require.Equal(t, "0.7", model.ParamConfig.ParamSchemas[0].DefaultValue)
+	require.Equal(t, "0.7", shippedConfigModel.ParamConfig.ParamSchemas[0].DefaultValue)
+
+	legacyConfigModel, err := manage.GetModel(context.Background(), 2)
+	require.NoError(t, err)
+	require.Equal(t, "0.8", legacyConfigModel.ParamConfig.ParamSchemas[0].DefaultValue)
+
+	bothKeysModel, err := manage.GetModel(context.Background(), 3)
+	require.NoError(t, err)
+	require.Equal(t, "canonical", bothKeysModel.ParamConfig.ParamSchemas[0].Properties[0].DefaultValue)
 }

--- a/backend/modules/llm/infra/config/manage_test.go
+++ b/backend/modules/llm/infra/config/manage_test.go
@@ -5,14 +5,73 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/coze-dev/coze-loop/backend/modules/llm/domain/entity"
+	"github.com/coze-dev/coze-loop/backend/pkg/conf"
 	confviper "github.com/coze-dev/coze-loop/backend/pkg/conf/viper"
 )
+
+type changingModelConfigLoader struct {
+	calls int
+}
+
+func (l *changingModelConfigLoader) Get(context.Context, string) any {
+	return nil
+}
+
+func (l *changingModelConfigLoader) Unmarshal(context.Context, any, ...conf.DecodeOptionFn) error {
+	return nil
+}
+
+func (l *changingModelConfigLoader) UnmarshalKey(_ context.Context, _ string, value any, _ ...conf.DecodeOptionFn) error {
+	l.calls++
+	switch target := value.(type) {
+	case *[]*entity.Model:
+		*target = []*entity.Model{
+			{
+				ID: 1,
+				ParamConfig: &entity.ParamConfig{ParamSchemas: []*entity.ParamSchema{
+					{Name: "temperature", DefaultValue: "legacy-temperature"},
+					{Name: "top_p", DefaultValue: "legacy-top-p"},
+				}},
+			},
+			{
+				ID: 2,
+				ParamConfig: &entity.ParamConfig{ParamSchemas: []*entity.ParamSchema{
+					{Name: "max_tokens", DefaultValue: "legacy-max-tokens"},
+				}},
+			},
+		}
+	case *[]*modelConfigAliases:
+		maxTokens := "canonical-max-tokens"
+		topP := "canonical-top-p"
+		temperature := "canonical-temperature"
+		*target = []*modelConfigAliases{
+			{
+				ID: 2,
+				ParamConfig: &paramConfigAliases{ParamSchemas: []*paramSchemaAliases{
+					{Name: "max_tokens", DefaultVal: &maxTokens},
+				}},
+			},
+			{
+				ID: 1,
+				ParamConfig: &paramConfigAliases{ParamSchemas: []*paramSchemaAliases{
+					{Name: "top_p", DefaultVal: &topP},
+					{Name: "temperature", DefaultVal: &temperature},
+				}},
+			},
+		}
+	default:
+		return fmt.Errorf("unexpected unmarshal target %T", value)
+	}
+	return nil
+}
 
 func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
 	configDir := t.TempDir()
@@ -54,4 +113,14 @@ func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
 	bothKeysModel, err := manage.GetModel(context.Background(), 3)
 	require.NoError(t, err)
 	require.Equal(t, "canonical", bothKeysModel.ParamConfig.ParamSchemas[0].Properties[0].DefaultValue)
+}
+
+func TestManageImplMatchesAliasesByStableIdentity(t *testing.T) {
+	manage := &ManageImpl{loader: &changingModelConfigLoader{}}
+
+	models, err := manage.readConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "canonical-temperature", models[0].ParamConfig.ParamSchemas[0].DefaultValue)
+	require.Equal(t, "canonical-top-p", models[0].ParamConfig.ParamSchemas[1].DefaultValue)
+	require.Equal(t, "canonical-max-tokens", models[1].ParamConfig.ParamSchemas[0].DefaultValue)
 }

--- a/backend/modules/llm/infra/config/manage_test.go
+++ b/backend/modules/llm/infra/config/manage_test.go
@@ -5,71 +5,50 @@ package config
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	"github.com/coze-dev/coze-loop/backend/modules/llm/domain/entity"
 	"github.com/coze-dev/coze-loop/backend/pkg/conf"
 	confviper "github.com/coze-dev/coze-loop/backend/pkg/conf/viper"
 )
 
-type changingModelConfigLoader struct {
+type singleSnapshotModelConfigLoader struct {
 	calls int
 }
 
-func (l *changingModelConfigLoader) Get(context.Context, string) any {
+func (l *singleSnapshotModelConfigLoader) Get(context.Context, string) any {
 	return nil
 }
 
-func (l *changingModelConfigLoader) Unmarshal(context.Context, any, ...conf.DecodeOptionFn) error {
+func (l *singleSnapshotModelConfigLoader) Unmarshal(context.Context, any, ...conf.DecodeOptionFn) error {
 	return nil
 }
 
-func (l *changingModelConfigLoader) UnmarshalKey(_ context.Context, _ string, value any, _ ...conf.DecodeOptionFn) error {
+func (l *singleSnapshotModelConfigLoader) UnmarshalKey(_ context.Context, _ string, value any, _ ...conf.DecodeOptionFn) error {
 	l.calls++
-	switch target := value.(type) {
-	case *[]*entity.Model:
-		*target = []*entity.Model{
-			{
-				ID: 1,
-				ParamConfig: &entity.ParamConfig{ParamSchemas: []*entity.ParamSchema{
-					{Name: "temperature", DefaultValue: "legacy-temperature"},
-					{Name: "top_p", DefaultValue: "legacy-top-p"},
-				}},
-			},
-			{
-				ID: 2,
-				ParamConfig: &entity.ParamConfig{ParamSchemas: []*entity.ParamSchema{
-					{Name: "max_tokens", DefaultValue: "legacy-max-tokens"},
-				}},
-			},
-		}
-	case *[]*modelConfigAliases:
-		maxTokens := "canonical-max-tokens"
-		topP := "canonical-top-p"
-		temperature := "canonical-temperature"
-		*target = []*modelConfigAliases{
-			{
-				ID: 2,
-				ParamConfig: &paramConfigAliases{ParamSchemas: []*paramSchemaAliases{
-					{Name: "max_tokens", DefaultVal: &maxTokens},
-				}},
-			},
-			{
-				ID: 1,
-				ParamConfig: &paramConfigAliases{ParamSchemas: []*paramSchemaAliases{
-					{Name: "top_p", DefaultVal: &topP},
-					{Name: "temperature", DefaultVal: &temperature},
-				}},
-			},
-		}
-	default:
+	if l.calls > 1 {
+		return fmt.Errorf("unexpected second config read")
+	}
+	target, ok := value.(*[]*entity.Model)
+	if !ok {
 		return fmt.Errorf("unexpected unmarshal target %T", value)
 	}
+	canonical := "canonical"
+	*target = []*entity.Model{{
+		ID: 1,
+		ParamConfig: &entity.ParamConfig{ParamSchemas: []*entity.ParamSchema{{
+			Name:         "temperature",
+			DefaultValue: "legacy",
+			DefaultVal:   &canonical,
+		}}},
+	}}
 	return nil
 }
 
@@ -94,6 +73,12 @@ func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
             - name: type
               default_value: legacy
               default_val: canonical
+  - id: 4
+    param_config:
+      param_schemas:
+        - name: stop
+          default_value: legacy
+          default_val: ""
 `
 	require.NoError(t, os.WriteFile(filepath.Join(configDir, "model_config.yaml"), []byte(config), 0o600))
 
@@ -113,14 +98,29 @@ func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
 	bothKeysModel, err := manage.GetModel(context.Background(), 3)
 	require.NoError(t, err)
 	require.Equal(t, "canonical", bothKeysModel.ParamConfig.ParamSchemas[0].Properties[0].DefaultValue)
+
+	emptyCanonicalModel, err := manage.GetModel(context.Background(), 4)
+	require.NoError(t, err)
+	require.Empty(t, emptyCanonicalModel.ParamConfig.ParamSchemas[0].DefaultValue)
+
+	schema := bothKeysModel.ParamConfig.ParamSchemas[0].Properties[0]
+	jsonSchema, err := json.Marshal(schema)
+	require.NoError(t, err)
+	require.NotContains(t, string(jsonSchema), `"default_val":`)
+	require.Contains(t, string(jsonSchema), `"default_value":"canonical"`)
+	yamlSchema, err := yaml.Marshal(schema)
+	require.NoError(t, err)
+	require.NotContains(t, string(yamlSchema), "default_val:")
+	require.Contains(t, string(yamlSchema), "default_value: canonical")
 }
 
-func TestManageImplMatchesAliasesByStableIdentity(t *testing.T) {
-	manage := &ManageImpl{loader: &changingModelConfigLoader{}}
+func TestManageImplNormalizesAliasFromSingleSnapshot(t *testing.T) {
+	loader := &singleSnapshotModelConfigLoader{}
+	manage := &ManageImpl{loader: loader}
 
 	models, err := manage.readConfig(context.Background())
 	require.NoError(t, err)
-	require.Equal(t, "canonical-temperature", models[0].ParamConfig.ParamSchemas[0].DefaultValue)
-	require.Equal(t, "canonical-top-p", models[0].ParamConfig.ParamSchemas[1].DefaultValue)
-	require.Equal(t, "canonical-max-tokens", models[1].ParamConfig.ParamSchemas[0].DefaultValue)
+	require.Equal(t, 1, loader.calls)
+	require.Equal(t, "canonical", models[0].ParamConfig.ParamSchemas[0].DefaultValue)
+	require.Nil(t, models[0].ParamConfig.ParamSchemas[0].DefaultVal)
 }

--- a/backend/modules/llm/infra/config/manage_test.go
+++ b/backend/modules/llm/infra/config/manage_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	confviper "github.com/coze-dev/coze-loop/backend/pkg/conf/viper"
+)
+
+func TestManageImplReadsParamSchemaDefaultVal(t *testing.T) {
+	configDir := t.TempDir()
+	config := `models:
+  - id: 1
+    param_config:
+      param_schemas:
+        - name: temperature
+          default_val: "0.7"
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "model_config.yaml"), []byte(config), 0o600))
+
+	manage, err := NewManage(context.Background(), confviper.NewFileConfigLoaderFactory(
+		confviper.WithFactoryConfigPath(configDir),
+	))
+	require.NoError(t, err)
+
+	model, err := manage.GetModel(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, "0.7", model.ParamConfig.ParamSchemas[0].DefaultValue)
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title

- [x] This PR title matches the format: `[<type>][<scope>] <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] No usage-level documentation is required for this configuration-decoding fix.
- [x] This PR is written in English.

#### (Optional) More detailed description for this PR

en:

The shipped Docker Compose and Helm `model_config.yaml` files define parameter defaults with the `default_val` key. `ParamSchema` originally decoded only `default_value`, so Viper left every shipped default empty and the model-management response did not expose those defaults.

This change decodes `default_val` as the canonical shipped spelling while preserving `default_value` for backward compatibility with existing custom configurations. The alias is normalized from the same Viper snapshot, so live reloads cannot return mixed configuration versions. When both keys are present, `default_val` takes precedence; the public JSON field remains `default_value`.

A regression test loads real YAML through the production Viper factory and verifies both spellings, nested parameter schemas, and deterministic precedence. A second test verifies normalization uses a single loader snapshot and removes the internal alias before returning the model.

#### Validation

- `go test -count=1 ./modules/llm/infra/config`
- `go test -count=1 ./modules/llm/...`
- `go vet ./modules/llm/...`
- `go build ./modules/llm/...`
- `git diff --check`

#### (Optional) Which issue(s) this PR fixes

Fixes #125