### PR TITLE
[feat][dataset] support filtering dataset items by item_id

### DIFF
--- a/backend/modules/data/application/item_app.go
+++ b/backend/modules/data/application/item_app.go
@@ -165,7 +165,9 @@ func (h *DatasetApplicationImpl) ListDatasetItems(ctx context.Context, req *data
 		}
 	}
 	// TODO: 改为超过固定数值不允许 offset 访问
+	itemIDs := parseItemIDFilter(req.GetFilter())
 	query := repo.NewListItemsParamsOfDataset(req.GetWorkspaceID(), req.GetDatasetID(), func(p *repo.ListItemsParams) {
+		p.ItemIDs = itemIDs
 		p.Paginator = pagination.New(
 			repo.ItemOrderBy(gptr.Indirect(orderBy.Field)),
 			pagination.WithOrderByAsc(gptr.Indirect(orderBy.IsAsc)),

--- a/backend/modules/data/application/item_filter.go
+++ b/backend/modules/data/application/item_filter.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"strconv"
+
+	"github.com/coze-dev/coze-loop/backend/kitex_gen/stone/fornax/ml_flow/domain/filter"
+)
+
+// filterFieldItemID 是唯一被白名单放行、可转为 item_id 过滤的筛选字段名。
+// 其它 field_name 一律忽略,绝不拼成任意列过滤。
+const filterFieldItemID = "item_id"
+
+// parseItemIDFilter 从通用 Filter 中解析出面向 item_id 的精确筛选值集合。
+// 只识别 field_name == item_id 的 FilterField,其它字段直接忽略。
+// query_type 为 eq / in 均落成 item_id 值集合(DAL 走 item_id IN(...));
+// 其它 query_type 按 in 处理(取全部 values),语义仍是 item_id 属于该集合。
+// values 为字符串,item_id 底层是 i64,解析失败的值跳过而非报错。
+func parseItemIDFilter(f *filter.Filter) []int64 {
+	if f == nil || len(f.FilterFields) == 0 {
+		return nil
+	}
+	var itemIDs []int64
+	for _, field := range f.FilterFields {
+		if field == nil || field.GetFieldName() != filterFieldItemID {
+			continue
+		}
+		for _, v := range field.GetValues() {
+			id, err := strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				continue
+			}
+			itemIDs = append(itemIDs, id)
+		}
+	}
+	return itemIDs
+}

--- a/backend/modules/data/application/item_filter_test.go
+++ b/backend/modules/data/application/item_filter_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 coze-dev Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package application
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coze-dev/coze-loop/backend/kitex_gen/stone/fornax/ml_flow/domain/filter"
+)
+
+func TestParseItemIDFilter(t *testing.T) {
+	eq := filter.QueryTypeEq
+	in := filter.QueryTypeIn
+	tests := []struct {
+		name   string
+		filter *filter.Filter
+		want   []int64
+	}{
+		{
+			name:   "nil filter returns nil",
+			filter: nil,
+			want:   nil,
+		},
+		{
+			name:   "no filter fields returns nil",
+			filter: &filter.Filter{FilterFields: nil},
+			want:   nil,
+		},
+		{
+			name: "item_id eq single value",
+			filter: &filter.Filter{FilterFields: []*filter.FilterField{
+				{FieldName: filterFieldItemID, FieldType: filter.FieldTypeLong, QueryType: &eq, Values: []string{"123"}},
+			}},
+			want: []int64{123},
+		},
+		{
+			name: "item_id in multiple values",
+			filter: &filter.Filter{FilterFields: []*filter.FilterField{
+				{FieldName: filterFieldItemID, FieldType: filter.FieldTypeLong, QueryType: &in, Values: []string{"123", "456", "789"}},
+			}},
+			want: []int64{123, 456, 789},
+		},
+		{
+			name: "non item_id field is ignored",
+			filter: &filter.Filter{FilterFields: []*filter.FilterField{
+				{FieldName: "created_by", FieldType: filter.FieldTypeString, QueryType: &eq, Values: []string{"alice"}},
+			}},
+			want: nil,
+		},
+		{
+			name: "mixed item_id and illegal field only item_id takes effect",
+			filter: &filter.Filter{FilterFields: []*filter.FilterField{
+				{FieldName: "created_by", FieldType: filter.FieldTypeString, QueryType: &eq, Values: []string{"alice"}},
+				{FieldName: filterFieldItemID, FieldType: filter.FieldTypeLong, QueryType: &eq, Values: []string{"123"}},
+			}},
+			want: []int64{123},
+		},
+		{
+			name: "invalid numeric value is skipped",
+			filter: &filter.Filter{FilterFields: []*filter.FilterField{
+				{FieldName: filterFieldItemID, FieldType: filter.FieldTypeLong, QueryType: &in, Values: []string{"123", "abc", "456"}},
+			}},
+			want: []int64{123, 456},
+		},
+		{
+			name: "empty values returns nil",
+			filter: &filter.Filter{FilterFields: []*filter.FilterField{
+				{FieldName: filterFieldItemID, FieldType: filter.FieldTypeLong, QueryType: &in, Values: nil},
+			}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseItemIDFilter(tt.filter)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## 背景
评测数据集详情页的数据项列表已有「复制 ID」，但筛选器无「按 ID 筛选」选项。多人协作查看同一数据集时，拿到他人分享的 item_id 无法在筛选器里定位对应 case。ID 也是数据项的一列，理应可筛选。

## 改动（data 模块）
- 新增 `item_filter.go` 的 `parseItemIDFilter`：白名单只识别 `field_name==item_id` 的 FilterField，`eq` 取单值 / `in` 取多值，落为 item_id 值集合；其余字段一律忽略，绝不拼入 SQL 列。
- `item_app.go` 的 `ListDatasetItems` 消费该解析结果，写入 `ListItemsParams.ItemIDs`；filter 为 nil / 无 item_id 字段时行为与现状一致。
- 新增 `item_filter_test.go`：eq 单值 / in 多值 / 非法字段被忽略 / 空 filter 返回空集合，共 8 例，全部通过。

## 兼容性
纯新增筛选能力，无 IDL / Schema 变更，向前兼容。

Meego: 7375138657